### PR TITLE
manifest: zephyr_alif: Add common files for balletto series

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 8fca450c6bd0069304e5a116228cac5d77f9729a
+      revision: pull/285/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 945743acd3aa139dac8eb1453a1848d8a909278c
+      revision: pull/285/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr revision to pick the common dtsi file for all
SOCs in balletto.

The PR points to https://github.com/alifsemi/zephyr_alif/pull/285