### PR TITLE
manifest: Zephyr revision update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: abc572ee2f59f900d157770b012fa2a0972b01e0
+      revision: aaa3f7accc1d3da4c29923f2977a8b4902304d22
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated zephyr revision to contain Defualt disabled NS status for FPGA targets.
Depends on https://github.com/alifsemi/zephyr_alif/pull/164