### PR TITLE
manifest: update zephyr revision to include uart reset support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e428bcf4c081d226d8e354931e0729fb944f17a4
+      revision: a92ae0ad42df74391761e1258ffa573d4e20102a
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to include ns16550 uart reset support.

Depends on: https://github.com/alifsemi/zephyr_alif/pull/186