### PR TITLE
samples: drivers: video: overlays to configure camera sensors in video sample

### DIFF
--- a/samples/drivers/video/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/drivers/video/boards/alif_e7_dk_rtss_he.overlay
@@ -1,0 +1,95 @@
+/* Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+
+
+&i2c1 {
+	status = "okay";
+
+	mt9m114: mt9m114@48{
+		compatible = "aptina,mt9m114";
+		reg = <0x48>;
+		status = "okay";
+
+		port {
+			mt9m114_ep_out: endpoint {
+				remote-endpoint = < &lpcam_ep_in >;
+				//remote-endpoint = < &cam_ep_in >;
+			};
+		};
+	};
+	arx3a0: arx3a0@36 {
+		compatible = "onnn,arx3a0";
+		reg = <0x36>;
+		pinctrl-0 = < &pinctrl_cam_xvclk >;
+		pinctrl-names = "default";
+		reset-gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+		power-gpios = <&gpio7 5 GPIO_ACTIVE_HIGH>;
+
+		status = "disabled";
+
+		port {
+			arx3a0_csi2_ep_out: endpoint {
+				//remote-endpoint = <&csi2_ep_in>;
+			};
+		};
+	};
+};
+
+&cam {
+	status = "disabled";
+	sensor = <&arx3a0>;
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Parallel Bus endpoint. */
+		cam_ep_in: endpoint@1 {
+			reg = <1>;
+			//remote-endpoint = <&mt9m114_ep_out>;
+		};
+		/* MIPI CSI-2 bus endpoint. */
+		cam_csi2_ep_in: endpoint@0 {
+			reg = <0>;
+			//remote-endpoint = <&csi2_ep_out>;
+		};
+	};
+};
+
+&lpcam {
+	status = "okay";
+	sensor = <&mt9m114>;
+	lp-cam;
+	port {
+		lpcam_ep_in: endpoint {
+			remote-endpoint = <&mt9m114_ep_out>;
+		};
+	};
+};
+
+&csi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	port@1 {
+		reg = <1>;
+		csi2_ep_in: endpoint {
+			//remote-endpoint = <&arx3a0_csi2_ep_out>;
+		};
+	};
+	port@2 {
+		reg = <2>;
+		csi2_ep_out: endpoint {
+			//remote-endpoint = <&cam_csi2_ep_in>;
+		};
+	};
+};

--- a/samples/drivers/video/boards/alif_e7_dk_rtss_hp.overlay
+++ b/samples/drivers/video/boards/alif_e7_dk_rtss_hp.overlay
@@ -1,0 +1,83 @@
+/* Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+
+
+&i2c1 {
+	status = "okay";
+
+	mt9m114: mt9m114@48{
+		compatible = "aptina,mt9m114";
+		reg = <0x48>;
+		status = "disabled";
+
+		port {
+			mt9m114_ep_out: endpoint {
+				remote-endpoint = < &cam_ep_in >;
+			};
+		};
+	};
+	arx3a0: arx3a0@36 {
+		compatible = "onnn,arx3a0";
+		reg = <0x36>;
+		pinctrl-0 = < &pinctrl_cam_xvclk >;
+		pinctrl-names = "default";
+		reset-gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+		power-gpios = <&gpio7 5 GPIO_ACTIVE_HIGH>;
+
+		status = "okay";
+
+		port {
+			arx3a0_csi2_ep_out: endpoint {
+				remote-endpoint = <&csi2_ep_in>;
+			};
+		};
+	};
+};
+
+&cam {
+	status = "okay";
+	sensor = <&arx3a0>;
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Parallel Bus endpoint. */
+		cam_ep_in: endpoint@1 {
+			reg = <1>;
+			remote-endpoint = <&mt9m114_ep_out>;
+		};
+		/* MIPI CSI-2 bus endpoint. */
+		cam_csi2_ep_in: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&csi2_ep_out>;
+		};
+	};
+};
+
+&csi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	port@1 {
+		reg = <1>;
+		csi2_ep_in: endpoint {
+			remote-endpoint = <&arx3a0_csi2_ep_out>;
+		};
+	};
+	port@2 {
+		reg = <2>;
+		csi2_ep_out: endpoint {
+			remote-endpoint = <&cam_csi2_ep_in>;
+		};
+	};
+};


### PR DESCRIPTION
- Configured mt9m114 and arx3a0 camera sensors using overlay files for ensemble e7 board since video sample uses them.