### PR TITLE
samples: video: Fix cam app for non-HM0360 sensor.

### DIFF
--- a/samples/drivers/video/src/main.c
+++ b/samples/drivers/video/src/main.c
@@ -151,14 +151,14 @@ int main(void)
 	 */
 	k_msleep(7000);
 
-	if (IS_ENABLED(CONFIG_DT_HAS_HIMAX_HM0360_ENABLED)) {
-		/* Video test SNAPSHOT capture. */
-		num_frames = N_FRAMES;
-		ret = video_set_ctrl(video, VIDEO_CID_SNAPSHOT_CAPTURE, &num_frames);
-		if (ret) {
-			LOG_INF("Snapshot mode not-supported by CMOS sensor.");
-		}
+#if CONFIG_DT_HAS_HIMAX_HM0360_ENABLED
+	/* Video test SNAPSHOT capture. */
+	num_frames = N_FRAMES;
+	ret = video_set_ctrl(video, VIDEO_CID_SNAPSHOT_CAPTURE, &num_frames);
+	if (ret) {
+		LOG_INF("Snapshot mode not-supported by CMOS sensor.");
 	}
+#endif /* CONFIG_DT_HAS_HIMAX_HM0360_ENABLED */
 
 	/* Start video capture */
 	ret = video_stream_start(video);


### PR DESCRIPTION
The camera app is failing for the case we use camera other than HM0360. The issue is because of code using IS_ENABLED() guard code uses some APIs that are there only in the case of HM0360 sensor. The compiler during the pre-processing stage is marking the code inside if(0), but the code is compiled out in later stages of compilation only. So, during the rest of compilation process, the un-available APIs are tried to be resolved, which causes a compile time failure