### PR TITLE
 samples: bluetooth: le_periph_plxp: BLE ROM v1.2 support

### DIFF
--- a/samples/bluetooth/le_periph_plxp/src/main.c
+++ b/samples/bluetooth/le_periph_plxp/src/main.c
@@ -280,6 +280,8 @@ static void on_adv_actv_stopped(uint32_t metainfo, uint8_t actv_idx, uint16_t re
 static void on_adv_actv_proc_cmp(uint32_t metainfo, uint8_t proc_id, uint8_t actv_idx,
 				 uint16_t status)
 {
+	gap_addr_t *p_addr;
+
 	if (status) {
 		LOG_ERR("Advertising activity process completed with error %u", status);
 		return;
@@ -303,7 +305,10 @@ static void on_adv_actv_proc_cmp(uint32_t metainfo, uint8_t proc_id, uint8_t act
 		break;
 
 	case GAPM_ACTV_START:
-		LOG_DBG("Advertising was started");
+		p_addr = gapm_le_get_adv_addr(actv_idx);
+		LOG_INF("Advertising has been started, address: %02X:%02X:%02X:%02X:%02X:%02X",
+			p_addr->addr[5], p_addr->addr[4], p_addr->addr[3], p_addr->addr[2],
+			p_addr->addr[1], p_addr->addr[0]);
 		break;
 
 	default:


### PR DESCRIPTION
- Add support for BLE ROM v1.2 to Pulse Oximeter sample application
- Rename boolean variable to lower case for consistency
- Add advertising address logs to identify units when running multiple devices