### PR TITLE
Add encryption support for le_audio

### DIFF
--- a/samples/bluetooth/le_audio/broadcast_sink/Kconfig
+++ b/samples/bluetooth/le_audio/broadcast_sink/Kconfig
@@ -14,6 +14,11 @@ config BROADCAST_NAME
 	help
 	  Broadcast name to connect to
 
+config BROADCAST_PASSWORD
+	string "LE audio broadcast password"
+	help
+	  If defined the broadcast stream will be encrypted. Length needs to be 16 chars.
+
 choice
 	prompt "Choose way to determine left/right audio channels"
 	default AUDIO_LOCATION_USE_GAF

--- a/samples/bluetooth/le_audio/broadcast_sink/prj.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink/prj.conf
@@ -48,3 +48,5 @@ CONFIG_WM8904_INIT_PRIORITY=99
 
 # For MRAM(XIP) builds with LLVM exception tables cause linker errors as part of the code is placed to TCM
 CONFIG_EXCEPTIONS=n
+
+CONFIG_BROADCAST_PASSWORD="passwordpassword"

--- a/samples/bluetooth/le_audio/broadcast_source/Kconfig
+++ b/samples/bluetooth/le_audio/broadcast_source/Kconfig
@@ -18,6 +18,11 @@ config BROADCAST_NAME
 	string "LE audio broadcast name"
 	default "ALIF_LE_AUDIO"
 
+config BROADCAST_PASSWORD
+	string "LE audio broadcast password"
+	help
+	  If defined the broadcast stream will be encrypted. Length needs to be 16 chars.
+
 config LE_AUDIO_PRESENTATION_DELAY_MS
 	int "Presentation delay in ms"
 	default 40

--- a/samples/bluetooth/le_audio/broadcast_source/prj.conf
+++ b/samples/bluetooth/le_audio/broadcast_source/prj.conf
@@ -37,6 +37,8 @@ CONFIG_DMA=y
 
 CONFIG_BROADCAST_NAME="ALIF_LE_AUDIO"
 
+CONFIG_BROADCAST_PASSWORD="passwordpassword"
+
 # Audio driver support specific to B1 DK board.
 # Audio codec is WM8904, connected via I2C.
 CONFIG_I2C=y


### PR DESCRIPTION
Added an option to set a password protection for BLE audio source and sink sample applications.