### PR TITLE
manifest: update zephyr to add spi mode selection fix.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 1242a7040ddd0b8cd282595acdb5236d52721803
+      revision: 5e644ebdeb8f34b347aae632d6f943e8bb34ff19
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
zephyr updated to add spi mode selection from dts.

Depends on [Zephyr SPI Mode Selection PR#177](https://github.com/alifsemi/zephyr_alif/pull/177)