### PR TITLE
Fixed branch in west init command for 1.2 release in User Guide.

### DIFF
--- a/doc/user_guide/source/building_application_binaries.rst
+++ b/doc/user_guide/source/building_application_binaries.rst
@@ -92,7 +92,7 @@ Fetch the SDK source from the `main` branch:
 
    mkdir sdk-alif
    cd sdk-alif
-   west init -m https://github.com/alifsemi/sdk-alif.git --mr main
+   west init -m https://github.com/alifsemi/sdk-alif.git --mr v1.2-zas-branch
    west update
 
 2. Build an Application


### PR DESCRIPTION
User guide writeup as pointing to main branch. In the 1.2 branch it should point to the 1.2 branch in the west init command.