### PR TITLE
manifest: Update zephyr_alif to fix incorrect memcpy in PDM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: d8b373d349b22941bb799b2941c24a277e0b791b
+      revision: pull/181/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr_alif to fix audio sample offset calculation by dividing bytes_available by 2 for 16-bit samples.

Depends on alifsemi/zephyr_alif#181.