### PR TITLE
manifest: Zephyr manifest update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 9e6f7378b811a2d08d357401f2aa6bad0edaa7ca
+      revision: 1cd41c6b4c5dbfab38d05044a1f5575c3debcec5
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Added baud2 delay support for max OSPI bus clock on E1C/B1.