### PR TITLE
automation: Jenkinsfile: add build steps for B1, E1C, and E7 boards

### DIFF
--- a/automation/Jenkinsfile
+++ b/automation/Jenkinsfile
@@ -25,12 +25,22 @@ pipeline {
                      --mr ${BRANCH} --mf west.yml ; west update ; cd alif ; \
                      if [ \"x${BRANCH}\" = \"xmain\" ] ; then cd ../zephyr ; \
                      rm -rf build ; \
-                     west build -b alif_e3_dk_rtss_hp samples/hello_world ; \
+		     west build -b alif_e3_dk_rtss_hp samples/hello_world ; \
+		     west build -b alif_e3_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_e7_dk_rtss_hp samples/hello_world -p ; \
+		     west build -b alif_e7_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_b1_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_e1c_dk_rtss_he samples/hello_world -p ; \
                      else if ../zephyr/scripts/checkpatch.pl \
                      --ignore=GERRIT_CHANGE_ID,EMAIL_SUBJECT,COMMIT_MESSAGE,COMMIT_LOG_LONG_LINE -g \
                      origin/${BRANCH}...origin/main ; then cd ../zephyr ; \
                      rm -rf build ; \
-                     west build -b alif_e3_dk_rtss_hp samples/hello_world ; \
+		     west build -b alif_e3_dk_rtss_hp samples/hello_world ; \
+		     west build -b alif_e3_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_e7_dk_rtss_hp samples/hello_world -p ; \
+		     west build -b alif_e7_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_b1_dk_rtss_he samples/hello_world -p ; \
+		     west build -b alif_e1c_dk_rtss_he samples/hello_world -p ; \
                      else echo 'ERROR:./zephyr/scripts/checkpatch.pl detected errors/warnings.'; \
                      echo 'CMD:Run git diff --cached | ./zephyr/scripts/checkpatch.pl - before \
                      committing' ; exit 1 ; fi ; fi"


### PR DESCRIPTION
Update Jenkinsfile to include different build combinations.