### PR TITLE
samples: display: enable non secure node in overlay

### DIFF
--- a/samples/drivers/display/boards/alif_e1c_dk_rtss_he.overlay
+++ b/samples/drivers/display/boards/alif_e1c_dk_rtss_he.overlay
@@ -22,3 +22,7 @@
 &lpuart {
 	status = "okay";
 };
+
+ns: &ns {
+	status = "okay";
+};


### PR DESCRIPTION
Enabling non secure node in overlay for e1c platform since by default it is disabled in dts.

Depends on alifsemi/zephyr_alif#138.