### PR TITLE
manifest: update zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 81dbfb8f3841d04e25cff0fa6eae78e6548427e2
+      revision: a089480190dc2476a01123ec3173eef823fa5094
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update manifest to BLE address generation fix.

Depends on https://github.com/alifsemi/zephyr_alif/pull/107