### PR TITLE
manifest: zephyr: spi multi buffer support in dma

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 5e644ebdeb8f34b347aae632d6f943e8bb34ff19
+      revision: pull/190/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Bump the zephyr version to include the spi multi buffer transfer support feature using dma.
Depends on: https://github.com/alifsemi/zephyr_alif/pull/190