### PR TITLE
samples: tflite-micro: Use maximum OSPI bus clock speed

### DIFF
--- a/samples/modules/tflite-micro/alif_kws/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/modules/tflite-micro/alif_kws/boards/alif_b1_dk_rtss_he.overlay
@@ -20,6 +20,6 @@
 };
 
 &ospi0 {
-	bus-speed = <40000000>;
+	bus-speed = <80000000>;
 	status = "okay";
 };

--- a/samples/modules/tflite-micro/alif_kws/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/modules/tflite-micro/alif_kws/boards/alif_e1c_dk_rtss_he.overlay
@@ -20,6 +20,6 @@
 };
 
 &ospi0 {
-	bus-speed = <40000000>;
+	bus-speed = <80000000>;
 	status = "okay";
 };

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/alif_b1_dk_rtss_he.overlay
@@ -9,6 +9,6 @@
  */
 
 &ospi0 {
-	bus-speed = <40000000>;
+	bus-speed = <80000000>;
 	status = "okay";
 };

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/alif_e1c_dk_rtss_he.overlay
@@ -9,6 +9,6 @@
  */
 
 &ospi0 {
-	bus-speed = <40000000>;
+	bus-speed = <80000000>;
 	status = "okay";
 };


### PR DESCRIPTION
Updated sample overlays to use maximum OSPI clock speed on E1C and B1