### PR TITLE
manifest: update zephyr to include HCI UART DMA fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: a92ae0ad42df74391761e1258ffa573d4e20102a
+      revision: 14a30a93eb0b3d1db8410127b655792be8acf409
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr to include HCI UART DMA fix

depends on https://github.com/alifsemi/zephyr_alif/pull/192