### PR TITLE
subsys: bluetooth: add BLE host Kconfig

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,5 +6,8 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-rsource "le_audio/Kconfig"
-rsource "host/Kconfig"
+config BLE_DEVICE_NAME
+	string "Default BLE device name"
+	default "ALIF"
+	help
+	  BLE device name


### PR DESCRIPTION
Add Kconfig file for bluetooth subsystem configuration.

Signed-off-by: Juan Vazquez <juan.vazquez@alifsemi.com>
(cherry picked from commit 85769db92e96bc2450851470fd751f53c4ec4eaa)