### PR TITLE
manifest: updates zephyr_alif

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 68a65b6b2d0a64d5fb8315b92d4e05ff143a6cd0
+      revision: pull/153/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
ospi_pinmux fix update.

Depends on [ospi_pin_fix:160](https://github.com/alifsemi/sdk-alif/pull/160)