### PR TITLE
samples: ble: broadcast sink: set audio configuration based on what source provides

### DIFF
--- a/drivers/codec/wm8904/wm8904.c
+++ b/drivers/codec/wm8904/wm8904.c
@@ -892,10 +892,6 @@ int cwm_init(const struct device *dev)
 
 	LOG_DBG("Initialisation completed");
 
-	/* TODO Remove once the application is updated to use the new API */
-	cwm_start_output(dev);
-	LOG_DBG("Output started. TODO: Remove");
-
 	return 0;
 }
 

--- a/samples/bluetooth/le_audio/broadcast_sink/README.rst
+++ b/samples/bluetooth/le_audio/broadcast_sink/README.rst
@@ -8,8 +8,8 @@ Overview
 
 This sample demonstrates the LE audio broadcast sink use-case.
 
-It scans for broadcast sources and synchronises with the first compatible source found. To be
-compatible, a source device must use a 48 kHz sampling rate and 10 ms frames, unless differently configured.
+It scans for broadcast sources and synchronises with the first compatible source found.
+The audio configuration (sampling rate, frame duration) is dynamically determined from the broadcast source and used to configure the audio codec at runtime.
 
 Both stereo and mono sources are supported. In case of a mono source, the single channel will be
 duplicated on both left and right I2S output streams.
@@ -22,21 +22,8 @@ sdk-alif tree.
 
 See :ref:`Alif bluetooth samples section <alif-bluetooth-samples>` for details.
 
-Configuration options:
-
-.. list-table::
-
-    * - :file:`prj.conf`
-      - This is the standard default config. Sampling frequency 48kHz, 10ms frame duration, 100 octets per codec frame. The default retransmissions are set to 4.
-
-    * - :file:`overlay-auracast_16_2.conf`
-      - Enables a Standard Quality codec configuration. 16-bit sample rate, 40 octets per codec frame.
-
-    * - :file:`overlay-auracast_24_2.conf`
-      - Enables a Standard Quality codec configuration. 24-bit sample rate, 60 octets per codec frame.
-
-BAP defined Codec Configuration Settings
-******************************************
+BAP defined Codec Configuration Settings (Dynamically Supported)
+***************************************************************
 
 .. table:: BAP defined Codec Configuration Settings
    :widths: 1 1 1 1 1

--- a/samples/bluetooth/le_audio/broadcast_sink/overlay-auracast_16_2.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink/overlay-auracast_16_2.conf
@@ -1,4 +1,0 @@
-# Auracast Standard Quality codec configurations settings
-CONFIG_ALIF_BLE_AUDIO_FS_16KHZ=y
-CONFIG_ALIF_BLE_AUDIO_OCTETS_PER_CODEC_FRAME_40=y
-CONFIG_ALIF_BLE_AUDIO_RTN_4=y

--- a/samples/bluetooth/le_audio/broadcast_sink/overlay-auracast_24_2.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink/overlay-auracast_24_2.conf
@@ -1,4 +1,0 @@
-# Auracast Standard Quality codec configurations settings
-CONFIG_ALIF_BLE_AUDIO_FS_24KHZ=y
-CONFIG_ALIF_BLE_AUDIO_OCTETS_PER_CODEC_FRAME_60=y
-CONFIG_ALIF_BLE_AUDIO_RTN_4=y

--- a/samples/bluetooth/le_audio/broadcast_sink/src/audio_datapath.h
+++ b/samples/bluetooth/le_audio/broadcast_sink/src/audio_datapath.h
@@ -23,21 +23,47 @@ struct audio_datapath_config {
 };
 
 /**
- * @brief Create the audio datapath
+ * @brief Create the audio datapath for sink
  *
- * This creates and configures all of the required elements to stream audio from Bluetooth LE to I2S
+ * Creates and configures all of the required elements to stream audio from Bluetooth LE to I2S.
+ * This includes configuring and starting the codec.
  *
  * @param cfg Desired configuration of the audio datapath
  *
  * @retval 0 if successful
  * @retval Negative error code on failure
  */
-int audio_datapath_create(struct audio_datapath_config *cfg);
+int audio_datapath_create_sink(struct audio_datapath_config const *cfg);
+
+/**
+ * @brief Create a channel for the audio datapath
+ *
+ * Creates a channel for the audio decoder.
+ *
+ * @param octets_per_frame Number of octets per frame
+ * @param ch_index Channel index
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_channel_create_sink(size_t const octets_per_frame, uint8_t const ch_index);
+
+/**
+ * @brief Start a channel for the audio datapath
+ *
+ * Starts a channel for the audio decoder.
+ *
+ * @param ch_index Channel index
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_channel_start_sink(uint8_t const ch_index);
 
 /**
  * @brief Start the audio datapath
  *
- * This starts reception of the first SDU over the ISO datapath, which when received starts off the
+ * Starts reception of the first SDU over the ISO datapath, which when received starts off the
  * operation of the rest of the datapath.
  *
  * @retval 0 if successful
@@ -48,13 +74,13 @@ int audio_datapath_start(void);
 /**
  * @brief Clean up the audio datapath
  *
- * This stops the audio datapath and cleans up all elements created by audio_datapath_create,
+ * Stops the audio datapath and cleans up all elements created by audio_datapath_create_sink,
  * freeing any allocated memory if necessary. After calling this function, it is possible to create
- * a new audio datapath again using audio_datapath_create.
+ * a new audio datapath again using audio_datapath_create_sink.
  *
  * @retval 0 if successful
  * @retval Negative error code on failure
  */
-int audio_datapath_cleanup(void);
+int audio_datapath_cleanup_sink(void);
 
 #endif /* _AUDIO_DATAPATH_H */

--- a/samples/bluetooth/le_audio/broadcast_sink/src/broadcast_sink.c
+++ b/samples/bluetooth/le_audio/broadcast_sink/src/broadcast_sink.c
@@ -437,10 +437,10 @@ static void on_bap_bc_sink_cmp_evt(uint8_t cmd_type, uint16_t status, uint8_t gr
 
 		/* Start audio datapath when all chosen streams are started */
 		if (sink_env.started_streams_bf == sink_env.chosen_streams_bf) {
-			int ret = audio_datapath_create(&sink_env.datapath_cfg);
+			int ret = audio_datapath_create_sink(&sink_env.datapath_cfg);
 
 			if (ret) {
-				audio_datapath_cleanup();
+				audio_datapath_cleanup_sink();
 				LOG_ERR("Failed to create audio datapath");
 				start_scanning();
 			}
@@ -479,7 +479,7 @@ static void on_bap_bc_sink_status(uint8_t grp_lid, uint8_t state, uint32_t strea
 	case BAP_BC_SINK_UPPER_TERMINATE:
 	case BAP_BC_SINK_MIC_FAILURE:
 		LOG_INF("no sync with group %u, state %u", grp_lid, state);
-		audio_datapath_cleanup();
+		audio_datapath_cleanup_sink();
 		start_scanning();
 		break;
 	default:


### PR DESCRIPTION
* Removes hardcoded setups from the sink side.
* Makes WM8904 driver not to start audio output by default.