### PR TITLE
manifest: update zephyr to include dave2d driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 14a30a93eb0b3d1db8410127b655792be8acf409
+      revision: pull/168/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to include D/AVE2D driver

Depends on alifsemi/zephyr_alif#168