### PR TITLE
manifest: update zephyr_alif

### DIFF
--- a/samples/bluetooth/le_audio/broadcast_sink/boards/alif_b1_fpga_rtss_he_ble.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink/boards/alif_b1_fpga_rtss_he_ble.conf
@@ -21,9 +21,6 @@ CONFIG_WM8904_INIT_PRIORITY=53
 # SI570 clock output is passed through a fixed /8 divider to create MCLK signal
 CONFIG_AUDIO_CLOCK_DIVIDER=8
 
-# Uses ROM code version 1.2
-CONFIG_ALIF_BLE_ROM_IMAGE_V1_2=y
-
 # Debug support
 CONFIG_USE_SEGGER_RTT=y
 CONFIG_RTT_CONSOLE=y

--- a/samples/bluetooth/le_audio/broadcast_source/boards/alif_b1_fpga_rtss_he_ble.conf
+++ b/samples/bluetooth/le_audio/broadcast_source/boards/alif_b1_fpga_rtss_he_ble.conf
@@ -24,9 +24,6 @@ CONFIG_AUDIO_CLOCK_DIVIDER=8
 # 24 MHz FPGA bitstream is not fast enough to encode stereo
 CONFIG_BROADCAST_SOURCE_MONO=y
 
-# Uses ROM code version 1.2
-CONFIG_ALIF_BLE_ROM_IMAGE_V1_2=y
-
 # Debug
 CONFIG_USE_SEGGER_RTT=y
 CONFIG_RTT_CONSOLE=y

--- a/samples/bluetooth/le_periph_hr/src/main.c
+++ b/samples/bluetooth/le_periph_hr/src/main.c
@@ -165,10 +165,6 @@ static void on_appearance_get(uint8_t conidx, uint32_t metainfo, uint16_t token)
 	gapc_le_get_appearance_cfm(conidx, token, GAP_ERR_NO_ERROR, 0);
 }
 
-static void on_gapm_err(enum co_error err)
-{
-	LOG_ERR("gapm error %d", err);
-}
 
 /* HRPS callbacks */
 
@@ -240,6 +236,28 @@ static const gapc_connection_info_cb_t gapc_con_inf_cbs = {
 /* All callbacks in this struct are optional */
 static const gapc_le_config_cb_t gapc_le_cfg_cbs;
 
+#if !CONFIG_ALIF_BLE_ROM_IMAGE_V1_0 /* ROM version > 1.0 */
+static void on_gapm_err(uint32_t metainfo, uint8_t code)
+{
+	LOG_ERR("gapm error %d", code);
+}
+static const gapm_cb_t gapm_err_cbs = {
+	.cb_hw_error = on_gapm_err,
+};
+
+static const gapm_callbacks_t gapm_cbs = {
+	.p_con_req_cbs = &gapc_con_cbs,
+	.p_sec_cbs = &gapc_sec_cbs,
+	.p_info_cbs = &gapc_con_inf_cbs,
+	.p_le_config_cbs = &gapc_le_cfg_cbs,
+	.p_bt_config_cbs = NULL, /* BT classic so not required */
+	.p_gapm_cbs = &gapm_err_cbs,
+};
+#else
+static void on_gapm_err(enum co_error err)
+{
+	LOG_ERR("gapm error %d", err);
+}
 static const gapm_err_info_config_cb_t gapm_err_cbs = {
 	.ctrl_hw_error = on_gapm_err,
 };
@@ -252,6 +270,7 @@ static const gapm_callbacks_t gapm_cbs = {
 	.p_bt_config_cbs = NULL, /* BT classic so not required */
 	.p_err_info_config_cbs = &gapm_err_cbs,
 };
+#endif /* !CONFIG_ALIF_BLE_ROM_IMAGE_V1_0 */
 
 static const hrps_cb_t hrps_cb = {
 	.cb_bond_data_upd = on_bond_data_upd,

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 13d84793afd42bbf4110f4f907fe71d25d5e1335
+      revision: 826af61ce741488e653ee2618a318a11b3f8ca85
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
FPGA uses version 1.2 of the BLE&802154&LC3 ROM code.

Depends on alifsemi/zephyr_alif#46.