### PR TITLE
manifest: update zephyr revision to include board target cleanups

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 3220a641d1257a815b6544221689cec1d8c13bad
+      revision: 3dd2298fde86afe8d7e5aac9d9128a8aade1aa21
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to include the clean up of alif_e3_dk and alif_e4_dk.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/371