### PR TITLE
update west manifest file for i2c-clock-control-support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 8721597d22794f1c69305eb468fa6c6187567868
+      revision: 017ad6a7aa9f30d35f26f1abf52bc65e6b785ac3
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated sdk manifest file to point to I2C Clock Control Support PR: https://github.com/alifsemi/zephyr_alif/pull/77