### PR TITLE
tools: Fix clang-format file to handle goto command

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,3 +90,4 @@ UseTab: ForContinuationAndIndentation
 WhitespaceSensitiveMacros:
   - STRINGIFY
   - Z_STRINGIFY
+IndentGotoLabels: false


### PR DESCRIPTION
goto labels were indented incorrectly. Left aling lables.