### PR TITLE
samples: bluetooth: le_audio: unidir: make __ramfunc optional

### DIFF
--- a/drivers/i2s/i2s_sync/i2s_sync.c
+++ b/drivers/i2s/i2s_sync/i2s_sync.c
@@ -35,6 +35,12 @@ LOG_MODULE_REGISTER(i2s_sync, CONFIG_I2S_SYNC_LOG_LEVEL);
 #define EVTRTR2_DMA_CTRL_ACK_PERIPH (0x0 << 16)
 #define EVTRTR2_DMA_CTRL_ACK_ROUTER (0x1 << 16)
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 struct i2s_sync_channel {
 	i2s_sync_cb_t cb;
 	void *buf;
@@ -121,8 +127,8 @@ static int configure_dma_event_router(const uint32_t dma_group, const uint32_t d
 	return 0;
 }
 
-__ramfunc static void dma_tx_callback(const struct device *dma_dev, void *p_user_data,
-				      uint32_t const channel, int const status)
+INT_RAMFUNC static void dma_tx_callback(const struct device *dma_dev, void *p_user_data,
+					uint32_t const channel, int const status)
 {
 	const struct device *const dev = p_user_data;
 	struct i2s_sync_data *const dev_data = dev->data;
@@ -143,8 +149,8 @@ __ramfunc static void dma_tx_callback(const struct device *dma_dev, void *p_user
 	LOG_DBG("I2S:%s tx dma callback ch:%d completed", dev->name, channel);
 }
 
-__ramfunc static int i2s_transmitter_start_dma(const struct device *const dev,
-					       size_t const bytes_per_sample)
+INT_RAMFUNC static int i2s_transmitter_start_dma(const struct device *const dev,
+						 size_t const bytes_per_sample)
 {
 	const struct i2s_sync_config_priv *dev_cfg = dev->config;
 	struct i2s_t *i2s = dev_cfg->paddr;
@@ -206,7 +212,7 @@ __ramfunc static int i2s_transmitter_start_dma(const struct device *const dev,
 	return ret;
 }
 
-__ramfunc static void i2s_transmitter_start(struct i2s_t *const i2s)
+INT_RAMFUNC static void i2s_transmitter_start(struct i2s_t *const i2s)
 {
 	i2s_tx_channel_enable(i2s);
 	i2s_tx_interrupt_enable(i2s);
@@ -214,7 +220,7 @@ __ramfunc static void i2s_transmitter_start(struct i2s_t *const i2s)
 	/* Should immediately get interrupt during which FIFO is filled */
 }
 
-__ramfunc static int i2s_send(const struct device *dev, void *buf, size_t len)
+INT_RAMFUNC static int i2s_send(const struct device *dev, void *buf, size_t len)
 {
 	if ((buf == NULL) || (len == 0)) {
 		return -EINVAL;
@@ -256,8 +262,8 @@ __ramfunc static int i2s_send(const struct device *dev, void *buf, size_t len)
 	return 0;
 }
 
-__ramfunc static void dma_rx_callback(const struct device *dma_dev, void *p_user_data,
-				      uint32_t const channel, int const status)
+INT_RAMFUNC static void dma_rx_callback(const struct device *dma_dev, void *p_user_data,
+					uint32_t const channel, int const status)
 {
 	const struct device *const dev = p_user_data;
 	struct i2s_sync_data *const dev_data = dev->data;
@@ -282,8 +288,8 @@ __ramfunc static void dma_rx_callback(const struct device *dma_dev, void *p_user
 	LOG_DBG("I2S:%s rx dma callback ch:%d completed", dev->name, channel);
 }
 
-__ramfunc static int i2s_receiver_start_dma(const struct device *const dev,
-					    size_t const bytes_per_sample)
+INT_RAMFUNC static int i2s_receiver_start_dma(const struct device *const dev,
+					      size_t const bytes_per_sample)
 {
 	const struct i2s_sync_config_priv *dev_cfg = dev->config;
 	struct i2s_t *i2s = dev_cfg->paddr;
@@ -340,14 +346,14 @@ __ramfunc static int i2s_receiver_start_dma(const struct device *const dev,
 	return ret;
 }
 
-__ramfunc static void i2s_receiver_start(struct i2s_t *const i2s)
+INT_RAMFUNC static void i2s_receiver_start(struct i2s_t *const i2s)
 {
 	i2s_rx_channel_enable(i2s);
 	i2s_rx_interrupt_enable(i2s);
 	i2s_rx_block_enable(i2s);
 }
 
-__ramfunc static int i2s_recv(const struct device *dev, void *buf, size_t len)
+INT_RAMFUNC static int i2s_recv(const struct device *dev, void *buf, size_t len)
 {
 	if ((buf == NULL) || (len == 0)) {
 		return -EINVAL;
@@ -647,7 +653,7 @@ static int i2s_sync_init(const struct device *dev)
 	return 0;
 }
 
-__ramfunc static void i2s_sync_tx_isr_handler(const struct device *dev)
+INT_RAMFUNC static void i2s_sync_tx_isr_handler(const struct device *dev)
 {
 	const struct i2s_sync_config_priv *dev_cfg = dev->config;
 	struct i2s_sync_data *dev_data = dev->data;
@@ -710,7 +716,7 @@ __ramfunc static void i2s_sync_tx_isr_handler(const struct device *dev)
 	}
 }
 
-__ramfunc static void i2s_sync_rx_isr_handler(const struct device *dev)
+INT_RAMFUNC static void i2s_sync_rx_isr_handler(const struct device *dev)
 {
 	const struct i2s_sync_config_priv *dev_cfg = (struct i2s_sync_config_priv *)dev->config;
 	struct i2s_sync_data *dev_data = dev->data;
@@ -772,7 +778,7 @@ __ramfunc static void i2s_sync_rx_isr_handler(const struct device *dev)
 	}
 }
 
-__ramfunc static void i2s_sync_isr(const struct device *dev)
+INT_RAMFUNC static void i2s_sync_isr(const struct device *dev)
 {
 	const struct i2s_sync_config_priv *dev_cfg = dev->config;
 	struct i2s_sync_data *dev_data = dev->data;

--- a/samples/bluetooth/le_audio/broadcast_source/src/audio_datapath.c
+++ b/samples/bluetooth/le_audio/broadcast_source/src/audio_datapath.c
@@ -18,6 +18,12 @@
 
 LOG_MODULE_REGISTER(audio_datapath, CONFIG_AUDIO_DATAPATH_LOG_LEVEL);
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #define MIC_LEVEL_CALC(_s)   (((int)(_s) * CONFIG_MICROPHONE_GAIN) / 100)
 #define INPUT_LEVEL_CALC(_s) (((int)(_s) * CONFIG_INPUT_VOLUME_LEVEL) / 100)
 
@@ -80,7 +86,7 @@ static int configure_codec(const uint32_t sampling_rate_hz)
 	return 0;
 }
 
-__ramfunc static void audio_encoder_mixer_thread_func(void *p1, void *p2, void *p3)
+INT_RAMFUNC static void audio_encoder_mixer_thread_func(void *p1, void *p2, void *p3)
 {
 	/* thread:
 	 * get audio input jack buffer

--- a/samples/bluetooth/le_audio/broadcast_source/src/mic_source.c
+++ b/samples/bluetooth/le_audio/broadcast_source/src/mic_source.c
@@ -26,7 +26,13 @@ struct mic_source_env {
 
 static struct mic_source_env mic_source;
 
-__ramfunc static void recv_next_block(const struct device *dev)
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
+INT_RAMFUNC static void recv_next_block(const struct device *dev)
 {
 	struct audio_block *p_block = NULL;
 	int ret = k_mem_slab_alloc(&mic_source.audio_queue->slab, (void **)&p_block, K_NO_WAIT);
@@ -41,8 +47,8 @@ __ramfunc static void recv_next_block(const struct device *dev)
 	p_block->num_channels = mic_source.number_of_channels;
 }
 
-__ramfunc static void on_data_received(const struct device *dev, const enum i2s_sync_status status,
-				       void *block)
+INT_RAMFUNC static void on_data_received(const struct device *dev,
+					 const enum i2s_sync_status status, void *block)
 {
 	ARG_UNUSED(status);
 

--- a/samples/bluetooth/le_audio/unicast_sink/bidir.conf
+++ b/samples/bluetooth/le_audio/unicast_sink/bidir.conf
@@ -1,0 +1,10 @@
+# Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_UNICAST_MONO=y
+CONFIG_UNICAST_BIDIR=y

--- a/samples/bluetooth/le_audio/unicast_sink/src/audio_datapath.c
+++ b/samples/bluetooth/le_audio/unicast_sink/src/audio_datapath.c
@@ -17,6 +17,12 @@
 
 #include "audio_datapath.h"
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #define I2S_SINK_DEV DEVICE_DT_GET(CODEC_I2S_NODE)
 
 #if DT_NODE_EXISTS(I2S_MIC_NODE)
@@ -66,7 +72,7 @@ static int unicast_audio_path_init(void)
 SYS_INIT(unicast_audio_path_init, APPLICATION, 0);
 
 #if ENCODER_DEBUG
-__ramfunc static void on_encoder_frame_complete(void *param, uint32_t timestamp, uint16_t sdu_seq)
+INT_RAMFUNC static void on_encoder_frame_complete(void *param, uint32_t timestamp, uint16_t sdu_seq)
 {
 	if ((sdu_seq % 128) == 0) {
 		LOG_INF("SDU sequence number: %u", sdu_seq);
@@ -75,7 +81,7 @@ __ramfunc static void on_encoder_frame_complete(void *param, uint32_t timestamp,
 #endif
 
 #if DECODER_DEBUG
-__ramfunc static void print_sdus(void *context, uint32_t timestamp, uint16_t sdu_seq)
+INT_RAMFUNC static void print_sdus(void *context, uint32_t timestamp, uint16_t sdu_seq)
 {
 	static uint16_t last_sdu;
 

--- a/samples/bluetooth/le_audio/unicast_source/bidir.conf
+++ b/samples/bluetooth/le_audio/unicast_source/bidir.conf
@@ -1,0 +1,9 @@
+# Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_LE_AUDIO_BIDIRECTIONAL=y

--- a/samples/bluetooth/le_audio/unicast_source/src/audio_datapath.c
+++ b/samples/bluetooth/le_audio/unicast_source/src/audio_datapath.c
@@ -16,6 +16,12 @@
 
 #include "audio_datapath.h"
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 LOG_MODULE_REGISTER(audio_datapath, CONFIG_BLE_AUDIO_LOG_LEVEL);
 
 struct audio_datapath {
@@ -49,7 +55,7 @@ static int unicast_audio_path_init(void)
 SYS_INIT(unicast_audio_path_init, APPLICATION, 0);
 
 #if ENCODER_DEBUG
-__ramfunc static void on_encoder_frame_complete(void *param, uint32_t timestamp, uint16_t sdu_seq)
+INT_RAMFUNC static void on_encoder_frame_complete(void *param, uint32_t timestamp, uint16_t sdu_seq)
 {
 	if ((sdu_seq % 128) == 0) {
 		LOG_INF("SDU sequence number: %u", sdu_seq);
@@ -58,7 +64,7 @@ __ramfunc static void on_encoder_frame_complete(void *param, uint32_t timestamp,
 #endif
 
 #if DECODER_DEBUG
-__ramfunc static void print_sdus(void *context, uint32_t timestamp, uint16_t sdu_seq)
+INT_RAMFUNC static void print_sdus(void *context, uint32_t timestamp, uint16_t sdu_seq)
 {
 	static uint16_t last_sdu;
 

--- a/subsys/bluetooth/le_audio/Kconfig
+++ b/subsys/bluetooth/le_audio/Kconfig
@@ -177,6 +177,10 @@ config ALIF_BLE_AUDIO_SOURCE_TRANSMISSION_DELAY_MS
 	range 0 100
 	default 30
 
+config ALIF_BLE_AUDIO_USE_RAMFUNC
+	bool "Run some critical functions in RAM"
+	default n
+
 rsource "Kconfig.lc3"
 rsource "Kconfig.presentation_compensation"
 

--- a/subsys/bluetooth/le_audio/audio_decoder.c
+++ b/subsys/bluetooth/le_audio/audio_decoder.c
@@ -24,6 +24,12 @@
 #include "bluetooth/le_audio/audio_sink_i2s.h"
 #include "bluetooth/le_audio/iso_datapath_ctoh.h"
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #define AUDIO_QUEUE_MARGIN_US     (CONFIG_ALIF_BLE_AUDIO_PRESENTATION_DELAY_QUEUE_MARGIN * 1000)
 #define MIN_PRESENTATION_DELAY_US (CONFIG_ALIF_BLE_AUDIO_MIN_PRESENTATION_DELAY_MS * 1000)
 
@@ -160,11 +166,13 @@ static int get_channel_index(struct audio_decoder const *const decoder, uint32_t
 	return -EINVAL;
 }
 
-__ramfunc static void audio_decoder_thread_func(void *p1, void *p2, void *p3)
+INT_RAMFUNC static void audio_decoder_thread_func(void *p1, void *p2, void *p3)
 {
 	struct audio_decoder *dec = (struct audio_decoder *)p1;
 	(void)p2;
 	(void)p3;
+
+	LOG_DBG("Decoder thread started");
 
 	int ret;
 	struct audio_block *audio;

--- a/subsys/bluetooth/le_audio/audio_encoder.c
+++ b/subsys/bluetooth/le_audio/audio_encoder.c
@@ -21,6 +21,12 @@
 #include "bluetooth/le_audio/iso_datapath_htoc.h"
 #include "bluetooth/le_audio/audio_encoder.h"
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #define AUDIO_QUEUE_MARGIN_US     (CONFIG_ALIF_BLE_AUDIO_PRESENTATION_DELAY_QUEUE_MARGIN * 1000)
 #define MIN_PRESENTATION_DELAY_US (CONFIG_ALIF_BLE_AUDIO_MIN_PRESENTATION_DELAY_MS * 1000)
 
@@ -144,7 +150,7 @@ static int get_channel_index(struct audio_encoder const *const encoder, uint32_t
 	return -EINVAL;
 }
 
-__ramfunc static void audio_encoder_thread_func(void *p1, void *p2, void *p3)
+INT_RAMFUNC static void audio_encoder_thread_func(void *p1, void *p2, void *p3)
 {
 	struct audio_encoder *enc = (struct audio_encoder *)p1;
 	(void)p2;

--- a/subsys/bluetooth/le_audio/audio_i2s_common.c
+++ b/subsys/bluetooth/le_audio/audio_i2s_common.c
@@ -10,8 +10,14 @@
 #include <zephyr/sys/util.h>
 #include "audio_i2s_common.h"
 
-__ramfunc int audio_i2s_timing_apply_correction(struct audio_i2s_timing *timing,
-						int32_t const correction_us)
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
+INT_RAMFUNC int audio_i2s_timing_apply_correction(struct audio_i2s_timing *timing,
+						  int32_t const correction_us)
 {
 	if (timing == NULL) {
 		return -EINVAL;
@@ -41,7 +47,7 @@ __ramfunc int audio_i2s_timing_apply_correction(struct audio_i2s_timing *timing,
 	return 0;
 }
 
-__ramfunc int32_t audio_i2s_get_sample_correction(struct audio_i2s_timing *timing)
+INT_RAMFUNC int32_t audio_i2s_get_sample_correction(struct audio_i2s_timing *timing)
 {
 	if (timing == NULL) {
 		return 0;

--- a/subsys/bluetooth/le_audio/audio_sink_i2s.c
+++ b/subsys/bluetooth/le_audio/audio_sink_i2s.c
@@ -19,6 +19,12 @@
 
 LOG_MODULE_REGISTER(audio_sink_i2s, CONFIG_BLE_AUDIO_LOG_LEVEL);
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #include <zephyr/drivers/gpio.h>
 
 #define GPIO_TEST0_NODE DT_ALIAS(sink_i2s_test0) /* DT_NODELABEL(test_pin0) */
@@ -91,7 +97,7 @@ static struct pres_delay_work pd_work;
 
 static pcm_sample_t silence[MAX_SAMPLES_PER_AUDIO_BLOCK];
 
-__ramfunc static void send_next_block(const struct device *dev, uint32_t const time_now)
+INT_RAMFUNC static void send_next_block(const struct device *dev, uint32_t const time_now)
 {
 	struct audio_block *block = NULL;
 	int32_t const correction_samples = audio_i2s_get_sample_correction(&audio_sink.timing);
@@ -144,8 +150,8 @@ __ramfunc static void send_next_block(const struct device *dev, uint32_t const t
 	audio_sink.current_block = block;
 }
 
-__ramfunc static void on_i2s_complete(const struct device *dev, enum i2s_sync_status status,
-				      void *p_block)
+INT_RAMFUNC static void on_i2s_complete(const struct device *dev, enum i2s_sync_status status,
+					void *p_block)
 {
 	ARG_UNUSED(p_block);
 
@@ -169,7 +175,7 @@ __ramfunc static void on_i2s_complete(const struct device *dev, enum i2s_sync_st
 	}
 }
 
-__ramfunc static void submit_presentation_delay(struct k_work *item)
+INT_RAMFUNC static void submit_presentation_delay(struct k_work *item)
 {
 	(void)item;
 	/* struct pres_delay_work *w = CONTAINER_OF(item, struct pres_delay_work, work); */
@@ -236,8 +242,8 @@ int audio_sink_i2s_configure(const struct device *dev, struct audio_queue *audio
 	return 0;
 }
 
-__ramfunc void audio_sink_i2s_notify_buffer_available(void *param, uint32_t const timestamp,
-						      uint16_t const sdu_seq)
+INT_RAMFUNC void audio_sink_i2s_notify_buffer_available(void *param, uint32_t const timestamp,
+							uint16_t const sdu_seq)
 {
 	(void)param;
 	(void)timestamp;
@@ -253,7 +259,7 @@ __ramfunc void audio_sink_i2s_notify_buffer_available(void *param, uint32_t cons
 	send_next_block(audio_sink.dev, time_now);
 }
 
-__ramfunc void audio_sink_i2s_apply_timing_correction(int32_t correction_us)
+INT_RAMFUNC void audio_sink_i2s_apply_timing_correction(int32_t correction_us)
 {
 	audio_i2s_timing_apply_correction(&audio_sink.timing, correction_us);
 }

--- a/subsys/bluetooth/le_audio/audio_source_i2s.c
+++ b/subsys/bluetooth/le_audio/audio_source_i2s.c
@@ -18,6 +18,12 @@
 
 LOG_MODULE_REGISTER(audio_source_i2s, CONFIG_BLE_AUDIO_LOG_LEVEL);
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #if CONFIG_ALIF_BLE_AUDIO_FRAME_DURATION_10MS
 #define FRAMES_PER_SECOND 100
 #else
@@ -118,7 +124,7 @@ struct last_block_job {
 K_KERNEL_STACK_DEFINE(i2s_worker_stack, 2048);
 static struct k_work_q i2s_worker_queue;
 
-__ramfunc static void finish_last_block(struct k_work *work)
+INT_RAMFUNC static void finish_last_block(struct k_work *work)
 {
 	struct last_block_job *p_context = CONTAINER_OF(work, struct last_block_job, work);
 	struct audio_input_buffer *p_block = p_context->p_block;
@@ -196,7 +202,7 @@ static struct last_block_job finish_last_block_job = {
 	.p_block = NULL,
 };
 
-__ramfunc static void recv_next_block(const struct device *dev, uint32_t timestamp)
+INT_RAMFUNC static void recv_next_block(const struct device *dev, uint32_t timestamp)
 {
 	bool const ping_pong = audio_source.ping_pong_buffer ^ true;
 
@@ -247,8 +253,8 @@ __ramfunc static void recv_next_block(const struct device *dev, uint32_t timesta
 #endif
 }
 
-__ramfunc static void on_i2s_complete(const struct device *dev, enum i2s_sync_status status,
-				      void *block)
+INT_RAMFUNC static void on_i2s_complete(const struct device *dev, enum i2s_sync_status status,
+					void *block)
 {
 	/* Capture timestamp before doing anything else to reduce jitter */
 	const uint32_t time_now = gapi_isooshm_dp_get_local_time();
@@ -389,7 +395,7 @@ void audio_source_i2s_stop(void)
 	audio_source.started = false;
 }
 
-__ramfunc void audio_source_i2s_apply_timing_correction(int32_t const correction_us)
+INT_RAMFUNC void audio_source_i2s_apply_timing_correction(int32_t const correction_us)
 {
 	audio_i2s_timing_apply_correction(&audio_source.timing, correction_us);
 }

--- a/subsys/bluetooth/le_audio/iso_datapath_ctoh.c
+++ b/subsys/bluetooth/le_audio/iso_datapath_ctoh.c
@@ -17,6 +17,12 @@
 
 LOG_MODULE_REGISTER(iso_datapath_ctoh, CONFIG_BLE_AUDIO_LOG_LEVEL);
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #include <zephyr/drivers/gpio.h>
 
 #define GPIO_TEST0_NODE DT_ALIAS(ctoh_test0)
@@ -92,9 +98,9 @@ struct timestamp_debug timestamps_debug[CONFIG_ALIF_BLE_AUDIO_NMB_CHANNELS]
 	__attribute__((__used__));
 #endif
 
-__ramfunc static void finish_last_sdu(struct sdu_queue *sdu_queue,
-				      gapi_isooshm_sdu_buf_t *const p_sdu, size_t const stream_id,
-				      uint32_t const timestamp)
+INT_RAMFUNC static void finish_last_sdu(struct sdu_queue *sdu_queue,
+					gapi_isooshm_sdu_buf_t *const p_sdu, size_t const stream_id,
+					uint32_t const timestamp)
 {
 #if DT_NODE_EXISTS(GPIO_TEST1_NODE)
 	set_test_pin(&test_pin1, 1);
@@ -132,7 +138,7 @@ __ramfunc static void finish_last_sdu(struct sdu_queue *sdu_queue,
 #endif
 }
 
-__ramfunc static int recv_next_sdu(struct iso_datapath_ctoh *const datapath, bool const lock)
+INT_RAMFUNC static int recv_next_sdu(struct iso_datapath_ctoh *const datapath, bool const lock)
 {
 	gapi_isooshm_sdu_buf_t *p_sdu = NULL;
 	struct sdu_queue *const sdu_queue = datapath->sdu_queue;
@@ -189,8 +195,8 @@ __ramfunc static int recv_next_sdu(struct iso_datapath_ctoh *const datapath, boo
 	return ret;
 }
 
-__ramfunc static void on_dp_transfer_complete(gapi_isooshm_dp_t *const dp,
-					      gapi_isooshm_sdu_buf_t *const buf)
+INT_RAMFUNC static void on_dp_transfer_complete(gapi_isooshm_dp_t *const dp,
+						gapi_isooshm_sdu_buf_t *const buf)
 {
 #if DT_NODE_EXISTS(GPIO_TEST0_NODE)
 	set_test_pin(&test_pin0, 1);
@@ -342,8 +348,8 @@ int iso_datapath_ctoh_stop(struct iso_datapath_ctoh *const datapath)
 	return iso_datapath_ctoh_unbind(datapath);
 }
 
-__ramfunc void iso_datapath_ctoh_notify_sdu_done(void *p_datapath, uint32_t const timestamp,
-						 uint16_t const sdu_seq)
+INT_RAMFUNC void iso_datapath_ctoh_notify_sdu_done(void *p_datapath, uint32_t const timestamp,
+						   uint16_t const sdu_seq)
 {
 	ARG_UNUSED(timestamp);
 	ARG_UNUSED(sdu_seq);

--- a/subsys/bluetooth/le_audio/iso_datapath_htoc.c
+++ b/subsys/bluetooth/le_audio/iso_datapath_htoc.c
@@ -18,6 +18,12 @@
 
 LOG_MODULE_REGISTER(iso_datapath_htoc, CONFIG_BLE_AUDIO_LOG_LEVEL);
 
+#if CONFIG_ALIF_BLE_AUDIO_USE_RAMFUNC
+#define INT_RAMFUNC __ramfunc
+#else
+#define INT_RAMFUNC
+#endif
+
 #define GPIO_TEST0_NODE DT_ALIAS(htoc_test0)
 #define GPIO_TEST1_NODE DT_ALIAS(htoc_test1)
 
@@ -85,7 +91,7 @@ struct sdu_timing_info {
 	uint16_t seq_num;
 };
 
-__ramfunc static void send_next_sdu(struct iso_datapath_htoc *const datapath, bool const lock)
+INT_RAMFUNC static void send_next_sdu(struct iso_datapath_htoc *const datapath, bool const lock)
 {
 	void *p_sdu = NULL;
 	int ret = k_msgq_get(&datapath->sdu_queue->msgq, (void *)&p_sdu, K_NO_WAIT);
@@ -119,8 +125,8 @@ __ramfunc static void send_next_sdu(struct iso_datapath_htoc *const datapath, bo
 	LOG_ERR("Failed to set next ISO buffer, err %u", ret);
 }
 
-__ramfunc static void on_dp_transfer_complete(gapi_isooshm_dp_t *const dp,
-					      gapi_isooshm_sdu_buf_t *const buf)
+INT_RAMFUNC static void on_dp_transfer_complete(gapi_isooshm_dp_t *const dp,
+						gapi_isooshm_sdu_buf_t *const buf)
 {
 #if DT_NODE_EXISTS(GPIO_TEST0_NODE)
 	set_test_pin(&test_pin0, 1);
@@ -256,8 +262,8 @@ int iso_datapath_htoc_unbind(struct iso_datapath_htoc *const datapath)
 	return 0;
 }
 
-__ramfunc static void store_sdu_timing_info(struct iso_datapath_htoc *iso_dp,
-					    uint32_t capture_timestamp, uint16_t sdu_seq)
+INT_RAMFUNC static void store_sdu_timing_info(struct iso_datapath_htoc *iso_dp,
+					      uint32_t capture_timestamp, uint16_t sdu_seq)
 {
 	struct sdu_timing_info info = {
 		.seq_num = sdu_seq,
@@ -271,8 +277,8 @@ __ramfunc static void store_sdu_timing_info(struct iso_datapath_htoc *iso_dp,
 	}
 }
 
-__ramfunc static int get_sdu_timing(struct iso_datapath_htoc *iso_dp, uint16_t sdu_seq,
-				    struct sdu_timing_info *info)
+INT_RAMFUNC static int get_sdu_timing(struct iso_datapath_htoc *iso_dp, uint16_t sdu_seq,
+				      struct sdu_timing_info *info)
 {
 	/* Loop through SDU queue until we either find a matching SDU or we know that the matching
 	 * SDU does not exist in the queue
@@ -303,9 +309,9 @@ __ramfunc static int get_sdu_timing(struct iso_datapath_htoc *iso_dp, uint16_t s
 	}
 }
 
-__ramfunc void iso_datapath_htoc_notify_sdu_available(void *const datapath,
-						      uint32_t const capture_timestamp,
-						      uint16_t const sdu_seq)
+INT_RAMFUNC void iso_datapath_htoc_notify_sdu_available(void *const datapath,
+							uint32_t const capture_timestamp,
+							uint16_t const sdu_seq)
 {
 	if (datapath == NULL) {
 		LOG_ERR("null datapath");


### PR DESCRIPTION
`__ramfunc` macro causes linking issue so make it optional to be able enabled if needed.