### PR TITLE
samples: ble: drops deprecated APIs

### DIFF
--- a/samples/bluetooth/le_periph_cgms/src/main.c
+++ b/samples/bluetooth/le_periph_cgms/src/main.c
@@ -26,8 +26,6 @@
 
 /*  Profile definitions */
 #include "prf.h"
-#include "cgmp_common.h"
-#include "cgms_msg.h"
 #include "prf_types.h"
 #include "rwprf_config.h"
 #include "batt_svc.h"

--- a/samples/bluetooth/le_periph_glps/src/main.c
+++ b/samples/bluetooth/le_periph_glps/src/main.c
@@ -27,7 +27,6 @@
 
 /*  Profile definitions */
 #include "prf.h"
-#include "cgmp_common.h"
 #include "glps.h"
 #include "glps_msg.h"
 #include "prf_types.h"

--- a/samples/bluetooth/le_periph_prxp/src/main.c
+++ b/samples/bluetooth/le_periph_prxp/src/main.c
@@ -29,8 +29,6 @@
 #include "batt_svc.h"
 #include "shared_control.h"
 #include "prf.h"
-#include "proxr.h"
-#include "proxr_msg.h"
 #include "bass.h"
 
 #include "prxp_app.h"

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 6f290e7aec994fa89f5ea1ae91f1336f26f76567
+      revision: pull/183/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Since BLE ROM v1.2 the deprecated APIs are not available anymore.


Depends on alifsemi/zephyr_alif#183.