### PR TITLE
 samples: bluetooth: le_audio: broadcast_sink_sd: Implement broadcast sink with scan delegator

### DIFF
--- a/samples/bluetooth/le_audio/broadcast_sink_sd/CMakeLists.txt
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(le_audio_broadcast_sink)
+
+target_sources(app PRIVATE
+    src/main.c
+    src/broadcast_sink.c
+    src/audio_datapath.c
+)

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/Kconfig
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/Kconfig
@@ -1,0 +1,42 @@
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+menu "Alif Bluetooth LE Audio Broadcast Sink"
+
+config BROADCAST_NAME
+	string "LE audio broadcast name"
+	default "ALIF_LE_AUDIO"
+	help
+	  Broadcast name to connect to
+
+choice
+	prompt "Choose way to determine left/right audio channels"
+	default AUDIO_LOCATION_USE_GAF
+
+	config AUDIO_LOCATION_USE_GAF
+		bool "Use GAF audio location sent by audio source"
+	config AUDIO_LOCATION_IMPLICIT
+		bool "Assume left channel is first stream, and right channel is second"
+
+endchoice
+
+menu "Logging"
+
+module = MAIN
+module-str = main
+source "subsys/logging/Kconfig.template.log_config"
+
+module = BROADCAST_SINK
+module-str = broadcast_sink
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu # "Logging"
+
+endmenu # "Alif Bluetooth LE Audio Broadcast Sink with Scan Delegator"
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/README.rst
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/README.rst
@@ -1,0 +1,75 @@
+.. _bluetooth-broadcast-sink-sd-sample:
+
+BLE Audio Broadcast Sink with Scan Delegator Sample
+###############################
+
+Overview
+********
+
+This sample demonstrates the LE audio broadcast sink with scan delegator role use-case.
+
+This app can be used as a scan delegator role device to scan, so the broadcast assistant can assist in the
+connection process for broadcast sources and synchronise with the chosen source.
+
+Building and Running
+********************
+
+This sample can be found under :zephyr_file:`samples/bluetooth/broadcast_sink_sd` in the
+sdk-alif tree.
+
+See :ref:`Alif bluetooth samples section <alif-bluetooth-samples>` for details.
+
+BAP defined Codec Configuration Settings (Dynamically Supported)
+***************************************************************
+
+.. table:: BAP defined Codec Configuration Settings
+   :widths: 2 2 2 3 2
+
+   +------------------+------------------+------------------+------------------+------------------+
+   | Codec            | Supported        | Supported        | Supported        | Bitrate          |
+   | Configuration    | Sampling         | Frame            | Octets per       | (kbps)           |
+   | Setting          | Frequency (kHz)  | Duration         | Codec Frame      |                  |
+   +==================+==================+==================+==================+==================+
+   | 8_1              | 8                | 7.5 ms           | 26               | 27.734           |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 8_2              | 8                | 10 ms            | 30               | 24               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 16_1             | 16               | 7.5 ms           | 30               | 32               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 16_2\*           | 16               | 10 ms            | 40               | 32               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 24_1             | 24               | 7.5 ms           | 45               | 48               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 24_2\*\*         | 24               | 10 ms            | 60               | 48               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 32_1             | 32               | 7.5 ms           | 60               | 64               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 32_2             | 32               | 10 ms            | 80               | 64               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 441_1            | 44.1             | 7.5 ms           | 97               | 95.06            |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 441_2            | 44.1             | 10 ms            | 130              | 95.55            |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_1             | 48               | 7.5 ms           | 75               | 80               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_2             | 48               | 10 ms            | 100              | 80               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_3             | 48               | 7.5 ms           | 90               | 96               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_4             | 48               | 10 ms            | 120              | 96               |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_5             | 48               | 7.5 ms           | 117              | 124.8            |
+   +------------------+------------------+------------------+------------------+------------------+
+   | 48_6             | 48               | 10 ms            | 155              | 124              |
+   +------------------+------------------+------------------+------------------+------------------+
+
+\* Auracast mandated Standard Quality Public Broadcast Codec Configuration option 1
+
+\*\* Auracast mandated Standard Quality Public Broadcast Codec Configuration option 2
+
+All Auracast transmitters must support at least one broadcast stream that uses one of the
+Standard Quality(SQ) codec configurations which are defined in Public Broadcast Profile(PBP).
+Support for other codec configurations is optional.
+Low latency configurations set retransmissions to 2, the high reliability ones to 4.
+Low latency configurations are beneficial when there is ambient sound which would be causing echo effects.
+

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/boards/alif_b1_dk_rtss_he.overlay
@@ -1,0 +1,97 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/balletto-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#define I2S0_IRQ_NUM  141
+#define I2S0_IRQ_PRIO 3
+
+#define I2S0_DMA_RX_CH  2
+#define I2S0_DMA_RX_REQ 24
+#define I2S0_DMA_TX_CH  3
+#define I2S0_DMA_TX_REQ 28
+
+#define AUDIO_DMA_ENABLED 1
+
+/ {
+	aliases {
+		audio-codec = &wm8904;
+		i2s-bus = &i2s0;
+	};
+};
+
+&dma2 {
+	status = "okay";
+	dma-channels = <8>;
+	interrupts = <0 3>, <1 3>, <2 3>, <3 3>, <4 3>, <5 3>,
+		     <6 3>, <7 3>, <32 3>;
+	interrupt-names = "channel0", "channel1",
+			  "channel2", "channel3",
+			  "channel4", "channel5",
+			  "channel6", "channel7",
+			  "abort";
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+
+	wm8904: wm8904@1a {
+		compatible = "cirrus,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
+};
+
+&i2s0 {
+	/delete-property/ clock-frequency;
+	/delete-property/ driver_instance;
+	compatible = "alif,i2s-sync";
+	interrupts = <I2S0_IRQ_NUM I2S0_IRQ_PRIO>;
+	bit-depth = <16>;
+	sample-rate = <48000>;
+	status = "okay";
+#if AUDIO_DMA_ENABLED
+	dmas = <&dma2 I2S0_DMA_RX_CH I2S0_DMA_RX_REQ>,
+	       <&dma2 I2S0_DMA_TX_CH I2S0_DMA_TX_REQ>;
+	dma-names = "rxdma", "txdma";
+#endif
+};
+
+&pinctrl_i2c1 {
+	group0 {
+		pinmux = <PIN_P7_3__I2C1_SCL_C>,
+			 <PIN_P7_2__I2C1_SDA_C>;
+	};
+};
+
+&pinctrl_i2s0 {
+	group0 {
+		pinmux = <PIN_P2_4__I2S0_SDI_B>,
+			 <PIN_P2_5__I2S0_SDO_B>,
+			 <PIN_P1_7__I2S0_WS_A>,
+			 <PIN_P1_6__I2S0_SCLK_A>;
+	};
+};
+
+/* Disable unnecessary nodes */
+&i2s1 {
+	status = "disabled";
+};
+
+&i2s2 {
+	status = "disabled";
+};
+
+&uart_ahi {
+	status = "disabled";
+};

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/overlay-dbg.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/overlay-dbg.conf
@@ -1,0 +1,41 @@
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_NO_OPTIMIZATIONS=y
+
+# Debug
+CONFIG_LOG=y
+CONFIG_USE_SEGGER_RTT=y
+CONFIG_RTT_CONSOLE=y
+
+CONFIG_MAIN_LOG_LEVEL_DBG=y
+CONFIG_BROADCAST_SINK_LOG_LEVEL_DBG=y
+CONFIG_BLE_AUDIO_LOG_LEVEL_DBG=y
+CONFIG_PRESENTATION_COMPENSATION_PRINT_STATS=y
+CONFIG_LOG_BUFFER_SIZE=4096
+CONFIG_LOG_DEFAULT_LEVEL=3
+
+## Debugging configuration
+CONFIG_THREAD_NAME=y
+CONFIG_THREAD_ANALYZER=y
+CONFIG_THREAD_ANALYZER_AUTO=y
+CONFIG_THREAD_ANALYZER_RUN_UNLOCKED=y
+CONFIG_THREAD_ANALYZER_USE_PRINTK=y
+#CONFIG_THREAD_ANALYZER_AUTO_STACK_SIZE=6044
+
+## Add asserts
+CONFIG_ASSERT=y
+#CONFIG_ASSERT_VERBOSE=y
+#CONFIG_ASSERT_NO_COND_INFO=n
+#CONFIG_ASSERT_NO_MSG_INFO=n
+
+CONFIG_STACK_SENTINEL=y
+
+#CONFIG_LOG_MODE_IMMEDIATE=y
+CONFIG_LOG_MODE_MINIMAL=y
+

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/prj.conf
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/prj.conf
@@ -1,0 +1,72 @@
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+CONFIG_BT=y
+CONFIG_BT_CUSTOM=y
+CONFIG_ALIF_ROM_LC3_CODEC=y
+CONFIG_ALIF_BLE_AUDIO=y
+CONFIG_BLE_DEVICE_NAME="ALIF_LE_SINK_SD"
+
+CONFIG_LOG=y
+
+CONFIG_PRESENTATION_COMPENSATION_DIRECTION_SINK=y
+CONFIG_PRESENTATION_COMPENSATION_CORRECTION_FACTOR=2
+
+# Should be replaced by TRNG when support is available
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+# malloc support is required, simplest way is using newlib although it would also be possible to
+# configure heap for picolibc
+CONFIG_NEWLIB_LIBC=y
+
+# Driver support for audio
+CONFIG_I2S=y
+CONFIG_I2S_SYNC_BUFFER_FORMAT_SEQUENTIAL=n
+CONFIG_DMA=y
+
+# Determine left and right channels by index, not GAF
+CONFIG_AUDIO_LOCATION_IMPLICIT=y
+
+# Audio codec is WM8904, connected via I2C.
+CONFIG_I2C=y
+CONFIG_WM8904=y
+
+CONFIG_I2C_INIT_PRIORITY=50
+CONFIG_WM8904_INIT_PRIORITY=99
+
+# This is specific to whichever clock you use. Currently presentation layer is
+# commented out so this does nothing
+CONFIG_AUDIO_CLOCK_DIVIDER=1
+
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_ISR_STACK_SIZE=4096
+CONFIG_PRIVILEGED_STACK_SIZE=2048
+CONFIG_IDLE_STACK_SIZE=1024
+CONFIG_BOOT_BANNER=n
+CONFIG_ALIF_BLE_HOST_ADDL_PRF_HEAPSIZE=10240
+CONFIG_ALIF_BLE_HOST_ADDL_ENV_HEAPSIZE=8192
+
+# Enable NVS as the backend for Settings
+CONFIG_NVS=y
+# Enable the Settings subsystem
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_NVS=y
+CONFIG_SETTINGS_RUNTIME=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+
+# Adjust logging levels
+CONFIG_MAIN_LOG_LEVEL_DBG=y
+CONFIG_BROADCAST_SINK_LOG_LEVEL_DBG=y
+CONFIG_BLE_AUDIO_LOG_LEVEL_DBG=y
+CONFIG_PRESENTATION_COMPENSATION_PRINT_STATS=y
+
+CONFIG_AUDIO=y
+CONFIG_AUDIO_CODEC=y
+CONFIG_AUDIO_CODEC_SHELL=y
+CONFIG_SHELL=y

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/src/audio_datapath.c
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/src/audio_datapath.c
@@ -1,0 +1,193 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/audio/codec.h>
+#include "bluetooth/le_audio/audio_decoder.h"
+#include "bluetooth/le_audio/presentation_compensation.h"
+#include "audio_datapath.h"
+
+LOG_MODULE_REGISTER(audio_datapath, CONFIG_BLE_AUDIO_LOG_LEVEL);
+
+#define CODEC_NODE DT_ALIAS(audio_codec)
+
+struct audio_datapath {
+	struct audio_decoder *decoder;
+	size_t octets_per_frame;
+};
+
+static struct audio_datapath env;
+
+#if CONFIG_APP_PRINT_STATS
+static void print_sdus(void *context, uint32_t timestamp, uint16_t sdu_seq)
+{
+	static uint16_t last_sdu;
+
+	if (last_sdu && (last_sdu + 1 < sdu_seq)) {
+		LOG_INF("SDU sequence number jumps, last: %u, now: %u", last_sdu, sdu_seq);
+	}
+	last_sdu = sdu_seq;
+
+	if (0 == (sdu_seq % 128)) {
+		LOG_INF("SDU sequence number %u", sdu_seq);
+	}
+}
+#endif
+
+#ifdef CONFIG_PRESENTATION_COMPENSATION_DEBUG
+void on_timing_debug_info_ready(struct presentation_comp_debug_data *dbg_data)
+{
+	LOG_INF("Presentation compensation debug data is ready");
+}
+#endif
+
+int audio_datapath_create_sink(struct audio_datapath_config const *const cfg)
+{
+	int ret;
+
+	if (!cfg) {
+		__ASSERT(false, "Datapath configuration missing");
+		return -EINVAL;
+	}
+
+	if (env.decoder) {
+		return -EALREADY;
+	}
+
+	env.octets_per_frame = cfg->octets_per_frame;
+
+	/* Configure codec */
+	struct audio_codec_cfg codec_cfg = {
+		.dai_type = AUDIO_DAI_TYPE_I2S,
+		.dai_cfg = {
+			.i2s = {
+				.word_size = AUDIO_PCM_WIDTH_16_BITS,
+				.channels = 2,
+				.format = I2S_FMT_DATA_FORMAT_I2S,
+				.options = 0,
+				.frame_clk_freq = cfg->sampling_rate_hz,
+				.mem_slab = NULL,
+				.block_size = 0,
+				.timeout = 0,
+			},
+		},
+	};
+
+	ret = audio_codec_configure(DEVICE_DT_GET(CODEC_NODE), &codec_cfg);
+	if (ret) {
+		LOG_ERR("Failed to configure sink codec. err %d", ret);
+		return ret;
+	}
+	audio_codec_start_output(DEVICE_DT_GET(CODEC_NODE));
+
+	struct audio_decoder_params const dec_params = {
+		.i2s_dev = cfg->i2s_dev,
+		.frame_duration_us = cfg->frame_duration_is_10ms ? 10000 : 7500,
+		.sampling_rate_hz = cfg->sampling_rate_hz,
+		.pres_delay_us = cfg->pres_delay_us,
+	};
+
+	env.decoder = audio_decoder_create(&dec_params);
+	if (env.decoder == NULL) {
+		LOG_ERR("Failed to create audio decoder");
+		return -ENOMEM;
+	}
+
+	/* TODO: Change MCLK to use alif clock control */
+
+	/* ret = presentation_compensation_configure(cfg->mclk_dev, pres_delay_us);
+	 * if (ret != 0) {
+	 *	LOG_ERR("Failed to configure presentation compensation module, err %d", ret);
+	 *	return ret;
+	 * }
+	 */
+
+	/* Add presentation compensation callback to notify audio sink */
+	/* ret = presentation_compensation_register_cb(audio_sink_i2s_apply_timing_correction);
+	 * if (ret != 0) {
+	 *	LOG_ERR("Failed to register presentation compensation callback, err %d", ret);
+	 *	return ret;
+	 * }
+	 */
+
+#ifdef CONFIG_PRESENTATION_COMPENSATION_DEBUG
+	/* ret = presentation_compensation_register_debug_cb(on_timing_debug_info_ready);
+	 * if (ret != 0) {
+	 *	LOG_ERR("Failed to register presentation compensation debug callback, err %d", ret);
+	 *	return ret;
+	 * }
+	 */
+#endif
+
+#if CONFIG_APP_PRINT_STATS
+	ret = audio_decoder_register_cb(env.decoder, print_sdus, NULL);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to register decoder cb, err %d", ret);
+		return ret;
+	}
+#endif
+
+	LOG_INF("Created audio datapath");
+
+	return 0;
+}
+
+int audio_datapath_channel_create_sink(size_t const octets_per_frame, uint8_t const ch_index)
+{
+	int ret = audio_decoder_add_channel(env.decoder, octets_per_frame, ch_index);
+
+	if (ret) {
+		LOG_ERR("Failed to create channel %u, err %d", ch_index, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int audio_datapath_channel_start_sink(uint8_t const ch_index)
+{
+	int ret = audio_decoder_start_channel(env.decoder, ch_index);
+
+	if (ret) {
+		LOG_ERR("Failed to start channel %u, err %d", ch_index, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int audio_datapath_start(void)
+{
+	for (int iter = 0; iter < CONFIG_ALIF_BLE_AUDIO_NMB_CHANNELS; iter++) {
+		audio_datapath_channel_create_sink(env.octets_per_frame, iter);
+	}
+
+	for (int iter = 0; iter < CONFIG_ALIF_BLE_AUDIO_NMB_CHANNELS; iter++) {
+		audio_datapath_channel_start_sink(iter);
+	}
+
+	LOG_INF("Audio datapath started");
+
+	return 0;
+}
+
+int audio_datapath_cleanup_sink(void)
+{
+	audio_decoder_delete(env.decoder);
+	env.decoder = NULL;
+
+	/* Stop codec output */
+	audio_codec_stop_output(DEVICE_DT_GET(CODEC_NODE));
+
+	LOG_INF("Removed audio datapath");
+
+	return 0;
+}

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/src/audio_datapath.h
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/src/audio_datapath.h
@@ -1,0 +1,86 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef _AUDIO_DATAPATH_H
+#define _AUDIO_DATAPATH_H
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+struct audio_datapath_config {
+	const struct device *i2s_dev;
+	/* const struct device *mclk_dev; */
+	uint32_t pres_delay_us;
+	uint32_t sampling_rate_hz;
+	uint16_t octets_per_frame;
+	bool frame_duration_is_10ms;
+};
+
+/**
+ * @brief Create the audio datapath for sink
+ *
+ * Creates and configures all of the required elements to stream audio from Bluetooth LE to I2S.
+ * This includes configuring and starting the codec.
+ *
+ * @param cfg Desired configuration of the audio datapath
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_create_sink(struct audio_datapath_config const *cfg);
+
+/**
+ * @brief Create a channel for the audio datapath
+ *
+ * Creates a channel for the audio decoder.
+ *
+ * @param octets_per_frame Number of octets per frame
+ * @param ch_index Channel index
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_channel_create_sink(size_t const octets_per_frame, uint8_t const ch_index);
+
+/**
+ * @brief Start a channel for the audio datapath
+ *
+ * Starts a channel for the audio decoder.
+ *
+ * @param ch_index Channel index
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_channel_start_sink(uint8_t const ch_index);
+
+/**
+ * @brief Start the audio datapath
+ *
+ * Starts reception of the first SDU over the ISO datapath, which when received starts off the
+ * operation of the rest of the datapath.
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_start(void);
+
+/**
+ * @brief Clean up the audio datapath
+ *
+ * Stops the audio datapath and cleans up all elements created by audio_datapath_create_sink,
+ * freeing any allocated memory if necessary. After calling this function, it is possible to create
+ * a new audio datapath again using audio_datapath_create_sink.
+ *
+ * @retval 0 if successful
+ * @retval Negative error code on failure
+ */
+int audio_datapath_cleanup_sink(void);
+
+#endif /* _AUDIO_DATAPATH_H */

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/src/broadcast_sink.c
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/src/broadcast_sink.c
@@ -1,0 +1,1083 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+#include <string.h>
+
+#include "bluetooth/le_audio/audio_utils.h"
+
+#include "bap_bc_sink.h"
+#include "bap_bc_scan.h"
+#include "bap_bc_deleg.h"
+#include "audio_datapath.h"
+#include "broadcast_sink.h"
+#include "gaf_adv.h"
+#include "gapm_le.h"
+
+LOG_MODULE_REGISTER(broadcast_sink, CONFIG_BROADCAST_SINK_LOG_LEVEL);
+
+/* ---------- Device ---------- */
+#define MAX_DEVICE_NAME_LEN 29
+
+/* ---------- Timing ---------- */
+#define SYNCHRONISATION_TIMEOUT_MS 2000
+#define SYNCHRONISATION_TIMEOUT    (SYNCHRONISATION_TIMEOUT_MS / 10)
+#define SCAN_TIMEOUT_MS            1000
+#define SCAN_TIMEOUT               (SCAN_TIMEOUT_MS / 10)
+#define SINK_TIMEOUT_MS            1000
+#define SINK_TIMEOUT               (SINK_TIMEOUT_MS / 10)
+
+/* ---------- Misc ---------- */
+#define INVALID_CHANNEL_INDEX      0xFF
+#define SD_MSGQ_LEN                8
+#define SD_MAX_SUBGROUPS           8
+#define SD_WAIT                    K_SECONDS(5)   /* be generous to avoid races */
+
+/* ---------- Channels from GAF Location ---------- */
+#define GAF_LOC_LEFT_OR_CENTRE_MASK                                                                \
+	(GAF_LOC_FRONT_LEFT_BIT | GAF_LOC_FRONT_LEFT_BIT | GAF_LOC_BACK_LEFT_BIT |                 \
+	GAF_LOC_FRONT_LEFT_CENTER_BIT | GAF_LOC_BACK_CENTER_BIT | GAF_LOC_SIDE_LEFT_BIT |         \
+	GAF_LOC_TOP_FRONT_LEFT_BIT | GAF_LOC_TOP_FRONT_CENTER_BIT | GAF_LOC_TOP_CENTER_BIT |      \
+	GAF_LOC_TOP_BACK_LEFT_BIT | GAF_LOC_TOP_SIDE_LEFT_BIT | GAF_LOC_TOP_BACK_CENTER_BIT |     \
+	GAF_LOC_BOTTOM_FRONT_CENTER_BIT | GAF_LOC_BOTTOM_FRONT_LEFT_BIT |                         \
+	GAF_LOC_FRONT_LEFT_WIDE_BIT | GAF_LOC_LEFT_SURROUND_BIT)
+
+#define GAF_LOC_RIGHT_MASK                                                                         \
+	(GAF_LOC_FRONT_RIGHT_BIT | GAF_LOC_BACK_RIGHT_BIT | GAF_LOC_FRONT_RIGHT_CENTER_BIT |       \
+	GAF_LOC_SIDE_RIGHT_BIT | GAF_LOC_TOP_FRONT_RIGHT_BIT | GAF_LOC_TOP_BACK_RIGHT_BIT |       \
+	GAF_LOC_TOP_SIDE_RIGHT_BIT | GAF_LOC_BOTTOM_FRONT_RIGHT_BIT |                             \
+	GAF_LOC_FRONT_RIGHT_WIDE_BIT)
+
+/* ---------- Devicetree ---------- */
+#define I2S_NODE   DT_ALIAS(i2s_bus)
+#define CODEC_NODE DT_ALIAS(audio_codec)
+
+BUILD_ASSERT(!DT_PROP(I2S_NODE, mono_mode), "I2S must be configured in stereo mode");
+
+static const struct device *const i2s_dev   = DEVICE_DT_GET(I2S_NODE);
+static const struct device *const codec_dev = DEVICE_DT_GET(CODEC_NODE);
+
+/* ================================================================
+ *                   RUNTIME ENVIRONMENT
+ * ================================================================
+ */
+
+struct broadcast_sink_env {
+	/* IDs / LIDs */
+	bap_bcast_id_t bcast_id;
+	bap_adv_id_t   adv_id;        /* stored from Add Source to reuse for PA sync */
+	uint8_t        pa_lid;
+	uint8_t        grp_lid;
+	uint8_t        src_lid;
+	uint8_t        con_lid;
+
+	/* Stream selection */
+	uint32_t chosen_streams_bf;
+	uint32_t started_streams_bf;
+	uint8_t  left_channel_pos;
+	uint8_t  right_channel_pos;
+
+	/* Scan/session state */
+	bool     scanning_active;
+	uint8_t  expected_streams;
+	uint8_t  stream_report_count;
+
+	/* Audio datapath */
+	struct audio_datapath_config datapath_cfg;
+	bool     datapath_cfg_valid;
+};
+
+static struct broadcast_sink_env sink_env;
+
+/* ================================================================
+ *               WORKER QUEUE
+ * ================================================================
+ */
+
+enum sd_evt_type {
+	SD_EVT_REMOTE_SCAN,
+	SD_EVT_ADD,
+	SD_EVT_MODIFY,
+	SD_EVT_REMOVE,
+	SD_EVT_ESTABLISHED
+};
+
+struct sd_evt {
+	enum sd_evt_type type;
+
+	/* BA context */
+	uint8_t  src_lid;
+	uint8_t  con_lid;
+
+	/* Remote scan */
+	uint8_t  remote_scan_state; /* 0 stop, 1 start */
+
+	/* Add/Modify context */
+	uint8_t  nb_subgroups;
+	uint8_t  pa_sync_req;       /* 0x00 off, 0x01 PAST avail, 0x02 PAST not avail */
+	uint16_t pa_intv_frames;
+
+	bap_adv_id_t   adv_id;
+	bap_bcast_id_t bcast_id;
+};
+
+K_MSGQ_DEFINE(sd_msgq, sizeof(struct sd_evt), SD_MSGQ_LEN, 4);
+static struct k_work sd_work;
+
+/* Async completion semaphores */
+static K_SEM_DEFINE(sem_sink_disabled, 0, 1);
+static K_SEM_DEFINE(sem_pa_synced,     0, 1);
+static K_SEM_DEFINE(sem_pa_terminated, 0, 1);
+static K_SEM_DEFINE(sem_scan_started,  0, 1);
+static K_SEM_DEFINE(sem_scan_stopped,  0, 1);
+
+
+/* ================================================================
+ *                   HELPERS / INTERNAL API
+ * ================================================================
+ */
+
+static void reset_sink_config(void)
+{
+	memset(&sink_env, 0, sizeof(sink_env));
+	sink_env.datapath_cfg_valid = true;
+	sink_env.datapath_cfg.i2s_dev = i2s_dev;
+	sink_env.right_channel_pos = INVALID_CHANNEL_INDEX;
+	sink_env.left_channel_pos  = INVALID_CHANNEL_INDEX;
+	sink_env.src_lid = GAF_INVALID_LID;
+	sink_env.con_lid = GAF_INVALID_LID;
+	sink_env.pa_lid  = GAF_INVALID_LID;
+	sink_env.grp_lid = GAF_INVALID_LID;
+	sink_env.chosen_streams_bf  = 0;
+	sink_env.started_streams_bf = 0;
+	sink_env.scanning_active = false;
+	sink_env.expected_streams = 0;
+	sink_env.stream_report_count = 0;
+
+	LOG_DBG("Reset sink config");
+}
+
+static int start_scanning(void)
+{
+	uint16_t err = bap_bc_scan_start(0);
+
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Scanning failed: err=%u", err);
+		return -ENODEV;
+	}
+
+	reset_sink_config();
+	LOG_INF("Scanning started");
+	return 0;
+}
+
+static int sink_enable(void)
+{
+	sink_env.chosen_streams_bf  = 0;
+	sink_env.started_streams_bf = 0;
+
+	if (!sink_env.datapath_cfg_valid) {
+		LOG_ERR("Sink enable failed: invalid configuration");
+		return -EINVAL;
+	}
+
+	if (sink_env.left_channel_pos != INVALID_CHANNEL_INDEX) {
+		sink_env.chosen_streams_bf |= (1U << (sink_env.left_channel_pos - 1));
+	}
+	if (sink_env.right_channel_pos != INVALID_CHANNEL_INDEX) {
+		sink_env.chosen_streams_bf |= (1U << (sink_env.right_channel_pos - 1));
+	}
+
+	LOG_INF("Sink enabled: pa_lid=%u bcast_id=%02x:%02x:%02x L=%u R=%u chosen_bf=0x%08x",
+		sink_env.pa_lid,
+		sink_env.bcast_id.id[0], sink_env.bcast_id.id[1], sink_env.bcast_id.id[2],
+		sink_env.left_channel_pos, sink_env.right_channel_pos, sink_env.chosen_streams_bf);
+
+	uint16_t err = bap_bc_sink_enable(sink_env.pa_lid, &sink_env.bcast_id,
+					sink_env.chosen_streams_bf,
+					NULL,
+					0,
+					SINK_TIMEOUT,
+					&sink_env.grp_lid);
+	if (err != GAF_ERR_NO_ERROR) {
+		LOG_ERR("Sink enable failed: err=%u", err);
+		return -EIO;
+	}
+
+	LOG_INF("Sink enabled: grp_lid=%u (pending ESTABLISHED)", sink_env.grp_lid);
+	return 0;
+}
+
+static int start_streaming(void)
+{
+	gaf_codec_id_t codec_id = GAF_CODEC_ID_LC3;
+
+	LOG_INF("Start streaming: grp=%u L=%u R=%u",
+		sink_env.grp_lid, sink_env.left_channel_pos, sink_env.right_channel_pos);
+
+	uint16_t err = 0;
+
+	if (sink_env.left_channel_pos != INVALID_CHANNEL_INDEX) {
+		err = bap_bc_sink_start_streaming(sink_env.grp_lid, sink_env.left_channel_pos,
+						&codec_id, GAPI_DP_ISOOSHM, 0, NULL);
+		LOG_INF("Start streaming: L pos=%u rc=%u", sink_env.left_channel_pos, err);
+		if (err) {
+			return -EIO;
+		}
+	}
+
+	if (sink_env.right_channel_pos != INVALID_CHANNEL_INDEX) {
+		err = bap_bc_sink_start_streaming(sink_env.grp_lid, sink_env.right_channel_pos,
+						&codec_id, GAPI_DP_ISOOSHM, 0, NULL);
+		LOG_INF("Start streaming: R pos=%u rc=%u", sink_env.right_channel_pos, err);
+		if (err) {
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static void sd_teardown_sink_and_wait(void)
+{
+	if (sink_env.grp_lid != GAF_INVALID_LID) {
+		while (k_sem_count_get(&sem_sink_disabled) > 0) {
+			k_sem_take(&sem_sink_disabled, K_NO_WAIT);
+		}
+
+		LOG_INF("Sink disable: grp=%u", sink_env.grp_lid);
+		uint16_t rc = bap_bc_sink_disable(sink_env.grp_lid);
+
+		if (rc != GAF_ERR_NO_ERROR) {
+			LOG_WRN("Sink disable: rc=%u", rc);
+		}
+
+		bool ok = (k_sem_take(&sem_sink_disabled, SD_WAIT) == 0);
+
+		if (!ok) {
+			LOG_ERR("Sink disable: timeout waiting for status");
+		}
+
+		LOG_INF("Sink disable: done");
+		sink_env.grp_lid = GAF_INVALID_LID;
+	}
+
+	audio_datapath_cleanup_sink();
+}
+
+/* ================================================================
+ *                   BASS / DELEGATOR CALLBACKS
+ * ================================================================
+ */
+
+static void on_bass_cmp_evt(uint8_t cmd_type, uint16_t status, uint8_t src_lid)
+{
+	LOG_DBG("BASS cmp event: cmd=%u status=%u src=%u", cmd_type, status, src_lid);
+}
+
+static void on_bass_solicite_stopped(uint8_t reason)
+{
+	LOG_DBG("BASS solicitation stopped: reason=%u", reason);
+}
+
+static void on_bass_bond_data(uint8_t con_lid, uint16_t cli_cfg_bf)
+{
+	LOG_DBG("BASS bond data: con=%u cli_cfg=0x%04x", con_lid, cli_cfg_bf);
+}
+
+static void on_bass_remote_scan(uint8_t con_lid, uint8_t state)
+{
+	LOG_INF("BASS remote scan: con=%u state=%u", con_lid, state);
+
+	struct sd_evt evt = {0};
+
+	evt.type = SD_EVT_REMOTE_SCAN;
+	evt.remote_scan_state = state ? 1 : 0;
+
+	int rc = k_msgq_put(&sd_msgq, &evt, K_NO_WAIT);
+
+	if (rc != 0) {
+		LOG_ERR("BASS remote scan: msgq_put rc=%d", rc);
+		return;
+	}
+
+	(void)k_work_submit(&sd_work);
+}
+
+static void on_bass_bcast_code(uint8_t src_lid, uint8_t con_lid,
+	const gaf_bcast_code_t *p_bcast_code)
+{
+	ARG_UNUSED(p_bcast_code);
+	LOG_INF("BASS broadcast code: src=%u con=%u", src_lid, con_lid);
+}
+
+/* Add Source request from BA */
+static void on_bass_add_source_req(uint8_t src_lid, uint8_t con_lid, const bap_adv_id_t *p_adv_id,
+	const bap_bcast_id_t *p_bcast_id, uint8_t pa_sync_req,
+	uint16_t pa_intv_frames, uint8_t nb_subgroups, uint16_t metadata_len)
+{
+	ARG_UNUSED(pa_intv_frames);
+	ARG_UNUSED(metadata_len);
+
+	LOG_INF("BASS add source request: src=%u con=%u pa_sync=%u nb_sgrp=%u meta_len=%u",
+		src_lid, con_lid, pa_sync_req, nb_subgroups, metadata_len);
+
+	for (uint8_t i = 0; i < nb_subgroups; i++) {
+		uint32_t bis_mask = 0;
+		bap_cfg_metadata_ptr_t meta_ptr = (bap_cfg_metadata_ptr_t){0};
+		uint16_t err = bap_bc_deleg_get_sgrp_info(src_lid, &bis_mask, &meta_ptr);
+
+		LOG_DBG("BASS add: get_sgrp[%u] rc=%u bis=0x%08x ctx=0x%04x",
+			i, err, bis_mask, meta_ptr.param.context_bf);
+		if (err != GAF_ERR_NO_ERROR) {
+			break;
+		}
+	}
+
+	struct sd_evt evt = {0};
+
+	evt.type = SD_EVT_ADD;
+	evt.src_lid = src_lid;
+	evt.con_lid = con_lid;
+	evt.pa_sync_req = pa_sync_req;
+	evt.nb_subgroups = MIN(nb_subgroups, SD_MAX_SUBGROUPS);
+	memcpy(&evt.adv_id,   p_adv_id,   sizeof(evt.adv_id));
+	memcpy(&evt.bcast_id, p_bcast_id, sizeof(evt.bcast_id));
+
+	int rc = k_msgq_put(&sd_msgq, &evt, K_NO_WAIT);
+
+	if (rc != 0) {
+		LOG_ERR("BASS add source request: msgq_put rc=%d", rc);
+		return;
+	}
+
+	(void)k_work_submit(&sd_work);
+}
+
+/* Modify Source request from BA */
+static void on_bass_modify_source_req(uint8_t src_lid, uint8_t con_lid, uint8_t pa_sync_req,
+	uint16_t pa_intv_frames, uint8_t nb_subgroups, uint16_t metadata_len)
+{
+	ARG_UNUSED(pa_intv_frames);
+	ARG_UNUSED(metadata_len);
+
+	LOG_INF("BASS modify source request: src=%u con=%u pa_sync=%u nb_sgrp=%u meta_len=%u",
+		src_lid, con_lid, pa_sync_req, nb_subgroups, metadata_len);
+
+	for (uint8_t i = 0; i < nb_subgroups; i++) {
+		uint32_t bis_mask = 0;
+		bap_cfg_metadata_ptr_t meta_ptr = (bap_cfg_metadata_ptr_t){0};
+		uint16_t err = bap_bc_deleg_get_sgrp_info(src_lid, &bis_mask, &meta_ptr);
+
+		LOG_DBG("BASS modify source request: get_sgrp[%u] rc=%u bis=0x%08x ctx=0x%04x",
+			i, err, bis_mask, meta_ptr.param.context_bf);
+		if (err != GAF_ERR_NO_ERROR) {
+			break;
+		}
+	}
+
+	struct sd_evt evt = {0};
+
+	evt.type = SD_EVT_MODIFY;
+	evt.src_lid = src_lid;
+	evt.con_lid = con_lid;
+	evt.pa_sync_req = pa_sync_req;
+	evt.nb_subgroups = MIN(nb_subgroups, SD_MAX_SUBGROUPS);
+
+	int rc = k_msgq_put(&sd_msgq, &evt, K_NO_WAIT);
+
+	if (rc != 0) {
+		LOG_ERR("BASS modify source request: msgq_put rc=%d", rc);
+		return;
+	}
+
+	(void)k_work_submit(&sd_work);
+}
+
+/* Remove Source request from BA */
+static void on_bass_remove_source_req(uint8_t src_lid, uint8_t con_lid)
+{
+	LOG_INF("BASS remove_source_req: src=%u con=%u", src_lid, con_lid);
+
+	struct sd_evt evt = {0};
+
+	evt.type = SD_EVT_REMOVE;
+	evt.src_lid = src_lid;
+	evt.con_lid = con_lid;
+
+	int rc = k_msgq_put(&sd_msgq, &evt, K_NO_WAIT);
+
+	if (rc != 0) {
+		LOG_ERR("BASS remove source request: msgq_put rc=%d", rc);
+		return;
+	}
+
+	(void)k_work_submit(&sd_work);
+}
+
+static const struct bap_bc_deleg_cb bass_cbs = {
+	.cb_cmp_evt           = on_bass_cmp_evt,
+	.cb_solicite_stopped  = on_bass_solicite_stopped,
+	.cb_bond_data         = on_bass_bond_data,
+	.cb_remote_scan       = on_bass_remote_scan,
+	.cb_bcast_code        = on_bass_bcast_code,
+	.cb_add_source_req    = on_bass_add_source_req,
+	.cb_modify_source_req = on_bass_modify_source_req,
+	.cb_remove_source_req = on_bass_remove_source_req,
+};
+
+/* ================================================================
+ *                   SCAN CALLBACKS
+ * ================================================================
+ */
+
+static void on_bap_bc_scan_cmp_evt(uint8_t cmd_type, uint16_t status, uint8_t pa_lid)
+{
+	LOG_DBG("Scan cmp event: cmd=%u status=%u pa_lid=%u", cmd_type, status, pa_lid);
+
+	switch (cmd_type) {
+	case BAP_BC_SCAN_CMD_TYPE_START:
+		k_sem_give(&sem_scan_started);
+		break;
+	case BAP_BC_SCAN_CMD_TYPE_STOP:
+		k_sem_give(&sem_scan_stopped);
+		break;
+	case BAP_BC_SCAN_CMD_TYPE_PA_SYNCHRONIZE:
+		/* wait in pa_established */
+		break;
+	case BAP_BC_SCAN_CMD_TYPE_PA_TERMINATE:
+		k_sem_give(&sem_pa_terminated);
+		break;
+	default:
+		break;
+	}
+}
+
+static void on_bap_bc_scan_timeout(void)
+{
+	LOG_WRN("Scan timeout");
+}
+
+static void on_bap_bc_scan_report(const bap_adv_id_t *p_adv_id, const bap_bcast_id_t *p_bcast_id,
+				uint8_t info_bf, const gaf_adv_report_air_info_t *p_air_info,
+				uint16_t length, const uint8_t *p_data)
+{
+	ARG_UNUSED(info_bf);
+	ARG_UNUSED(length);
+	ARG_UNUSED(p_data);
+
+	LOG_DBG("Scan adv report rssi=%d", p_air_info ? p_air_info->rssi : 0);
+	memcpy(&sink_env.bcast_id, p_bcast_id, sizeof(sink_env.bcast_id));
+	memcpy(&sink_env.adv_id,   p_adv_id,   sizeof(sink_env.adv_id));
+}
+
+static void on_bap_bc_scan_public_bcast(const bap_adv_id_t *p_adv_id,
+					const bap_bcast_id_t *p_bcast_id, uint8_t pbp_features_bf,
+					uint8_t broadcast_name_len, const uint8_t *p_broadcast_name,
+					uint8_t metadata_len, const uint8_t *p_metadata)
+{
+	ARG_UNUSED(p_adv_id);
+	ARG_UNUSED(p_bcast_id);
+	ARG_UNUSED(pbp_features_bf);
+	ARG_UNUSED(broadcast_name_len);
+	ARG_UNUSED(p_broadcast_name);
+	ARG_UNUSED(metadata_len);
+	ARG_UNUSED(p_metadata);
+}
+
+static void on_bap_bc_scan_pa_established(uint8_t pa_lid, const bap_adv_id_t *p_adv_id,
+					uint8_t phy, uint16_t interval_frames)
+{
+	ARG_UNUSED(p_adv_id);
+	LOG_INF("PA established: pa_lid=%u phy=%u intv=%u", pa_lid, phy, interval_frames);
+	sink_env.pa_lid = pa_lid;
+	k_sem_give(&sem_pa_synced);
+}
+
+static void on_bap_bc_scan_pa_terminated(uint8_t pa_lid, uint8_t reason)
+{
+	LOG_INF("PA terminated: pa_lid=%u reason=%u", pa_lid, reason);
+}
+
+static void on_bap_bc_scan_pa_report(uint8_t pa_lid, const gaf_adv_report_air_info_t *p_air_info,
+					uint16_t length, const uint8_t *p_data)
+{
+	ARG_UNUSED(pa_lid);
+	ARG_UNUSED(length);
+	ARG_UNUSED(p_data);
+	LOG_DBG("PA report: rssi=%d", p_air_info ? p_air_info->rssi : 0);
+}
+
+static void on_bap_bc_scan_big_info_report(uint8_t pa_lid, const gapm_le_big_info_t *p_report)
+{
+	LOG_INF("BIGinfo: pa=%u sdu_int=%u iso_int=%ums max_pdu=%u max_sdu=%u num_bis=%u enc=%u",
+		pa_lid, p_report->sdu_interval, p_report->iso_interval, p_report->max_pdu,
+		p_report->max_sdu, p_report->num_bis, p_report->encrypted);
+}
+
+static void on_bap_bc_scan_group_report(uint8_t pa_lid, uint8_t nb_subgroups, uint8_t nb_streams,
+					uint32_t pres_delay_us)
+{
+	LOG_INF("Group report: pa=%u subgrp=%u streams=%u pres_delay=%uus",
+		pa_lid, nb_subgroups, nb_streams, pres_delay_us);
+
+	sink_env.expected_streams = nb_streams;
+	sink_env.stream_report_count = 0;
+	sink_env.datapath_cfg.pres_delay_us = pres_delay_us;
+}
+
+static void on_bap_bc_scan_subgroup_report(uint8_t pa_lid, uint8_t sgrp_id, uint32_t stream_pos_bf,
+					const gaf_codec_id_t *p_codec_id,
+					const bap_cfg_ptr_t *p_cfg,
+					const bap_cfg_metadata_ptr_t *p_metadata)
+{
+	ARG_UNUSED(pa_lid);
+	ARG_UNUSED(p_codec_id);
+	ARG_UNUSED(p_metadata);
+
+	LOG_INF("Subgroup: id=%u stream_bf=0x%08x loc_bf=0x%04x frame_oct=%u samp=%u "
+		"frame_dur=%u frames_sdu=%u",
+		sgrp_id, stream_pos_bf, p_cfg->param.location_bf,
+		p_cfg->param.frame_octet, p_cfg->param.sampling_freq,
+		p_cfg->param.frame_dur, p_cfg->param.frames_sdu);
+
+	/* Validate and stash config */
+	if (p_cfg->param.sampling_freq < BAP_SAMPLING_FREQ_MIN ||
+		p_cfg->param.sampling_freq > BAP_SAMPLING_FREQ_MAX) {
+		LOG_WRN("Invalid sampling_freq=%u", p_cfg->param.sampling_freq);
+		sink_env.datapath_cfg_valid = false;
+	}
+	if (p_cfg->param.frame_dur != BAP_FRAME_DUR_10MS) {
+		LOG_WRN("Invalid frame_dur=%u need 10ms", p_cfg->param.frame_dur);
+		sink_env.datapath_cfg_valid = false;
+	}
+
+	sink_env.datapath_cfg.octets_per_frame       = p_cfg->param.frame_octet;
+	sink_env.datapath_cfg.frame_duration_is_10ms =
+		(p_cfg->param.frame_dur == BAP_FRAME_DUR_10MS);
+	sink_env.datapath_cfg.sampling_rate_hz       =
+		audio_bap_sampling_freq_to_hz(p_cfg->param.sampling_freq);
+
+	LOG_INF("Datapath cfg: sr=%uHz octets=%u 10ms=%u",
+		sink_env.datapath_cfg.sampling_rate_hz,
+		sink_env.datapath_cfg.octets_per_frame,
+		sink_env.datapath_cfg.frame_duration_is_10ms);
+}
+
+static void assign_audio_channel(uint8_t stream_count, uint8_t stream_pos, uint16_t loc_bf)
+{
+#ifdef CONFIG_AUDIO_LOCATION_USE_GAF
+	if ((loc_bf & GAF_LOC_LEFT_OR_CENTRE_MASK) &&
+		(sink_env.left_channel_pos == INVALID_CHANNEL_INDEX))
+#else
+	if (stream_count == 0)
+#endif
+	{
+		sink_env.left_channel_pos = stream_pos;
+		LOG_INF("Select LEFT/CENTER stream_pos=%u (count=%u)", stream_pos, stream_count);
+	}
+
+#ifdef CONFIG_AUDIO_LOCATION_USE_GAF
+	if ((loc_bf & GAF_LOC_RIGHT_MASK) &&
+		(sink_env.right_channel_pos == INVALID_CHANNEL_INDEX))
+#else
+	if (stream_count == 1)
+#endif
+	{
+		sink_env.right_channel_pos = stream_pos;
+		LOG_INF("Select RIGHT stream_pos=%u (count=%u)", stream_pos, stream_count);
+	}
+}
+
+static void on_bap_bc_scan_stream_report(uint8_t pa_lid, uint8_t sgrp_id, uint8_t stream_pos,
+					const gaf_codec_id_t *p_codec_id,
+					const bap_cfg_ptr_t *p_cfg)
+{
+	ARG_UNUSED(pa_lid);
+	ARG_UNUSED(sgrp_id);
+	ARG_UNUSED(p_codec_id);
+
+	LOG_INF("Stream report: pos=%u loc_bf=0x%04x (count=%u/%u)",
+		stream_pos, p_cfg->param.location_bf,
+		sink_env.stream_report_count + 1, sink_env.expected_streams);
+
+	assign_audio_channel(sink_env.stream_report_count, stream_pos, p_cfg->param.location_bf);
+
+	if (++sink_env.stream_report_count >= sink_env.expected_streams) {
+		sink_env.expected_streams = 0;
+		sink_env.stream_report_count = 0;
+
+		uint16_t rc = bap_bc_scan_pa_report_ctrl(sink_env.pa_lid, 0);
+
+		LOG_DBG("PA report ctrl: disable rc=%u", rc);
+
+		if (sink_env.left_channel_pos == INVALID_CHANNEL_INDEX) {
+			LOG_ERR("No LEFT/CENTER stream present – aborting");
+			sink_env.datapath_cfg_valid = false;
+		}
+
+		if (sink_env.datapath_cfg_valid) {
+			int er = sink_enable();
+
+			if (er != 0) {
+				LOG_ERR("Sink enable failed: rc=%d", er);
+			}
+		} else {
+			int er = start_scanning();
+
+			if (er != 0) {
+				LOG_ERR("Restart scanning failed: rc=%d", er);
+			}
+		}
+	}
+}
+
+static void on_bap_bc_scan_pa_sync_req(uint8_t pa_lid, uint8_t src_lid, uint8_t con_lid)
+{
+	ARG_UNUSED(src_lid);
+	ARG_UNUSED(con_lid);
+	LOG_INF("PA sync req: pa=%u", pa_lid);
+	bap_bc_scan_pa_synchronize_cfm(pa_lid, true, 0, 0, 0, 0);
+}
+
+static void on_bap_bc_scan_pa_terminate_req(uint8_t pa_lid, uint8_t con_lid)
+{
+	ARG_UNUSED(con_lid);
+	LOG_INF("PA terminate req: pa=%u", pa_lid);
+	bap_bc_scan_pa_terminate_cfm(pa_lid, true);
+}
+
+static const bap_bc_scan_cb_t scan_cbs = {
+	.cb_cmp_evt             = on_bap_bc_scan_cmp_evt,
+	.cb_timeout             = on_bap_bc_scan_timeout,
+	.cb_report              = on_bap_bc_scan_report,
+	.cb_public_bcast_source = on_bap_bc_scan_public_bcast,
+	.cb_pa_established      = on_bap_bc_scan_pa_established,
+	.cb_pa_terminated       = on_bap_bc_scan_pa_terminated,
+	.cb_pa_report           = on_bap_bc_scan_pa_report,
+	.cb_big_info_report     = on_bap_bc_scan_big_info_report,
+	.cb_group_report        = on_bap_bc_scan_group_report,
+	.cb_subgroup_report     = on_bap_bc_scan_subgroup_report,
+	.cb_stream_report       = on_bap_bc_scan_stream_report,
+	.cb_pa_sync_req         = on_bap_bc_scan_pa_sync_req,
+	.cb_pa_terminate_req    = on_bap_bc_scan_pa_terminate_req,
+};
+
+/* ================================================================
+ *                     SINK CALLBACKS
+ * ================================================================
+ */
+
+static void on_bap_bc_sink_cmp_evt(uint8_t cmd_type, uint16_t status, uint8_t grp_lid,
+				    uint8_t stream_pos)
+{
+	LOG_INF("Sink cmp event: cmd=%u status=%u grp=%u stream=%u", cmd_type, status, grp_lid,
+		stream_pos);
+
+	if (cmd_type == BAP_BC_SINK_CMD_TYPE_START_STREAMING && status == GAF_ERR_NO_ERROR) {
+		sink_env.started_streams_bf |= (1U << (stream_pos - 1));
+		LOG_INF("SINK started_bf=0x%08x chosen_bf=0x%08x",
+			sink_env.started_streams_bf, sink_env.chosen_streams_bf);
+
+		if (sink_env.started_streams_bf == sink_env.chosen_streams_bf) {
+			LOG_INF("Datapath: create start (sr=%uHz oct=%u 10ms=%u pres_delay=%uus)",
+				sink_env.datapath_cfg.sampling_rate_hz,
+				sink_env.datapath_cfg.octets_per_frame,
+				sink_env.datapath_cfg.frame_duration_is_10ms,
+				sink_env.datapath_cfg.pres_delay_us);
+
+			int ret = audio_datapath_create_sink(&sink_env.datapath_cfg);
+
+			if (ret) {
+				LOG_ERR("Datapath create failed rc=%d", ret);
+				audio_datapath_cleanup_sink();
+				return;
+			}
+
+			ret = audio_datapath_start();
+			LOG_INF("Datapath start rc=%d", ret);
+			if (ret) {
+				audio_datapath_cleanup_sink();
+			}
+		}
+	}
+}
+
+static void on_bap_bc_sink_quality_cmp_evt(uint16_t status, uint8_t grp_lid, uint8_t stream_pos,
+					uint32_t crc_error_packets, uint32_t rx_unrx_packets,
+					uint32_t duplicate_packets)
+{
+	ARG_UNUSED(status);
+	LOG_DBG("SINK quality: grp=%u stream=%u crc=%u miss=%u dup=%u",
+		grp_lid, stream_pos, crc_error_packets, rx_unrx_packets, duplicate_packets);
+}
+
+static void on_bap_bc_sink_status(uint8_t grp_lid, uint8_t state, uint32_t stream_pos_bf,
+				const gapi_bg_sync_config_t *p_bg_cfg, uint8_t nb_bis,
+				const uint16_t *p_conhdl)
+{
+	ARG_UNUSED(p_bg_cfg);
+	ARG_UNUSED(p_conhdl);
+
+	LOG_INF("SINK status: grp=%u state=%u stream_bf=0x%08x nb_bis=%u",
+		grp_lid, state, stream_pos_bf, nb_bis);
+
+	switch (state) {
+	case BAP_BC_SINK_ESTABLISHED: {
+		LOG_INF("SINK established (streams=0x%08x, nb_bis=%u) -> "
+			"deferring PA terminate & start_streaming",
+			stream_pos_bf, nb_bis);
+
+		struct sd_evt evt = { .type = SD_EVT_ESTABLISHED };
+		int rc = k_msgq_put(&sd_msgq, &evt, K_NO_WAIT);
+
+		if (rc != 0) {
+			LOG_ERR("status established: msgq_put rc=%d", rc);
+			break;
+		}
+		(void)k_work_submit(&sd_work);
+		break;
+	}
+
+	case BAP_BC_SINK_FAILED:
+	case BAP_BC_SINK_CANCELLED:
+	case BAP_BC_SINK_LOST:
+	case BAP_BC_SINK_PEER_TERMINATE:
+	case BAP_BC_SINK_MIC_FAILURE:
+	case BAP_BC_SINK_UPPER_TERMINATE:
+		k_sem_give(&sem_sink_disabled);
+		break;
+
+	default:
+		break;
+	}
+}
+
+static void on_bap_bc_sink_enable_req(uint8_t grp_lid, uint8_t src_lid, uint8_t con_lid,
+				       uint32_t stream_pos_bf)
+{
+	LOG_INF("SINK enable_req: grp=%u src=%u con=%u stream_bf=0x%08x",
+		grp_lid, src_lid, con_lid, stream_pos_bf);
+	bap_bc_sink_enable_cfm(grp_lid, true, stream_pos_bf, 1000, 1);
+}
+
+static void on_bap_bc_sink_disable_req(uint8_t grp_lid, uint8_t con_lid)
+{
+	LOG_INF("SINK disable_req: grp=%u con=%u", grp_lid, con_lid);
+	bap_bc_sink_disable_cfm(grp_lid, true);
+}
+
+static const bap_bc_sink_cb_t sink_cbs = {
+	.cb_cmp_evt         = on_bap_bc_sink_cmp_evt,
+	.cb_quality_cmp_evt = on_bap_bc_sink_quality_cmp_evt,
+	.cb_status          = on_bap_bc_sink_status,
+	.cb_enable_req      = on_bap_bc_sink_enable_req,
+	.cb_disable_req     = on_bap_bc_sink_disable_req,
+};
+
+/* ================================================================
+ *                         WORKER (SM)
+ * ================================================================
+ */
+
+static void sd_handle_remote_scan(const struct sd_evt *e)
+{
+	if (e->remote_scan_state) {
+		int rc = start_scanning();
+
+		if (rc != 0) {
+			LOG_ERR("Remote scan start: rc=%d", rc);
+			return;
+		}
+
+		bool ok = (k_sem_take(&sem_scan_started, SD_WAIT) == 0);
+
+		if (!ok) {
+			LOG_ERR("Remote scan start: timeout waiting for START");
+			return;
+		}
+
+		sink_env.scanning_active = true;
+	} else {
+		uint16_t err = bap_bc_scan_stop();
+
+		if (err != GAF_ERR_NO_ERROR && err != GAF_ERR_COMMAND_DISALLOWED) {
+			LOG_WRN("Remote scan stop: err=%u", err);
+		}
+
+		bool ok = (k_sem_take(&sem_scan_stopped, SD_WAIT) == 0);
+
+		if (!ok) {
+			LOG_ERR("Remote scan stop: timeout waiting for STOP");
+			return;
+		}
+
+		sink_env.scanning_active = false;
+	}
+}
+
+static void sd_handle_add(const struct sd_evt *e)
+{
+	/* Persist IDs for later Modify */
+	sink_env.src_lid = e->src_lid;
+	sink_env.con_lid = e->con_lid;
+	memcpy(&sink_env.bcast_id, &e->bcast_id, sizeof(sink_env.bcast_id));
+	memcpy(&sink_env.adv_id,   &e->adv_id,   sizeof(sink_env.adv_id));
+
+	LOG_INF("Add source request: src=%u con=%u bcast_id=%02x:%02x:%02x",
+		e->src_lid, e->con_lid,
+		sink_env.bcast_id.id[0], sink_env.bcast_id.id[1], sink_env.bcast_id.id[2]);
+
+	/* Confirm ADD from worker context */
+	bap_bc_deleg_add_source_cfm(e->src_lid, true);
+	LOG_INF("Add source request: cfm sent");
+
+	if (e->pa_sync_req && sink_env.pa_lid == GAF_INVALID_LID) {
+		uint16_t rc = bap_bc_scan_pa_synchronize(&sink_env.adv_id, 0,
+							BAP_BC_SCAN_REPORT_MASK,
+							SYNCHRONISATION_TIMEOUT, SCAN_TIMEOUT,
+							&sink_env.pa_lid);
+		LOG_INF("PA sync start: rc=%u -> pa_lid=%u", rc, sink_env.pa_lid);
+		bool ok = (k_sem_take(&sem_pa_synced, SD_WAIT) == 0);
+
+		if (!ok) {
+			LOG_ERR("Add source request: timeout waiting for PA establish");
+		}
+	}
+
+	if (sink_env.scanning_active) {
+		uint16_t rc = bap_bc_scan_stop();
+
+		if (rc != GAF_ERR_NO_ERROR && rc != GAF_ERR_COMMAND_DISALLOWED) {
+			LOG_WRN("Scan stop: err=%u", rc);
+		}
+		bool ok = (k_sem_take(&sem_scan_stopped, SD_WAIT) == 0);
+
+		if (!ok) {
+			LOG_ERR("Add source request: timeout waiting for scan stop");
+		} else {
+			sink_env.scanning_active = false;
+		}
+	}
+}
+
+static void sd_handle_modify(const struct sd_evt *e)
+{
+	LOG_INF("Modify source request: src=%u con=%u pa_sync=%u", e->src_lid, e->con_lid,
+		e->pa_sync_req);
+
+	/* 1) Bring BIG down and wait */
+	sd_teardown_sink_and_wait();
+
+	/* 2) Confirm MODIFY from worker context (let PA be driven by stack PA_* reqs) */
+	bap_bc_deleg_modify_source_cfm(e->src_lid, true);
+	LOG_INF("Modify source request: cfm sent");
+}
+
+static void sd_handle_remove(const struct sd_evt *e)
+{
+	LOG_INF("Remove source request: src=%u con=%u", e->src_lid, e->con_lid);
+
+	/* 1) Bring BIG down and wait */
+	sd_teardown_sink_and_wait();
+
+	/* 2) Confirm REMOVE (stack will drive PA terminate if needed) */
+	bap_bc_deleg_remove_source_cfm(sink_env.src_lid, true);
+	LOG_INF("Remove source request: cfm sent");
+
+	reset_sink_config();
+}
+
+static void sd_handle_established(void)
+{
+	/* Drop PA, but don't block the worker waiting for it */
+	if (sink_env.pa_lid != GAF_INVALID_LID) {
+		uint16_t rc = bap_bc_scan_pa_terminate(sink_env.pa_lid);
+
+		LOG_INF("Established: request PA terminate rc=%u (pa_lid=%u)", rc, sink_env.pa_lid);
+		sink_env.pa_lid = GAF_INVALID_LID;
+	}
+
+	/* Start streaming */
+	int rc = start_streaming();
+
+	if (rc) {
+		LOG_ERR("Established: start_streaming rc=%d", rc);
+	}
+}
+
+static void sd_work_fn(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	struct sd_evt e;
+
+	while (k_msgq_get(&sd_msgq, &e, K_NO_WAIT) == 0) {
+		switch (e.type) {
+		case SD_EVT_REMOTE_SCAN:
+			sd_handle_remote_scan(&e);
+			break;
+
+		case SD_EVT_ADD:
+			sd_handle_add(&e);
+			break;
+
+		case SD_EVT_MODIFY:
+			sd_handle_modify(&e);
+			break;
+
+		case SD_EVT_REMOVE:
+			sd_handle_remove(&e);
+			break;
+
+		case SD_EVT_ESTABLISHED:
+			sd_handle_established();
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+
+/* ================================================================
+ *                     SYSTEM / MODULE INIT
+ * ================================================================
+ */
+
+int broadcast_sink_start_solicitation(const char *device_name, uint16_t appearance)
+{
+	/* Prepare extended advertising data for BASS solicitation */
+	uint8_t adv_data_buffer[64];
+	uint8_t adv_data_len = 0;
+
+	if (device_name != NULL) {
+		size_t name_len = strlen(device_name);
+
+		if (name_len > 0) {
+			if (name_len > MAX_DEVICE_NAME_LEN) {
+				name_len = MAX_DEVICE_NAME_LEN;
+			}
+			if ((adv_data_len + 2 + name_len) <= sizeof(adv_data_buffer)) {
+				adv_data_buffer[adv_data_len++] = (uint8_t)(name_len + 1);
+				adv_data_buffer[adv_data_len++] = GAP_AD_TYPE_COMPLETE_NAME;
+				memcpy(&adv_data_buffer[adv_data_len], device_name, name_len);
+				adv_data_len += (uint8_t)name_len;
+			}
+		}
+	}
+
+	/* Add appearance*/
+	if ((adv_data_len + 4) <= sizeof(adv_data_buffer)) {
+		adv_data_buffer[adv_data_len++] = 3;
+		adv_data_buffer[adv_data_len++] = GAP_AD_TYPE_APPEARANCE;
+		adv_data_buffer[adv_data_len++] = (uint8_t)(appearance & 0xFF);
+		adv_data_buffer[adv_data_len++] = (uint8_t)((appearance >> 8) & 0xFF);
+	}
+
+	/* Create LTV structure for the EA data */
+	uint8_t ltv_buffer[sizeof(gaf_ltv_t) + 31];
+	gaf_ltv_t *adv_data_ltv = (gaf_ltv_t *)ltv_buffer;
+
+	adv_data_ltv->len = adv_data_len;
+	if (adv_data_len > 0) {
+		memcpy(adv_data_ltv->data, adv_data_buffer, adv_data_len);
+		LOG_INF("Solicitation EA payload: %u bytes", adv_data_len);
+	}
+
+	/* Start BASS solicitation advertising */
+	bap_bc_adv_param_t adv_param = {
+		.adv_intv_min_slot = 160,
+		.adv_intv_max_slot = 160,
+		.ch_map            = ADV_ALL_CHNLS_EN,
+		.phy_prim          = GAPM_PHY_TYPE_LE_1M,
+		.phy_second        = GAPM_PHY_TYPE_LE_2M,
+		.adv_sid           = 0x01,
+		.max_tx_pwr        = -2,
+	};
+
+	uint16_t err = bap_bc_deleg_start_solicite(0, &adv_param,
+					(adv_data_len > 0) ? adv_data_ltv : NULL);
+
+	if (err != GAF_ERR_NO_ERROR) {
+		LOG_ERR("BASS solicitation failed, err=%u (0x%02X)", err, err);
+		return -EIO;
+	}
+
+	LOG_INF("BASS solicitation started");
+	return 0;
+}
+
+static int _broadcast_sink_init(void)
+{
+	if (!device_is_ready(i2s_dev)) {
+		LOG_ERR("I2S not ready");
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(codec_dev)) {
+		LOG_ERR("Codec not ready");
+		return -ENODEV;
+	}
+
+	LOG_INF("Audio HW ready");
+	return 0;
+}
+SYS_INIT(_broadcast_sink_init, APPLICATION, 0);
+
+int broadcast_sink_init(void)
+{
+	reset_sink_config();
+
+	/* Worker */
+	k_work_init(&sd_work, sd_work_fn);
+
+	/* Configure Delegator (BASS) */
+	bap_bc_deleg_cfg_t bass_cfg = {
+		.nb_srcs  = 1,
+		.cfg_bf   = 0,
+		.shdl     = GATT_INVALID_HDL,
+		.pref_mtu = GAP_LE_MAX_OCTETS,
+	};
+	uint16_t err = bap_bc_deleg_configure(&bass_cbs, &bass_cfg);
+
+	if (err != GAF_ERR_NO_ERROR) {
+		LOG_ERR("deleg_configure err=%u", err);
+		return -ENODEV;
+	}
+
+	/* Configure Scan + Deleg + Sink roles */
+	err = bap_bc_scan_configure(BAP_ROLE_SUPP_BC_SINK_BIT | BAP_ROLE_SUPP_BC_DELEG_BIT |
+					BAP_ROLE_SUPP_BC_SCAN_BIT,
+					&scan_cbs);
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("scan_configure err=%u", err);
+		return -ENODEV;
+	}
+
+	err = bap_bc_sink_configure(BAP_ROLE_SUPP_BC_SINK_BIT | BAP_ROLE_SUPP_BC_DELEG_BIT |
+					BAP_ROLE_SUPP_BC_SCAN_BIT,
+					&sink_cbs);
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("sink_configure err=%u", err);
+		return -ENODEV;
+	}
+
+	if (!bap_bc_deleg_is_configured()) {
+		LOG_ERR("BASS not configured");
+		return -ENODEV;
+	}
+
+	LOG_INF("Broadcast sink BLE initialized");
+	return 0;
+}

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/src/broadcast_sink.h
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/src/broadcast_sink.h
@@ -1,0 +1,33 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef _BROADCAST_SINK_H
+#define _BROADCAST_SINK_H
+
+/**
+ * @brief Initialize BLE services for broadcast sink (BASS, scan, sink)
+ *
+ * @retval 0 on success
+ * @retval Negative error code on failure
+ */
+int broadcast_sink_init(void);
+
+/**
+ * @brief Start BASS solicitation advertising with a consistent Extended Adv payload.
+ *
+ * The payload includes Complete Local Name (if it fits) and Appearance.
+ *
+ * @param device_name  Device name.
+ * @param appearance   GAP Appearance value.
+ * @retval 0 on success
+ * @retval Negative error code on failure
+ */
+int broadcast_sink_start_solicitation(const char *device_name, uint16_t appearance);
+
+#endif /* _BROADCAST_SINK_H */

--- a/samples/bluetooth/le_audio/broadcast_sink_sd/src/main.c
+++ b/samples/bluetooth/le_audio/broadcast_sink_sd/src/main.c
@@ -1,0 +1,673 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/__assert.h>
+
+#include "alif_ble.h"
+#include "gapm.h"
+#include "gapm_le.h"
+#include "gapc.h"
+#include "gapc_le.h"
+#include "gapc_sec.h"
+#include "gaf_adv.h"
+
+#include "broadcast_sink.h"
+#include "bap_bc_deleg.h"
+#include "bap_bc_sink.h"
+#include "bap_bc_scan.h"
+#include "bap.h"
+
+LOG_MODULE_REGISTER(main, CONFIG_MAIN_LOG_LEVEL);
+
+/* Appearance */
+#define APPEARANCE_EARBUDS 0x0941
+#define APPEARANCE_HEADSET 0x0942
+
+/* TODO: Change appearance to Headset when bidir communication is implemented */
+#define APPEARANCE APPEARANCE_EARBUDS
+
+#define SETTINGS_BASE           "uc_periph"
+#define SETTINGS_NAME_KEYS      "bond_keys_0"
+#define SETTINGS_NAME_BOND_DATA "bond_data_0"
+
+K_SEM_DEFINE(gapm_init_sem, 0, 1);
+
+enum gapm_meta {
+	META_CONFIG      = 1,
+	META_SET_NAME    = 2,
+	META_RESET       = 3,
+};
+
+struct connection_status {
+	gap_bdaddr_t addr; /*!< Peer device address */
+	uint8_t conidx;    /*!< connection index */
+};
+
+static struct connection_status app_con_info = {
+	.conidx = GAP_INVALID_CONIDX,
+	.addr.addr_type = 0xff,
+};
+
+struct app_con_bond_data {
+	gapc_pairing_keys_t keys;
+	gapc_bond_data_t bond_data;
+};
+
+static struct app_con_bond_data app_con_bond_data;
+
+/* Load name from Kconfig */
+static const char device_name[] = CONFIG_BLE_DEVICE_NAME;
+
+static const gap_sec_key_t gapm_irk = {.key = {
+	0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0x07, 0x08,
+	0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
+}};
+
+static gap_addr_t g_private_identity = { .addr = {0} };
+
+/* ---------------------------------------------------------------------------------------- */
+/* Settings NVM storage handlers */
+
+struct storage_ctx {
+	uint8_t *p_output;
+	size_t size;
+};
+
+static int settings_direct_loader(const char *const key, size_t const len,
+			  settings_read_cb const read_cb, void *cb_arg, void *param)
+{
+	struct storage_ctx *p_ctx = (struct storage_ctx *)param;
+
+	if (settings_name_next(key, NULL) == 0) {
+		ssize_t const cb_len = read_cb(cb_arg, p_ctx->p_output, p_ctx->size);
+
+		if (cb_len != (ssize_t)p_ctx->size) {
+			LOG_ERR("Unable to read bytes_written from storage");
+			return (int)cb_len;
+		}
+	}
+
+	return 0;
+}
+
+static int storage_load(const char *key, void *data, size_t const size)
+{
+	struct storage_ctx ctx = {
+	    .p_output = (uint8_t *)data,
+	    .size = size,
+	};
+
+	char key_str[64];
+	(void)snprintf(key_str, sizeof(key_str), SETTINGS_BASE "/%s", key);
+
+	int err = settings_load_subtree_direct(key_str, settings_direct_loader, &ctx);
+
+	if (err != 0) {
+		LOG_ERR("Failed to load %s, err %d", key_str, err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int storage_save(const char *key, void *data, size_t const size)
+{
+	char key_str[64];
+	(void)snprintf(key_str, sizeof(key_str), SETTINGS_BASE "/%s", key);
+
+	int err = settings_save_one(key_str, data, size);
+
+	if (err) {
+		LOG_ERR("Failed to store %s (err %d)", key, err);
+	}
+	return err;
+}
+
+static int storage_load_bond_data(void)
+{
+	int err = settings_subsys_init();
+
+	if (err) {
+		LOG_ERR("settings_subsys_init() failed (err %d)", err);
+		return err;
+	}
+
+	err = storage_load(SETTINGS_NAME_KEYS, &app_con_bond_data.keys,
+		sizeof(app_con_bond_data.keys));
+
+	if (err != 0) {
+		LOG_WRN("No bond keys found");
+	}
+
+	err = storage_load(SETTINGS_NAME_BOND_DATA, &app_con_bond_data.bond_data,
+		sizeof(app_con_bond_data.bond_data));
+
+	if (err != 0) {
+		LOG_WRN("No bond data found");
+	}
+
+	return 0;
+}
+
+/* ---------------------------------------------------------------------------------------- */
+/* Bluetooth GAPM callbacks */
+
+static void on_get_peer_version_cmp_cb(uint8_t const conidx, uint32_t const metainfo,
+	uint16_t const status, const gapc_version_t *const p_version)
+{
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u Peer version fetch failed! err:%u", conidx, status);
+		return;
+	}
+	LOG_INF("Client %u company_id:%u, lmp_subversion:%u, lmp_version:%u",
+	    conidx, p_version->company_id, p_version->lmp_subversion, p_version->lmp_version);
+}
+
+static void on_peer_features_cmp_cb(uint8_t const conidx, uint32_t const metainfo, uint16_t status,
+	const uint8_t *const p_features)
+{
+	__ASSERT(status == GAP_ERR_NO_ERROR, "Client %u get peer features failed! status:%u",
+		conidx, status);
+
+	LOG_INF("Client %u features: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", conidx,
+		p_features[0], p_features[1], p_features[2], p_features[3],
+		p_features[4], p_features[5], p_features[6], p_features[7]);
+
+	status = gapc_get_peer_version(conidx, 0, on_get_peer_version_cmp_cb);
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u unable to get peer version! err:%u", conidx, status);
+	}
+}
+
+static void connection_confirm_not_bonded(uint_fast8_t const conidx)
+{
+	uint_fast16_t status;
+
+	status = gapc_le_connection_cfm(conidx, 0, NULL);
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u connection confirmation failed! err:%u", conidx, status);
+	}
+
+	status = gapc_le_get_peer_features(conidx, 0, on_peer_features_cmp_cb);
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u Unable to get peer features! err:%u", conidx, status);
+	}
+}
+
+static void on_address_resolved_cb(uint16_t status, const gap_addr_t *const p_addr,
+	const gap_sec_key_t *const pirk)
+{
+	uint_fast8_t const conidx = app_con_info.conidx;
+	bool const resolved = (status == GAP_ERR_NO_ERROR);
+
+	LOG_INF("Client %u address resolve ready! status:%u, %s peer device",
+		conidx, status, resolved ? "KNOWN" : "UNKNOWN");
+
+	memcpy(&app_con_info.addr, p_addr, sizeof(app_con_info.addr));
+
+	if (resolved) {
+		gapc_le_connection_cfm(conidx, 0, &app_con_bond_data.bond_data);
+		return;
+	}
+
+	connection_confirm_not_bonded(conidx);
+}
+
+static void on_le_connection_req(uint8_t const conidx, uint32_t const metainfo,
+	uint8_t const actv_idx, uint8_t const role,
+	const gap_bdaddr_t *const p_peer_addr,
+	const gapc_le_con_param_t *const p_con_params,
+	uint8_t const clk_accuracy)
+{
+	app_con_info.conidx = conidx;
+	memcpy(&app_con_info.addr, p_peer_addr, sizeof(app_con_info.addr));
+
+	/* Number of IRKs */
+	uint8_t nb_irk = 1;
+	/* Resolve Address */
+	uint16_t const status = gapm_le_resolve_address((gap_addr_t *)p_peer_addr->addr,
+								nb_irk,
+								&app_con_bond_data.keys.irk.key,
+								on_address_resolved_cb);
+
+	if (status == GAP_ERR_INVALID_PARAM) {
+		/* Address not resolvable, just confirm the connection */
+		connection_confirm_not_bonded(conidx);
+	} else if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u Unable to start resolve address! err:%u", conidx, status);
+	}
+
+	LOG_INF("Connection request. conidx:%u (actv_idx:%u), role %s",
+	    conidx, actv_idx, role ? "PERIPH" : "CENTRAL");
+
+	LOG_DBG("  interval %fms, latency %u, supervision timeout %ums, clk_accuracy:%u",
+	    (p_con_params->interval * 1.25), p_con_params->latency,
+	    (uint32_t)p_con_params->sup_to * 10, clk_accuracy);
+
+	LOG_DBG("  Peer address: %s %02X:%02X:%02X:%02X:%02X:%02X",
+	    (p_peer_addr->addr_type == GAP_ADDR_PUBLIC) ? "Public" : "Private",
+	    p_peer_addr->addr[5], p_peer_addr->addr[4], p_peer_addr->addr[3],
+	    p_peer_addr->addr[2], p_peer_addr->addr[1], p_peer_addr->addr[0]);
+}
+
+static const struct gapc_connection_req_cb gapc_con_cbs = {
+	.le_connection_req = on_le_connection_req,
+};
+
+static void on_gapc_le_encrypt_req(uint8_t const conidx, uint32_t const metainfo,
+	uint16_t const ediv, const gap_le_random_nb_t *const p_rand)
+{
+	LOG_INF("Client %u LE encryption request received, ediv: 0x%04X", conidx, ediv);
+
+	uint16_t const status = gapc_le_encrypt_req_reply(
+	    conidx, true, &app_con_bond_data.keys.ltk.key, app_con_bond_data.keys.ltk.key_size);
+
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Client %u LE encryption reply failed! err:%u", conidx, status);
+		return;
+	}
+
+	LOG_INF("Client %u LE encryption reply successful", conidx);
+}
+
+static void on_gapc_sec_auth_info(uint8_t const conidx, uint32_t const metainfo,
+	uint8_t const sec_lvl, bool const encrypted, uint8_t const key_size)
+{
+	LOG_INF("Client %u Link security info. level:%u, encrypted:%s, key_size:%u",
+	    conidx, sec_lvl, (encrypted ? "TRUE" : "FALSE"), key_size);
+}
+
+static void on_gapc_pairing_succeed(uint8_t const conidx, uint32_t const metainfo,
+	uint8_t const pairing_level, bool const enc_key_present, uint8_t const key_type)
+{
+	bool const bonded = gapc_is_bonded(conidx);
+
+	LOG_INF("Client %u pairing SUCCEED. pairing_level:%u, bonded:%s",
+	    conidx, pairing_level, bonded ? "TRUE" : "FALSE");
+
+	app_con_bond_data.bond_data.pairing_lvl = pairing_level;
+	app_con_bond_data.bond_data.enc_key_present = enc_key_present;
+
+	storage_save(SETTINGS_NAME_BOND_DATA, &app_con_bond_data.bond_data,
+		sizeof(app_con_bond_data.bond_data));
+}
+
+static void on_gapc_pairing_failed(uint8_t const conidx, uint32_t const metainfo,
+	uint16_t const reason)
+{
+	LOG_ERR("Client %u pairing failed, reason: 0x%04X", conidx, reason);
+	app_con_info.conidx = GAP_INVALID_CONIDX;
+}
+
+static void on_gapc_info_req(uint8_t const conidx, uint32_t const metainfo, uint8_t const exp_info)
+{
+	uint16_t err;
+
+	switch (exp_info) {
+	case GAPC_INFO_IRK: {
+		err = gapc_le_pairing_provide_irk(conidx, &gapm_irk);
+		if (err) {
+			LOG_ERR("Client %u IRK provide failed. err: %u", conidx, err);
+			break;
+		}
+		LOG_INF("Client %u IRK sent successful", conidx);
+		break;
+	}
+	case GAPC_INFO_CSRK: {
+		err = gapc_pairing_provide_csrk(conidx, &app_con_bond_data.bond_data.local_csrk);
+		if (err) {
+			LOG_ERR("Client %u CSRK provide failed. err: %u", conidx, err);
+			break;
+		}
+		LOG_INF("Client %u CSRK sent successful", conidx);
+		break;
+	}
+	case GAPC_INFO_BT_PASSKEY:
+	case GAPC_INFO_PASSKEY_DISPLAYED: {
+		err = gapc_pairing_provide_passkey(conidx, true, 123456);
+		if (err) {
+			LOG_ERR("Client %u PASSKEY provide failed. err: %u", conidx, err);
+			break;
+		}
+		LOG_INF("Client %u PASSKEY 123456 provided", conidx);
+		break;
+	}
+	default:
+		LOG_WRN("Client %u Unsupported info %u requested!", conidx, exp_info);
+		break;
+	}
+}
+
+static void on_gapc_pairing_req(uint8_t const conidx, uint32_t const metainfo,
+	uint8_t const auth_level)
+{
+	LOG_DBG("Client %u pairing requested. auth_level:%u", conidx, auth_level);
+
+	gapc_pairing_t pairing_info = {
+	    .auth = GAP_AUTH_REQ_SEC_CON_BOND,
+	    .iocap = GAP_IO_CAP_DISPLAY_ONLY,
+	    .ikey_dist = GAP_KDIST_ENCKEY | GAP_KDIST_IDKEY,
+	    .key_size = GAP_KEY_LEN,
+	    .oob = GAP_OOB_AUTH_DATA_NOT_PRESENT,
+	    .rkey_dist = GAP_KDIST_ENCKEY | GAP_KDIST_IDKEY,
+	};
+
+	if (auth_level & GAP_AUTH_SEC_CON) {
+		pairing_info.auth = GAP_AUTH_REQ_SEC_CON_BOND;
+	}
+
+	uint16_t const status = gapc_le_pairing_accept(conidx, true, &pairing_info, 0);
+
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("Pairing accept failed! error: %u", status);
+	}
+}
+
+static void on_gapc_sec_numeric_compare_req(uint8_t const conidx, uint32_t const metainfo,
+	uint32_t const value)
+{
+	LOG_INF("Client %u pairing - numeric compare. value:%u", conidx, value);
+	gapc_pairing_numeric_compare_rsp(conidx, true);
+}
+
+static void on_key_received(uint8_t conidx, uint32_t metainfo, const gapc_pairing_keys_t *p_keys)
+{
+	LOG_INF("Client %u keys received: key_bf:0x%02X, level:%u",
+	    conidx, p_keys->valid_key_bf, p_keys->pairing_lvl);
+
+	gapc_pairing_keys_t *const p_appkeys = &app_con_bond_data.keys;
+	uint8_t key_bits = GAP_KDIST_NONE;
+
+	if (p_keys->valid_key_bf & GAP_KDIST_ENCKEY) {
+		memcpy(&p_appkeys->ltk, &p_keys->ltk, sizeof(p_appkeys->ltk));
+		key_bits |= GAP_KDIST_ENCKEY;
+		LOG_INF("Client %u LTK received and stored", conidx);
+	}
+
+	if (p_keys->valid_key_bf & GAP_KDIST_IDKEY) {
+		memcpy(&p_appkeys->irk, &p_keys->irk, sizeof(p_appkeys->irk));
+		key_bits |= GAP_KDIST_IDKEY;
+		LOG_INF("Client %u IRK received and stored", conidx);
+	}
+
+	if (p_keys->valid_key_bf & GAP_KDIST_SIGNKEY) {
+		memcpy(&p_appkeys->csrk, &p_keys->csrk, sizeof(p_appkeys->csrk));
+		key_bits |= GAP_KDIST_SIGNKEY;
+		LOG_INF("Client %u CSRK received and stored", conidx);
+	}
+
+	p_appkeys->pairing_lvl = p_keys->pairing_lvl;
+	p_appkeys->valid_key_bf = key_bits;
+
+	storage_save(SETTINGS_NAME_KEYS, &app_con_bond_data.keys, sizeof(app_con_bond_data.keys));
+	LOG_INF("Client %u keys saved to storage", conidx);
+}
+
+static const gapc_security_cb_t gapc_sec_cbs = {
+	.le_encrypt_req = on_gapc_le_encrypt_req,
+	.auth_info = on_gapc_sec_auth_info,
+	.pairing_succeed = on_gapc_pairing_succeed,
+	.pairing_failed = on_gapc_pairing_failed,
+	.info_req = on_gapc_info_req,
+	.pairing_req = on_gapc_pairing_req,
+	.numeric_compare_req = on_gapc_sec_numeric_compare_req,
+	.key_received = on_key_received,
+};
+
+static void on_disconnection(uint8_t const conidx, uint32_t const metainfo, uint16_t const reason)
+{
+	LOG_INF("Client %u disconnected, reason: 0x%04X", conidx, reason);
+
+	app_con_info.conidx = GAP_INVALID_CONIDX;
+
+	/* Restart BASS solicitation */
+	int err = broadcast_sink_start_solicitation(device_name, APPEARANCE);
+
+	if (err != 0) {
+		LOG_ERR("Failed to restart BASS solicitation, err %d", err);
+		return;
+	}
+	LOG_INF("BASS solicitation restarted after disconnection");
+}
+
+static void on_bond_data_updated(uint8_t const conidx, uint32_t const metainfo,
+	const gapc_bond_data_updated_t *const p_data)
+{
+	LOG_INF("Client %u bond data updated: gatt_start_hdl:%u, gatt_end_hdl:%u, "
+	    "svc_chg_hdl:%u, cli_info:%u, cli_feat:%u, srv_feat:%u",
+	    conidx, p_data->gatt_start_hdl, p_data->gatt_end_hdl, p_data->svc_chg_hdl,
+	    p_data->cli_info, p_data->cli_feat, p_data->srv_feat);
+}
+
+static void on_name_get(uint8_t const conidx, uint32_t const metainfo, uint16_t const token,
+	uint16_t const offset, uint16_t const max_len)
+{
+	const size_t device_name_len = sizeof(device_name) - 1;
+	const size_t short_len = (device_name_len > max_len ? max_len : device_name_len);
+
+	LOG_INF("%s method called", __func__);
+	gapc_le_get_name_cfm(conidx, token, GAP_ERR_NO_ERROR, device_name_len, short_len,
+				(const uint8_t *)device_name);
+}
+
+static void on_appearance_get(uint8_t const conidx, uint32_t const metainfo, uint16_t const token)
+{
+	LOG_INF("%s method called", __func__);
+	gapc_le_get_appearance_cfm(conidx, token, GAP_ERR_NO_ERROR, APPEARANCE);
+}
+
+static const gapc_connection_info_cb_t gapc_inf_cbs = {
+	.disconnected = on_disconnection,
+	.bond_data_updated = on_bond_data_updated,
+	.name_get = on_name_get,
+	.appearance_get = on_appearance_get,
+};
+
+static const gapc_le_config_cb_t gapc_le_cfg_cbs = {0};
+
+#if !CONFIG_ALIF_BLE_ROM_IMAGE_V1_0 /* ROM version > 1.0 */
+static void on_gapm_err(uint32_t metainfo, uint8_t code)
+{
+	LOG_ERR("GAPM error %d", code);
+}
+
+static const gapm_cb_t gapm_err_cbs = {
+	.cb_hw_error = on_gapm_err,
+};
+#else
+static void on_gapm_err(enum co_error err)
+{
+	LOG_ERR("GAPM error %d", err);
+}
+
+static const gapm_err_info_config_cb_t gapm_err_cbs = {
+	.ctrl_hw_error = on_gapm_err,
+};
+#endif
+
+static const gapm_callbacks_t gapm_cbs = {
+	.p_con_req_cbs = &gapc_con_cbs,
+	.p_sec_cbs = &gapc_sec_cbs,
+	.p_info_cbs = &gapc_inf_cbs,
+	.p_le_config_cbs = &gapc_le_cfg_cbs,
+	.p_bt_config_cbs = NULL,
+#if !CONFIG_ALIF_BLE_ROM_IMAGE_V1_0
+	.p_gapm_cbs = &gapm_err_cbs,
+#else
+	.p_err_info_config_cbs = &gapm_err_cbs,
+#endif
+};
+
+static void on_gapm_process_complete(uint32_t const metainfo, uint16_t const status)
+{
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("GAPM process completed with error %u", status);
+		return;
+	}
+
+	switch (metainfo) {
+	case META_CONFIG:
+		LOG_INF("GAPM configured successfully");
+		break;
+
+	case META_SET_NAME:
+		LOG_INF("GAPM name set successfully");
+		break;
+
+	case META_RESET:
+		LOG_INF("GAPM reset successfully");
+		break;
+
+	default:
+		LOG_ERR("GAPM Unknown metadata!");
+		return;
+	}
+
+	k_sem_give(&gapm_init_sem);
+}
+
+static void on_gapm_le_random_addr_cb(uint16_t const status, const gap_addr_t *const p_addr)
+{
+	if (status != GAP_ERR_NO_ERROR) {
+		LOG_ERR("RPA generation error %u", status);
+		k_sem_give(&gapm_init_sem);
+		return;
+	}
+
+	g_private_identity = *p_addr;
+
+	LOG_DBG("Generated resolvable random address: %02X:%02X:%02X:%02X:%02X:%02X",
+		p_addr->addr[5], p_addr->addr[4], p_addr->addr[3],
+		p_addr->addr[2], p_addr->addr[1], p_addr->addr[0]);
+
+	k_sem_give(&gapm_init_sem);
+}
+
+/* Configure stack once with privacy+bonding (no reset / re-configure round-trip) */
+static int ble_stack_configure(uint8_t const role)
+{
+	LOG_DBG("Configuring GAPM with BLE role %s",
+	    (GAP_ROLE_LE_CENTRAL == role) ? "CENTRAL" : "PERIPHERAL");
+
+	int err = gapm_le_generate_random_addr(GAP_BD_ADDR_RSLV, on_gapm_le_random_addr_cb);
+
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("gapm_le_generate_random_addr error %u", err);
+		return -1;
+	}
+
+	if (k_sem_take(&gapm_init_sem, K_MSEC(1000)) != 0) {
+		LOG_ERR("  FAIL! GAPM random address timeout!");
+		return -1;
+	}
+
+	gapm_config_t gapm_cfg = {
+		.role = role,
+		.pairing_mode = GAPM_PAIRING_SEC_CON,
+		/* Enable controller-managed privacy / RPA */
+		.privacy_cfg = (GAPM_PRIV_CFG_PRIV_ADDR_BIT | GAPM_PRIV_CFG_PRIV_EN_BIT),
+		.renew_dur = 1500, /* seconds */
+		.private_identity = g_private_identity, /* let controller handle RPA */
+		.irk = gapm_irk,
+		.gap_start_hdl = 0,
+		.gatt_start_hdl = 0,
+		.att_cfg = 0, /* Disable automatic MTU exchange */
+		.sugg_max_tx_octets = GAP_LE_MAX_OCTETS,
+		.sugg_max_tx_time = GAP_LE_MIN_TIME,
+		.tx_pref_phy = GAP_PHY_LE_2MBPS,
+		.rx_pref_phy = GAP_PHY_LE_2MBPS,
+		.tx_path_comp = 0,
+		.rx_path_comp = 0,
+		.class_of_device = 0x200408,
+		.dflt_link_policy = 0,
+	};
+
+	err = gapm_configure(META_CONFIG, &gapm_cfg, &gapm_cbs, on_gapm_process_complete);
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("gapm_configure error %u", err);
+		return -1;
+	}
+	if (k_sem_take(&gapm_init_sem, K_SECONDS(1)) != 0) {
+		LOG_ERR("  FAIL! GAPM config timeout!");
+		return -1;
+	}
+
+	LOG_INF("Set name: %s", device_name);
+	err = gapm_set_name(META_SET_NAME, strlen(device_name),
+				(const uint8_t *)device_name, on_gapm_process_complete);
+	if (err != GAP_ERR_NO_ERROR) {
+		LOG_ERR("gapm_set_name error %u", err);
+		return -1;
+	}
+	if (k_sem_take(&gapm_init_sem, K_SECONDS(1)) != 0) {
+		LOG_ERR("  FAIL! GAPM name set timeout!");
+		return -1;
+	}
+
+	LOG_INF("Configure security level");
+	gapm_le_configure_security_level(GAP_SEC1_SEC_CON_PAIR_ENC);
+
+	gap_bdaddr_t identity;
+
+	gapm_get_identity(&identity);
+	LOG_DBG("Device address: %02X:%02X:%02X:%02X:%02X:%02X",
+	    identity.addr[5], identity.addr[4], identity.addr[3],
+	    identity.addr[2], identity.addr[1], identity.addr[0]);
+
+	LOG_DBG("BLE init complete!");
+	return 0;
+}
+
+int main(void)
+{
+	if (storage_load_bond_data() < 0) {
+		return -1;
+	}
+
+	int ret = alif_ble_enable(NULL);
+
+	if (ret) {
+		LOG_ERR("Failed to enable bluetooth, err %d", ret);
+		return ret;
+	}
+
+	LOG_DBG("BLE enabled");
+
+	if (ble_stack_configure(GAP_ROLE_LE_PERIPHERAL | GAP_ROLE_LE_OBSERVER) != 0) {
+		return -1;
+	}
+
+	LOG_INF("gapm process completed successfully");
+
+	/* Initialize BLE services (BASS, broadcast sink, scan) */
+	if (broadcast_sink_init() != 0) {
+		LOG_ERR("Failed to initialize broadcast sink BLE services");
+		return -1;
+	}
+
+	LOG_INF("Broadcast sink BLE services initialized");
+
+	/* Start solicitation advertising using a single, canonical API */
+	ret = broadcast_sink_start_solicitation(device_name, APPEARANCE);
+	if (ret != 0) {
+		LOG_ERR("Failed to start BASS solicitation, err %d", ret);
+		return -1;
+	}
+
+	for (;;) {
+		k_sleep(K_SECONDS(5));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
1. Added Scan Delegator role
    2. BA can connect to device and do next actions:
       - Start/stop scanning for the broadcast sources
       - Add source
       - Remove source
    3. Modify source now is added but only for pa_sync = 0. Currently the app is tested with native
       BLE Audio Broadcast Assistant on Samsung Galaxy S24 Ultra, and modify source request start
       when "Leave" button pressed on connected broadcast source. The behavior of native BA on Samsung
       cannot be fully debugged, so right now modify operation does the same as remove operation.
    
    Testing procedure:
    1. Start scanning BLE devices on the phone.
    2. Pair and bond with sink device.
    3. Start scanning for the sources.
    4. Connect to source -> audio works.
    5. Disconnect from source -> audio stops.
    6. Repeat 4 and 5 for a few times.
    
    Limitations:
    1. Was tested only with one source (only one B1 board for source is available.)
    2. Used native BA functionality on Samsung S24 Ultra.
    
    Observations:
    1. Sometimes disconnections happen and not sure what device is a real problem.
    2. There is a bug with scanning. Fix is in progress.