### PR TITLE
samples: drivers: display: Enable Non Secure node

### DIFF
--- a/samples/drivers/display/boards/alif_b1_dk_rtss_he.overlay
+++ b/samples/drivers/display/boards/alif_b1_dk_rtss_he.overlay
@@ -22,3 +22,7 @@
 &lpuart {
 	status = "okay";
 };
+
+ns: &ns {
+	status = "okay";
+};

--- a/samples/drivers/display/boards/serial_display_1lane.overlay
+++ b/samples/drivers/display/boards/serial_display_1lane.overlay
@@ -62,3 +62,7 @@
 &ili9488 {
 	status = "okay";
 };
+
+ns: &ns {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 14a30a93eb0b3d1db8410127b655792be8acf409
+      revision: 17b06df6b9a0f38a6851542def86045c51c7e649
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Enabled Non Secure node in overlays for single lane display and parallel display.