### PR TITLE
manifest: update zephyr revision to include LPPDM IRQ support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 9951f106e882be7cdc840bec6cc4e07dbd005918
+      revision: pull/333/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the Zephyr revision to include LPPDM IRQ handling changes.
depends on: [zephyr_alif/pull/333](https://github.com/alifsemi/zephyr_alif/pull/333)