### PR TITLE
samples: drivers: spi_dw: set SPI master SS default as H/W controlled

### DIFF
--- a/samples/drivers/spi_dw/boards/alif_e3_dk_rtss_he.overlay
+++ b/samples/drivers/spi_dw/boards/alif_e3_dk_rtss_he.overlay
@@ -12,6 +12,24 @@
  *
  */
 
+/* For SPI master SS(slave select) as:
+ * - H/W controlled (default):
+ *   - use SS pinmux as H/W
+ *     - example for SPI4 as master "PIN_P7_7__LPSPI_SS_A"
+ *  "OR"
+ * - S/W controlled using gpio:
+ *   - use SS pinmux as gpio
+ *     - example for SPI4 as master "PIN_P7_7__GPIO"
+ *   - define cs-gpios property
+ *     - example for SPI4 as master
+ *        cs-gpios = <&gpio7 7 GPIO_ACTIVE_LOW>;
+ */
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
 / {
 	aliases {
 		master-spi = &spi4;
@@ -35,12 +53,37 @@
  * dmas = <&dma0 0 25>, <&dma0 1 24>;
  */
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	cs-gpios = <&gpio7 7 GPIO_ACTIVE_LOW>;
+	/* as we are testing Loopback on the same board,
+	 * make sure master interrupt priority is
+	 * higher than slave interrupt priority.
+	 */
+	interrupts = <46 0>;
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 };
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+/* use SPI master SS pinmux as gpio. */
+&pinctrl_lpspi {
+	group0 {
+		pinmux = < PIN_P7_4__LPSPI_MISO_A >,
+			 < PIN_P7_5__LPSPI_MOSI_A >,
+			 < PIN_P7_6__LPSPI_SCLK_A >,
+			 < PIN_P7_7__GPIO >;
+		read_enable = < 0x1 >;
+	};
+};
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 
 &spi0 {
 	status = "okay";
-	interrupts = <137 1>;
+	serial-target;
 	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
-        serial-target;
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	interrupts = <137 1>;
+#endif
 };

--- a/samples/drivers/spi_dw/boards/alif_e3_dk_rtss_hp.overlay
+++ b/samples/drivers/spi_dw/boards/alif_e3_dk_rtss_hp.overlay
@@ -12,6 +12,24 @@
  *
  */
 
+/* For SPI master SS(slave select) as:
+ * - H/W controlled (default):
+ *   - use SS pinmux as H/W
+ *     - example for SPI1 as master "PIN_P6_4__SPI1_SS0_B"
+ *  "OR"
+ * - S/W controlled using gpio:
+ *   - use SS pinmux as gpio
+ *     - example for SPI1 as master "PIN_P6_4__GPIO"
+ *   - define cs-gpios property
+ *     - example for SPI1 as master
+ *        cs-gpios = <&gpio6 4 GPIO_ACTIVE_LOW>;
+ */
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
 / {
 	aliases {
 		master-spi = &spi1;
@@ -27,11 +45,37 @@
 	status = "okay";
 	dmas = <&dma0 0 21>, <&dma0 1 17>;
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	cs-gpios = <&gpio6 4 GPIO_ACTIVE_LOW>;
+	/* as we are testing Loopback on the same board,
+	 * make sure master interrupt priority is
+	 * higher than slave interrupt priority.
+	 */
+	interrupts = <138 0>;
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 };
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+/* use SPI master SS pinmux as gpio. */
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < PIN_P8_3__SPI1_MISO_B >,
+			 < PIN_P8_4__SPI1_MOSI_B >,
+			 < PIN_P8_5__SPI1_SCLK_B >,
+			 < PIN_P6_4__GPIO >;
+		read_enable = < 0x1 >;
+	};
+};
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 
 &spi0 {
 	status = "okay";
 	serial-target;
 	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	interrupts = <137 1>;
+#endif
 };

--- a/samples/drivers/spi_dw/boards/alif_e7_dk_rtss_he.overlay
+++ b/samples/drivers/spi_dw/boards/alif_e7_dk_rtss_he.overlay
@@ -12,6 +12,24 @@
  *
  */
 
+/* For SPI master SS(slave select) as:
+ * - H/W controlled (default):
+ *   - use SS pinmux as H/W
+ *     - example for SPI4 as master "PIN_P7_7__LPSPI_SS_A"
+ *  "OR"
+ * - S/W controlled using gpio:
+ *   - use SS pinmux as gpio
+ *     - example for SPI4 as master "PIN_P7_7__GPIO"
+ *   - define cs-gpios property
+ *     - example for SPI4 as master
+ *        cs-gpios = <&gpio7 7 GPIO_ACTIVE_LOW>;
+ */
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
 / {
 	aliases {
 		master-spi = &spi4;
@@ -29,19 +47,44 @@
 
 &spi4 {
 	status = "okay";
-
 	dmas = <&dma2 0 13>, <&dma2 1 12>;
 /* If user want to use dma0 for master spi(spi4),
  * add below dmas property:
  * dmas = <&dma0 0 25>, <&dma0 1 24>;
  */
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	cs-gpios = <&gpio7 7 GPIO_ACTIVE_LOW>;
+	/* as we are testing Loopback on the same board,
+	 * make sure master interrupt priority is
+	 * higher than slave interrupt priority.
+	 */
+	interrupts = <46 0>;
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 };
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+/* use SPI master SS pinmux as gpio. */
+&pinctrl_lpspi {
+	group0 {
+		pinmux = < PIN_P7_4__LPSPI_MISO_A >,
+			 < PIN_P7_5__LPSPI_MOSI_A >,
+			 < PIN_P7_6__LPSPI_SCLK_A >,
+			 < PIN_P7_7__GPIO >;
+		read_enable = < 0x1 >;
+	};
+};
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 
 &spi0 {
 	status = "okay";
 	serial-target;
 	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	interrupts = <137 1>;
+#endif
 };
 

--- a/samples/drivers/spi_dw/boards/alif_e7_dk_rtss_hp.overlay
+++ b/samples/drivers/spi_dw/boards/alif_e7_dk_rtss_hp.overlay
@@ -12,6 +12,24 @@
  *
  */
 
+/* For SPI master SS(slave select) as:
+ * - H/W controlled (default):
+ *   - use SS pinmux as H/W
+ *     - example for SPI1 as master "PIN_P6_4__SPI1_SS0_B"
+ *  "OR"
+ * - S/W controlled using gpio:
+ *   - use SS pinmux as gpio
+ *     - example for SPI1 as master "PIN_P6_4__GPIO"
+ *   - define cs-gpios property
+ *     - example for SPI1 as master
+ *        cs-gpios = <&gpio6 4 GPIO_ACTIVE_LOW>;
+ */
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
 / {
 	aliases {
 		master-spi = &spi1;
@@ -27,11 +45,37 @@
 	status = "okay";
 	dmas = <&dma0 0 21>, <&dma0 1 17>;
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	cs-gpios = <&gpio6 4 GPIO_ACTIVE_LOW>;
+	/* as we are testing Loopback on the same board,
+	 * make sure master interrupt priority is
+	 * higher than slave interrupt priority.
+	 */
+	interrupts = <138 0>;
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 };
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+/* use SPI master SS pinmux as gpio. */
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < PIN_P8_3__SPI1_MISO_B >,
+			 < PIN_P8_4__SPI1_MOSI_B >,
+			 < PIN_P8_5__SPI1_SCLK_B >,
+			 < PIN_P6_4__GPIO >;
+		read_enable = < 0x1 >;
+	};
+};
+#endif /* SPI_MASTER_SS_SW_CONTROLLED_GPIO */
 
 &spi0 {
 	status = "okay";
 	serial-target;
 	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	interrupts = <137 1>;
+#endif
 };


### PR DESCRIPTION
- set SPI master SS(slave select) default as H/W controlled, also add option to select S/W controlled using gpio.
- set master thread priority higher than slave thread.
- as we are testing Loopback on the same board, make sure slave is ready before master starts.