### PR TITLE
manifest: zephyr update to include se_service fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: aaa3f7accc1d3da4c29923f2977a8b4902304d22
+      revision: c8a2e16822c59c96e96433cfb7c289cbf65dc715
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr_alif revision to include the se_service fixes and improvements from hal_alif.

Depends on: https://github.com/alifsemi/zephyr_alif/pull/163/