### PR TITLE
samples: bluetooth: le_periph_rscps: Add support for BLE ROM v1.2

### DIFF
--- a/samples/bluetooth/le_periph_rscps/CMakeLists.txt
+++ b/samples/bluetooth/le_periph_rscps/CMakeLists.txt
@@ -10,6 +10,10 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(le_periph_rscps)
 
+# Include directories
+zephyr_include_directories(../common)
+
 target_sources(app PRIVATE
     src/main.c
+    ../common/batt_svc.c
 )


### PR DESCRIPTION
- Add support for BLE ROM v1.2 to Running Speed and Cadence sample application.
- Log advertising address to identify units when using multiple device.
- Rename variable to lower case for consistency.