### PR TITLE
tests: drivers: crc: extend coverage for CRC8, CRC16, CRC32 and CRC32C

### DIFF
--- a/tests/drivers/crc/CMakeLists.txt
+++ b/tests/drivers/crc/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(alif_crc)
+
+target_sources(app PRIVATE
+	src/main.c
+	src/software_crc.c
+)
+
+target_sources_ifdef(CONFIG_TEST_CRC_8 app PRIVATE src/test_crc_8.c)
+target_sources_ifdef(CONFIG_TEST_CRC_16 app PRIVATE src/test_crc_16.c)
+target_sources_ifdef(CONFIG_TEST_CRC_16_ALT app PRIVATE src/test_crc_16_alt.c)
+target_sources_ifdef(CONFIG_TEST_CRC_32 app PRIVATE src/test_crc_32.c)
+target_sources_ifdef(CONFIG_TEST_CRC_32C app PRIVATE src/test_crc_32c.c)
+target_sources_ifdef(CONFIG_TEST_CRC_STRESS app PRIVATE
+		     src/test_crc_stress.c)

--- a/tests/drivers/crc/Kconfig
+++ b/tests/drivers/crc/Kconfig
@@ -1,0 +1,81 @@
+
+menu "Alif CRC test options"
+
+config TEST_CRC_ALL
+	bool "Enable all CRC test suites"
+	select TEST_CRC_8
+	select TEST_CRC_16
+	select TEST_CRC_16_ALT
+	select TEST_CRC_32
+	select TEST_CRC_32C
+	help
+	  Enable all CRC algorithm test suites (CRC-8, CRC-16-CCITT,
+	  CRC-16, CRC-32, CRC-32C) in a single configuration.
+
+config TEST_CRC_8
+	bool "Test CRC 8-bit CCITT algorithm"
+	default n
+	help
+	  This configuration enables comprehensive test cases for the 8-bit CRC
+	  CCITT algorithm implementation. The tests cover basic CRC computation,
+	  reflection modes, byte and bit swapping options, and output inversion
+	  capabilities to ensure robust functionality across various use cases.
+
+config TEST_CRC_16
+	bool "Test CRC 16-bit CCITT algorithm"
+	default n
+	help
+	  This configuration enables comprehensive test cases for the 16-bit CRC
+	  CCITT algorithm implementation. The tests cover basic CRC computation,
+	  reflection modes, byte and bit swapping options, and output inversion
+	  capabilities to ensure robust functionality across various use cases.
+
+config TEST_CRC_16_ALT
+	bool "Test CRC 16-bit alternate polynomial algorithm"
+	default n
+	help
+	  This configuration enables comprehensive test cases for the 16-bit CRC
+	  alternate polynomial implementation using polynomial 0x8005. The tests
+	  cover basic CRC computation, reflection modes, byte and bit swapping
+	  options, output inversion, single-byte input, and seed variation for
+	  the alternate 16-bit mode.
+
+config TEST_CRC_32
+	bool "Test CRC 32-bit algorithm"
+	default n
+	help
+	  This configuration enables comprehensive test cases for the 32-bit CRC
+	  algorithm implementation using the standard polynomial 0x04C11DB7.
+	  The tests validate basic CRC computation, reflection modes, byte and
+	  bit swapping options, output inversion, and compatibility with common
+	  CRC-32 applications.
+
+config TEST_CRC_32C
+	bool "Test CRC-32C (Castagnoli) algorithm"
+	default n
+	help
+	  This configuration enables test cases for the CRC-32C (Castagnoli)
+	  algorithm implementation using polynomial 0x1EDC6F41. CRC-32C is
+	  widely used in networking protocols including iSCSI, SCTP, and
+	  filesystem integrity checks in ext4 and Btrfs. Tests cover standard
+	  operations, reflection, swapping, and inversion modes.
+
+config TEST_CRC_STRESS
+	bool "CRC stress and robustness tests"
+	default n
+	help
+	  Enable runtime-driven stress tests that exercise driver resilience
+	  across all enabled CRC algorithms. Tests cover repeatability,
+	  back-to-back operations, boundary conditions, bit-flip sensitivity,
+	  parameter orthogonality, output width masking, and large data
+	  handling.
+
+	  Combine with any algorithm config (TEST_CRC_8, TEST_CRC_16,
+	  TEST_CRC_16_ALT, TEST_CRC_32, or TEST_CRC_32C) to run the
+	  corresponding stress vectors in a single image. The 32-bit variants
+	  additionally exercise the custom-polynomial path because that
+	  capability is exposed by the public driver API.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/tests/drivers/crc/README.rst
+++ b/tests/drivers/crc/README.rst
@@ -1,0 +1,254 @@
+.. _crc_ztest:
+
+.. zephyr:code-sample:: crc-test
+   :name: Alif CRC Driver Test Suite
+   :relevant-api: crc_interface
+
+   Validate Alif CRC hardware driver against software reference model.
+
+#########
+Overview
+#########
+
+This test suite validates the Alif CRC hardware driver implementation against
+a software reference model, ensuring correctness across all supported CRC
+algorithms and configurations.
+
+The Alif CRC driver provides hardware acceleration for common CRC algorithms.
+Tests cover functional correctness, edge cases, and stress scenarios.
+
+Supported Algorithms
+********************
+
+- **CRC-8**: Polynomial ``0x07`` (standard 8-bit CRC)
+- **CRC-16-CCITT**: Polynomial ``0x1021`` (X.25, Bluetooth, etc.)
+- **CRC-16**: Polynomial ``0x8005`` (IBM/modem protocol)
+- **CRC-32**: Polynomial ``0x04C11DB7`` (ISO 3309, PKZIP, etc.)
+- **CRC-32C**: Polynomial ``0x1EDC6F41`` (iSCSI, Btrfs, etc.)
+
+Features Tested
+****************
+
+Functional Tests:
+
+- Standard CRC computation with known test vectors
+- Output reflection (bit reversal)
+- Output inversion (bitwise NOT)
+- Byte swapping (endianness conversion)
+- Bit swapping (MSB/LSB reversal)
+- Single-byte payload handling
+- Unaligned memory access
+- Custom seed values
+
+Stress Tests:
+
+- High-volume data processing
+- Rapid configuration changes
+- Multi-algorithm concurrent testing
+- Resource exhaustion scenarios
+- Boundary condition testing
+- Hardware register stress
+
+Building and Running
+*********************
+
+The application will build only for a target that has a devicetree entry with
+:dt compatible:`alif,alif-crc` as a compatible.
+
+.. zephyr-app-commands::
+   :zephyr-app: tests/drivers/crc
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
+   :goals: build
+
+Configuration
+*************
+
+Enable CRC algorithms using Kconfig options:
+
+Core Algorithm Tests:
+
+- ``CONFIG_TEST_CRC_ALL``: Enable all CRC test suites
+- ``CONFIG_TEST_CRC_8``: Enable CRC-8 test suite
+- ``CONFIG_TEST_CRC_16``: Enable CRC-16-CCITT test suite
+- ``CONFIG_TEST_CRC_16_ALT``: Enable CRC-16 test suite
+- ``CONFIG_TEST_CRC_32``: Enable CRC-32 test suite
+- ``CONFIG_TEST_CRC_32C``: Enable CRC-32C test suite
+
+Stress Testing:
+
+- ``CONFIG_TEST_CRC_STRESS``: Enable stress testing for active algorithms
+
+Device Mapping
+**************
+
+- ``boards/crc0.overlay``: Maps CRC0 hardware instance to ``crc`` alias
+- ``boards/crc1.overlay``: Maps CRC1 hardware instance to ``crc`` alias
+
+Manual Build Examples
+=====================
+
+Single Algorithm - CRC0 with CRC-32:
+
+.. code-block:: console
+
+   west build -p -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+      tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_32=y
+
+E8 Platform - CRC0 with CRC-32:
+
+.. code-block:: console
+
+   west build -p -b alif_e8_dk/ae822f80f55d5xx/rtss_hp \
+      tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_32=y
+
+A5 Platform - CRC0 with CRC-32:
+
+.. code-block:: console
+
+   west build -p -b alif_a5_dk/aa522f80f55d5xx/rtss_he \
+      tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_32=y
+
+Single Algorithm - CRC1 with CRC-32C:
+
+.. code-block:: console
+
+   west build -p -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
+      tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc1.overlay \
+     -DCONFIG_TEST_CRC_32C=y
+
+Comprehensive Coverage - All Algorithms with Stress:
+
+E7 Platform:
+
+.. code-block:: console
+
+   west build -p -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+      tests/drivers/alif_crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_ALL=y -DCONFIG_TEST_CRC_STRESS=y
+
+E8 Platform:
+
+.. code-block:: console
+
+   west build -p -b alif_e8_dk/ae822f80f55d5xx/rtss_hp \
+      tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_ALL=y -DCONFIG_TEST_CRC_STRESS=y
+
+A5 Platform:
+
+.. code-block:: console
+
+   west build -p -b alif_a5_dk/aa522f80f55d5xx/rtss_hp \
+     tests/drivers/crc -- \
+     -DDTC_OVERLAY_FILE=boards/crc0.overlay \
+     -DCONFIG_TEST_CRC_ALL=y -DCONFIG_TEST_CRC_STRESS=y
+
+Twister Testing
+===============
+
+Execute the complete test matrix:
+
+.. code-block:: console
+
+   west twister -p alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+     -T tests/drivers/crc
+
+For E8 and A5 platforms:
+
+.. code-block:: console
+
+   west twister -p alif_e8_dk/ae822f80f55d5xx/rtss_hp \
+     -T tests/drivers/crc
+
+   west twister -p alif_a5_dk/aa522f80f55d5xx/rtss_he \
+     -T tests/drivers/crc
+
+Platform Support
+****************
+
+Supported Hardware:
+
+- **Alif E7 DK**: Development Kit with AE722F80F55D5XX SoC
+- **Alif E8 DK**: Development Kit with AE822F80F55D5XX SoC
+- **Alif A5 DK**: Development Kit with AA522F80F55D5XX SoC
+- **RTSS_HP**: High-performance real-time subsystem
+- **RTSS_HE**: High-efficiency real-time subsystem
+
+Hardware Instances:
+
+- **CRC0**: Primary CRC hardware accelerator
+- **CRC1**: Secondary CRC hardware accelerator
+
+Test Architecture
+******************
+
+Source Organization:
+
+- ``src/main.c``: Shared utilities, device validation, test framework
+- ``src/software_crc.c`` & ``src/software_crc.h``: Reference software
+- ``src/test_crc_8.c``: CRC-8 algorithm test suite
+- ``src/test_crc_16.c``: CRC-16-CCITT algorithm test suite
+- ``src/test_crc_16_alt.c``: CRC-16 algorithm test suite
+- ``src/test_crc_32.c``: CRC-32 algorithm test suite
+- ``src/test_crc_32c.c``: CRC-32C algorithm test suite
+- ``src/test_crc_stress.c``: Stress and robustness test suite
+
+Test Matrix
+===========
+
+The ``testcase.yaml`` defines test coverage:
+
+Instance Coverage:
+
+- **CRC0**: Tests on CRC0 hardware instance (alif_e7_dk/rtss_hp,
+  alif_e8_dk/rtss_hp, alif_a5_dk/rtss_hp)
+- **CRC1**: Tests on CRC1 hardware instance (alif_e7_dk/rtss_he,
+  alif_e8_dk/rtss_he, alif_a5_dk/rtss_he)
+
+Algorithm Coverage:
+
+- Individual algorithm testing for each CRC variant
+- Stress testing for each algorithm
+- Combined multi-algorithm testing
+
+Test Categories:
+
+1. **Functional Tests**: Validate correctness against known vectors
+2. **Stress Tests**: High-load and boundary condition testing
+3. **Integration Tests**: Multi-algorithm coexistence
+
+Troubleshooting
+****************
+
+Common Issues:
+
+Build Failures:
+
+- Ensure correct platform selection in build commands
+- Verify overlay file paths are correct
+- Check Kconfig conflicts between algorithms
+
+Runtime Failures:
+
+- Hardware initialization failures: Check device tree bindings
+- CRC mismatches: Verify polynomial and configuration parameters
+- Stress test timeouts: May indicate hardware resource contention
+
+Debug Tips:
+
+1. Enable general system logging: ``-DCONFIG_LOG=y``
+2. Set global log level to debug: ``-DCONFIG_LOG_DEFAULT_LEVEL=4``
+3. Use single-algorithm builds for isolated testing
+4. Verify hardware clock configuration
+5. Check memory alignment for large data buffers
+6. Enable driver-specific logging if available: ``-DCONFIG_DRV_LOG=y``
+

--- a/tests/drivers/crc/boards/crc0.overlay
+++ b/tests/drivers/crc/boards/crc0.overlay
@@ -1,0 +1,19 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+
+/ {
+	aliases {
+		crc = &crc0;
+	};
+};
+
+&crc0 {
+	status = "okay";
+};

--- a/tests/drivers/crc/boards/crc1.overlay
+++ b/tests/drivers/crc/boards/crc1.overlay
@@ -1,0 +1,18 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/ {
+	aliases {
+		crc = &crc1;
+	};
+};
+
+&crc1 {
+	status = "okay";
+};

--- a/tests/drivers/crc/prj.conf
+++ b/tests/drivers/crc/prj.conf
@@ -1,0 +1,10 @@
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_CRC_DRV=y
+CONFIG_ZTEST=y

--- a/tests/drivers/crc/src/main.c
+++ b/tests/drivers/crc/src/main.c
@@ -1,0 +1,68 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(alif_crc_test);
+
+const uint8_t crc_test_data[] = {0x67, 0x3F, 0x90, 0xC9, 0x25,
+				 0xF0, 0x4A, 0xB1, 0x13};
+
+const size_t crc_test_data_len = ARRAY_SIZE(crc_test_data);
+
+const uint8_t crc_check_string[] = {'1', '2', '3', '4', '5',
+				    '6', '7', '8', '9'};
+
+const struct device *const crc_dev = DEVICE_DT_GET(DT_ALIAS(crc));
+
+/*
+ * Mirror the first field of the driver-private runtime data so the tests can
+ * steer the active CRC algorithm without changing the public driver API.
+ *
+ * This keeps multi-algorithm validation in a single image possible while the
+ * driver still selects its algorithm from devicetree at init time.
+ */
+struct crc_test_runtime_data {
+	uint8_t crc_algo;
+};
+
+void crc_test_force_hw_algo(enum test_crc_hw_algo algo)
+{
+	struct crc_test_runtime_data *data =
+		(struct crc_test_runtime_data *)crc_dev->data;
+
+	zassert_not_null(data, "CRC driver data not available");
+	zassert_true(algo <= TEST_CRC_HW_ALGO_CRC32C, "invalid CRC algo %u",
+		     (unsigned int)algo);
+
+	data->crc_algo = (uint8_t)algo;
+}
+
+uint32_t bit_reflect_n(uint32_t input, uint32_t width)
+{
+	uint32_t reflected = 0U;
+
+	for (uint32_t i = 0U; i < width; i++) {
+		if (input & BIT(i)) {
+			reflected |= BIT(width - 1U - i);
+		}
+	}
+
+	return reflected;
+}
+
+uint32_t bit_reflect_32(uint32_t input) { return bit_reflect_n(input, 32U); }
+
+void crc_test_verify_device(void)
+{
+	zassert_true(crc_dev != NULL, "CRC device not found");
+	zassert_true(device_is_ready(crc_dev), "CRC device not ready");
+	LOG_DBG("CRC device ready: %s", crc_dev->name);
+}

--- a/tests/drivers/crc/src/software_crc.c
+++ b/tests/drivers/crc/src/software_crc.c
@@ -1,0 +1,324 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <stdbool.h>
+#include "software_crc.h"
+#include <zephyr/sys/util.h>
+
+typedef struct crc_config_t {
+	int id;
+	int degree;
+	unsigned long poly;
+} crc_config_t;
+
+#define CRC_START_32 0xFFFFFFFFL
+
+static const crc_config_t crc_config[] = {
+	{CRC32_PRIME, 32, CRC32_POLY_NORMAL},
+	{CRC32C_PRIME, 32, CRC32C_HW_POLY},
+	{CRC16_802_15_4, 16, CRC16_CCITT_HW_POLY},
+	{CRC16_ALT, 16, CRC16_ALT_HW_POLY},
+	{CRC8_PRIME, 8, CRC8_HW_POLY},
+};
+
+static unsigned long crc_table[256] = {0};
+
+static const crc_config_t *find_config(int id)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(crc_config); i++) {
+		if (crc_config[i].id == id) {
+			return &crc_config[i];
+		}
+	}
+	return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+/* Table-driven version */
+/*---------------------------------------------------------------------------*/
+static unsigned long generate_mask(int degree)
+{
+	unsigned long half = (1ul << (degree / 2)) - 1;
+
+	return half << (degree / 2) | half;
+}
+
+static void generate_crc_table(const crc_config_t *config)
+{
+	int i, j;
+	unsigned long bit, crc;
+	unsigned long high_bit = (1ul << (config->degree - 1));
+	unsigned long mask = generate_mask(config->degree);
+
+	for (i = 0; i < 256; i++) {
+		crc = (unsigned long)i << (config->degree - 8);
+		for (j = 0; j < 8; j++) {
+			bit = crc & high_bit;
+			crc <<= 1;
+			if (bit) {
+				crc ^= config->poly;
+			}
+		}
+		crc_table[i] = crc & mask;
+	}
+}
+
+/*****************************************************************************/
+/* gen_crc - Return the CRC value for the data using the given CRC algorithm */
+/* int id : identifies the CRC algorithm */
+/* char *data : the data */
+/* size_t len : the size of the data */
+/*****************************************************************************/
+unsigned long gen_crc(int id, const unsigned char *data, size_t len)
+{
+	const crc_config_t *config = find_config(id);
+	unsigned long crc = 0;
+	unsigned long mask;
+	size_t i;
+
+	if (config == NULL) {
+		return 0U;
+	}
+
+	mask = generate_mask(config->degree);
+
+	if ((id == CRC32_PRIME) || (id == CRC32C_PRIME)) {
+		crc = 0xFFFFFFFFUL;
+	}
+
+	generate_crc_table(config);
+	for (i = 0; i < len; i++) {
+		unsigned int datum = data[i];
+
+		/*
+		 * This loop handles 16-bit chars when we compile on 16-bit
+		 * machines.
+		 */
+		int n;
+
+		for (n = 0; n < (CHAR_BIT / 8); n++) {
+			unsigned long octet = ((datum >> (8 * n)) & 0xff);
+			unsigned long term1 = (crc << 8);
+			int idx =
+				((crc >> (config->degree - 8)) & 0xff) ^ octet;
+
+			crc = term1 ^ crc_table[idx];
+		}
+	}
+	return crc & mask;
+}
+
+/*****************************************************************************/
+/* 32 Bit CRC */
+/*****************************************************************************/
+static void init_crc32_tab(unsigned long CRC_POLY_32);
+static uint32_t crc_tab32[256];
+
+/*
+ * uint32_t crc_32(const unsigned char *input_str, size_t num_bytes,
+ *                  unsigned long CRC_POLY_32);
+ *
+ * The function crc_32() calculates in one pass the common 32 bit CRC value for
+ * a byte string that is passed to the function together with a parameter
+ * indicating the length.
+ */
+uint32_t crc_32(const unsigned char *input_str, size_t num_bytes,
+		unsigned long CRC_POLY_32)
+{
+
+	uint32_t crc;
+	uint32_t tmp;
+	uint32_t long_c;
+	const unsigned char *ptr;
+	size_t a;
+
+	init_crc32_tab(CRC_POLY_32);
+	crc = CRC_START_32;
+	ptr = input_str;
+	if (ptr != NULL) {
+		for (a = 0; a < num_bytes; a++) {
+			long_c = 0x000000FFL & (uint32_t)*ptr;
+			tmp = crc ^ long_c;
+			crc = (crc >> 8) ^ crc_tab32[tmp & 0xff];
+			ptr++;
+		}
+	}
+	crc ^= 0xffffffffL;
+	return crc & 0xffffffffL;
+}
+
+/*
+ * static void init_crc32_tab(unsigned long CRC_POLY_32);
+ *
+ * For optimal speed, the CRC32 calculation uses a table with pre-calculated
+ * bit patterns which are used in the XOR operations in the program. This table
+ * is generated once, the first time the CRC update routine is called.
+ */
+static void init_crc32_tab(unsigned long CRC_POLY_32)
+{
+	uint32_t i;
+	uint32_t j;
+	uint32_t crc;
+
+	for (i = 0; i < 256; i++) {
+		crc = i;
+		for (j = 0; j < 8; j++) {
+			if (crc & 0x00000001L) {
+				crc = (crc >> 1) ^ CRC_POLY_32;
+			} else {
+				crc = crc >> 1;
+			}
+		}
+		crc_tab32[i] = crc;
+	}
+}
+
+uint32_t crc32_update_msb(uint32_t crc, uint8_t data, uint32_t poly)
+{
+	crc ^= ((uint32_t)data << 24);
+
+	for (int bit = 0; bit < 8; bit++) {
+		if (crc & 0x80000000U) {
+			crc = (crc << 1) ^ poly;
+		} else {
+			crc <<= 1;
+		}
+	}
+
+	return crc;
+}
+
+uint32_t crc32_update_msb_word(uint32_t crc, const uint8_t *word, bool bit_swap,
+			       bool byte_swap, uint32_t poly)
+{
+	for (int i = 0; i < 4; i++) {
+		const int src = byte_swap ? i : (3 - i);
+		uint8_t byte = word[src];
+
+		if (bit_swap) {
+			byte = (uint8_t)bit_reflect_n(byte, 8);
+		}
+
+		crc = crc32_update_msb(crc, byte, poly);
+	}
+
+	return crc;
+}
+
+uint32_t crc32_sw_unaligned(uint32_t crc, const uint8_t *input, uint32_t length,
+			    uint32_t poly)
+{
+	uint32_t poly_refl = bit_reflect_32(poly);
+
+	for (uint32_t byte_idx = 0; byte_idx < length; byte_idx++) {
+		uint8_t data = input[byte_idx];
+
+		for (uint32_t bit_idx = 0; bit_idx < 8; bit_idx++) {
+			uint32_t check_bit = (crc ^ data) & 1U;
+
+			crc >>= 1;
+			if (check_bit) {
+				crc ^= poly_refl;
+			}
+			data >>= 1;
+		}
+	}
+
+	return ~crc;
+}
+
+uint32_t crc32_driver_reference(const uint8_t *data, size_t len, uint32_t seed,
+				bool bit_swap, bool byte_swap, bool reflect,
+				bool invert, uint32_t poly_normal,
+				uint32_t poly_reflected)
+{
+	uint32_t crc = seed;
+	uint32_t aligned_len = len - (len % 4);
+	uint32_t unaligned_len = len % 4;
+	const uint8_t *tail = data + aligned_len;
+
+	ARG_UNUSED(poly_reflected);
+
+	/* --- Aligned phase: feed LE32 words (MSB-first engine) --- */
+	for (uint32_t off = 0; off < aligned_len; off += 4) {
+		crc = crc32_update_msb_word(crc, &data[off], bit_swap,
+					    byte_swap, poly_normal);
+	}
+
+	/*
+	 * HW applies reflect + invert to CRC_OUT automatically.
+	 * Apply the same transforms so we match the value that
+	 * crc_calculate_32bit_unaligned_sw receives as input.
+	 */
+	if (reflect) {
+		crc = bit_reflect_32(crc);
+	}
+	if (invert) {
+		crc = ~crc;
+	}
+
+	/* --- Unaligned tail: replicate driver SW fallback --- */
+	if (unaligned_len > 0) {
+		if (invert) {
+			crc = ~crc;
+		}
+		if (!reflect) {
+			crc = bit_reflect_32(crc);
+		}
+
+		crc = crc32_sw_unaligned(crc, tail, unaligned_len, poly_normal);
+
+		if (!reflect) {
+			crc = bit_reflect_32(crc);
+		}
+		if (!invert) {
+			crc = ~crc;
+		}
+	}
+
+	return crc;
+}
+
+uint32_t crc32_full_reference(const uint8_t *data, size_t len)
+{
+	return crc32_driver_reference(data, len, 0xFFFFFFFFU, true, true, true,
+				      true, CRC32_POLY_NORMAL,
+				      CRC32_POLY_REFLECTED);
+}
+
+uint32_t crc32c_full_reference(const uint8_t *data, size_t len)
+{
+	return crc32_driver_reference(data, len, 0xFFFFFFFFU, true, true, true,
+				      true, CRC32C_HW_POLY,
+				      CRC32C_SW_POLY_REFL);
+}
+
+uint32_t custom_poly_crc(const uint8_t *data, size_t len, uint32_t poly,
+			 uint32_t bits)
+{
+	uint32_t crc = 0; /* Seed 0, no invert */
+	uint32_t mask = (bits == 32U) ? UINT32_MAX : ((1U << bits) - 1U);
+
+	for (size_t i = 0; i < len; i++) {
+		crc ^= (uint32_t)data[i] << (bits - 8U);
+		for (int j = 0; j < 8; j++) {
+			if (crc & BIT(bits - 1U)) {
+				crc = (crc << 1) ^ poly;
+			} else {
+				crc <<= 1;
+			}
+			crc &= mask;
+		}
+	}
+
+	return crc;
+}
+

--- a/tests/drivers/crc/src/software_crc.h
+++ b/tests/drivers/crc/src/software_crc.h
@@ -1,0 +1,115 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+#ifndef SOFTWARE_CRC_H_
+#define SOFTWARE_CRC_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/crc.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+/* Software reference algorithm identifiers used by gen_crc(). */
+#define CRC32_PRIME 0
+#define CRC16_802_15_4 1
+#define CRC16_ALT 2
+#define CRC8_PRIME 3
+#define CRC32C_PRIME 4
+
+/*
+ * Keep this compatibility alias so local test edits that use CRC32C as an ID
+ * continue to build. The canonical software-reference ID is CRC32C_PRIME.
+ */
+#define CRC32C CRC32C_PRIME
+
+#define CRC_TRUE 1
+#define CRC_FALSE 0
+
+#ifndef CHAR_BIT
+#define CHAR_BIT 8
+#endif
+
+/* Standard hardware polynomials used by the software reference model. */
+#define CRC8_HW_POLY 0x07UL
+#define CRC16_CCITT_HW_POLY 0x1021UL
+#define CRC16_HW_POLY 0x8005UL
+
+/* Keep the existing test-facing name for the non-CCITT 16-bit polynomial. */
+#define CRC16_ALT_HW_POLY CRC16_HW_POLY
+
+/* Additional polynomials used by the extended test matrix. */
+#define CRC16_CUSTOM_TEST_POLY 0xA001UL
+#define CRC8_CUSTOM_TEST_POLY 0x9BUL
+#define CRC32C_HW_POLY 0x1EDC6F41UL
+#define CRC32C_SW_POLY_REFL 0x82F63B78UL
+#define CRC32_CUSTOM_HW_POLY 0x2CEEA6C8UL
+#define CRC32_CUSTOM_SW_POLY_REFL 0x13657734UL
+#define CRC32_POLY_NORMAL 0x04C11DB7UL
+#define CRC32_POLY_REFLECTED 0xEDB88320UL
+
+enum test_crc_hw_algo {
+	TEST_CRC_HW_ALGO_CRC8_CCITT = 0,
+	TEST_CRC_HW_ALGO_CRC16 = 1,
+	TEST_CRC_HW_ALGO_CRC16_CCITT = 2,
+	TEST_CRC_HW_ALGO_CRC32 = 3,
+	TEST_CRC_HW_ALGO_CRC32C = 4,
+};
+
+/*
+ * Test-side runtime algorithm selection and common device validation.
+ *
+ * The current driver still fixes its algorithm from devicetree at init time,
+ * so the test suite mirrors the first byte of the driver runtime data in
+ * order to exercise multiple algorithms from one image.
+ */
+void crc_test_force_hw_algo(enum test_crc_hw_algo algo);
+void crc_test_verify_device(void);
+
+/* Shared test input data (defined in main.c). */
+extern const uint8_t crc_test_data[];
+extern const size_t crc_test_data_len;
+
+/* CRC device handle (defined in main.c). */
+extern const struct device *const crc_dev;
+
+/* Shared CRC check string "123456789" - canonical CRC test vector. */
+extern const uint8_t crc_check_string[];
+
+#define CRC_CHECK_STRING_LEN 9
+
+/* Bit-reflect helpers (defined in main.c). */
+uint32_t bit_reflect_n(uint32_t input, uint32_t width);
+uint32_t bit_reflect_32(uint32_t input);
+
+/* CRC32 driver-path reference helpers. */
+uint32_t crc32_update_msb(uint32_t crc, uint8_t data, uint32_t poly);
+uint32_t crc32_update_msb_word(uint32_t crc, const uint8_t *word, bool bit_swap,
+			       bool byte_swap, uint32_t poly);
+uint32_t crc32_sw_unaligned(uint32_t crc, const uint8_t *input, uint32_t length,
+			    uint32_t poly);
+uint32_t crc32_driver_reference(const uint8_t *data, size_t len, uint32_t seed,
+				bool bit_swap, bool byte_swap, bool reflect,
+				bool invert, uint32_t poly_normal,
+				uint32_t poly_reflected);
+
+/* Convenience functions for standard CRC32 configurations. */
+uint32_t crc32_full_reference(const uint8_t *data, size_t len);
+uint32_t crc32c_full_reference(const uint8_t *data, size_t len);
+
+unsigned long gen_crc(int id, const unsigned char *data, size_t len);
+
+uint32_t crc_32(const unsigned char *input_str, size_t num_bytes,
+		unsigned long crc_poly);
+
+uint32_t custom_poly_crc(const uint8_t *data, size_t len, uint32_t poly,
+			 uint32_t bits);
+
+#endif /* SOFTWARE_CRC_H_ */

--- a/tests/drivers/crc/src/test_crc_16.c
+++ b/tests/drivers/crc/src/test_crc_16.c
@@ -1,0 +1,238 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_16)
+
+static void crc_16_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC16_CCITT);
+}
+
+/* ZTC-1185 / ZTC-1186: Basic 16-bit CRC */
+ZTEST(crc_16_tests, test_crc_16_bit)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC16_802_15_4, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	LOG_INF("16-bit CRC SW output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1376: 16-bit CRC with reflected output */
+ZTEST(crc_16_tests, test_crc_16_bit_reflect_output_en)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC16_802_15_4, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 16);
+	LOG_INF("16-bit CRC SW output (reflected): 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1391: 16-bit CRC with bit/byte swap */
+ZTEST(crc_16_tests, test_crc_16_bit_swap_en)
+{
+	uint32_t crc_output, software_output;
+	uint8_t input[] = {0x67, 0x37};
+	uint8_t reflected_input[] = {0xE6, 0xEC};
+	struct crc_params params = {
+		.data_in = (uint8_t *)input,
+		.len = ARRAY_SIZE(input),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW output: 0x%X", crc_output);
+
+	software_output = gen_crc(CRC16_802_15_4, reflected_input,
+				  sizeof(reflected_input));
+	LOG_INF("16-bit CRC SW output (swapped): 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1393: 16-bit CRC with inverted output */
+ZTEST(crc_16_tests, test_crc_16_bit_invert_output)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC16_802_15_4, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = (software_output ^ 0xFFFF);
+	LOG_INF("16-bit CRC SW output (inverted): 0x%X", software_output);
+
+	crc_output = (crc_output & 0xFFFF);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-NEW: 16-bit CRC with single byte input */
+ZTEST(crc_16_tests, test_crc_16_bit_single_byte)
+{
+	uint32_t crc_output, software_output;
+	uint8_t single_byte[] = {0x55};
+	struct crc_params params = {
+		.data_in = single_byte,
+		.len = 1,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW single byte output: 0x%X", crc_output);
+
+	software_output = gen_crc(CRC16_802_15_4, single_byte, 1);
+	LOG_INF("16-bit CRC SW single byte output: 0x%X", software_output);
+
+	zassert_equal((crc_output & 0xFFFF), software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", (crc_output & 0xFFFF),
+		      software_output);
+}
+
+/* ZTC-NEW: 16-bit CRC with non-zero seed */
+ZTEST(crc_16_tests, test_crc_16_bit_nonzero_seed)
+{
+	uint32_t crc_seed0 = 0, crc_seedFFFF = 0;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_seed0,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "seed 0 failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute seed 0");
+
+	params.data_out = &crc_seedFFFF;
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFF), 0, "seed FFFF failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute seed FFFF");
+
+	LOG_INF("16-bit CRC seed=0x0000: 0x%X, seed=0xFFFF: 0x%X", crc_seed0,
+		crc_seedFFFF);
+
+	zassert_not_equal((crc_seed0 & 0xFFFF), (crc_seedFFFF & 0xFFFF),
+			  "Different seeds produced same 16-bit CRC: 0x%X",
+			  (crc_seed0 & 0xFFFF));
+}
+
+/* ZTC-NEW: 16-bit CRC with reflect + invert combined */
+ZTEST(crc_16_tests, test_crc_16_bit_reflect_invert_combined)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("16-bit CRC HW reflect+invert output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC16_802_15_4, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 16);
+	software_output = (software_output ^ 0xFFFF);
+	LOG_INF("16-bit CRC SW reflect+invert output: 0x%X", software_output);
+
+	zassert_equal((crc_output & 0xFFFF), software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", (crc_output & 0xFFFF),
+		      software_output);
+}
+
+ZTEST_SUITE(crc_16_tests, NULL, NULL, crc_16_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_16 */

--- a/tests/drivers/crc/src/test_crc_16_alt.c
+++ b/tests/drivers/crc/src/test_crc_16_alt.c
@@ -1,0 +1,217 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_16_ALT)
+
+static void crc_16_alt_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC16);
+}
+
+static uint32_t crc16_alt_sw(const uint8_t *data, size_t len)
+{
+	return gen_crc(CRC16_ALT, data, len);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc16_alt_sw(crc_test_data, crc_test_data_len);
+	LOG_INF("16-bit ALT HW output: 0x%X", crc_output);
+	LOG_INF("16-bit ALT SW output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_reflect_output_en)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc16_alt_sw(crc_test_data, crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 16);
+	zassert_equal(crc_output & 0xFFFF, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output & 0xFFFF,
+		      software_output);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_bit_swap_en)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	uint8_t input[] = {0x67, 0x37};
+	uint8_t reflected_input[] = {0xE6, 0xEC};
+	struct crc_params params = {
+		.data_in = input,
+		.len = ARRAY_SIZE(input),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output =
+		crc16_alt_sw(reflected_input, ARRAY_SIZE(reflected_input));
+	zassert_equal(crc_output & 0xFFFF, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output & 0xFFFF,
+		      software_output);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_invert_output)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output =
+		crc16_alt_sw(crc_test_data, crc_test_data_len) ^ 0xFFFFU;
+	zassert_equal(crc_output & 0xFFFF, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output & 0xFFFF,
+		      software_output);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_single_byte)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	uint8_t single_byte[] = {0x55};
+	struct crc_params params = {
+		.data_in = single_byte,
+		.len = ARRAY_SIZE(single_byte),
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc16_alt_sw(single_byte, ARRAY_SIZE(single_byte));
+	zassert_equal(crc_output & 0xFFFF, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output & 0xFFFF,
+		      software_output);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_nonzero_seed)
+{
+	uint32_t crc_seed0 = 0;
+	uint32_t crc_seedffff = 0;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_seed0,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "seed 0 failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "compute seed 0 failed");
+
+	params.data_out = &crc_seedffff;
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFF), 0, "seed FFFF failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "compute seed FFFF failed");
+
+	zassert_not_equal(crc_seed0 & 0xFFFF, crc_seedffff & 0xFFFF,
+			  "Different seeds produced same CRC16_ALT: 0x%X",
+			  crc_seed0 & 0xFFFF);
+}
+
+ZTEST(crc_16_alt_tests, test_crc_16_alt_reflect_invert_combined)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE, /* Use native hardware support */
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x0000), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc16_alt_sw(crc_test_data, crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 16);
+	software_output = (software_output ^ 0xFFFF);
+	zassert_equal(crc_output & 0xFFFF, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output & 0xFFFF,
+		      software_output);
+}
+
+ZTEST_SUITE(crc_16_alt_tests, NULL, NULL, crc_16_alt_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_16_ALT */

--- a/tests/drivers/crc/src/test_crc_32.c
+++ b/tests/drivers/crc/src/test_crc_32.c
@@ -1,0 +1,407 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_32)
+
+static void crc_32_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC32);
+}
+
+/* CRC32_POLY_REFLECTED now defined in test_crc_common.h */
+
+static void crc32_validate_native_mode(const uint8_t *data, size_t len,
+				       uint32_t *crc_output)
+{
+	struct crc_params params = {
+		.data_in = data,
+		.len = len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = crc_output,
+	};
+	uint32_t software_output;
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc32_full_reference(data, len);
+	zassert_equal(*crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", *crc_output,
+		      software_output);
+}
+
+/* ZTC-1377 / ZTC-1379: Standard 32-bit CRC (full mode: */
+/* swap + reflect + invert) */
+ZTEST(crc_32_tests, test_crc_32_bit)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference((const uint8_t *)crc_test_data,
+					       crc_test_data_len);
+	LOG_INF("32-bit CRC SW output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1187: 32-bit CRC with reflect output disabled */
+ZTEST(crc_32_tests, test_crc_32_bit_reflect_output_disable)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW output: 0x%X", crc_output);
+
+	software_output = crc32_driver_reference(
+		(const uint8_t *)crc_test_data, crc_test_data_len, 0xFFFFFFFFU,
+		true, true, false, true, CRC32_POLY_NORMAL,
+		CRC32_POLY_REFLECTED);
+	LOG_INF("32-bit CRC SW output (reflect disabled): 0x%X",
+		software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-NEW: 32-bit CRC with unaligned length (5 bytes — */
+/* exercises SW fallback) */
+ZTEST(crc_32_tests, test_crc_32_bit_unaligned_5_bytes)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_5[] = {0x67, 0x3F, 0x90, 0xC9, 0x25};
+	struct crc_params params = {
+		.data_in = data_5,
+		.len = 5,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW 5-byte output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference(data_5, 5);
+	LOG_INF("32-bit CRC SW 5-byte output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch (5-byte unaligned): 0x%X != 0x%X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: 32-bit CRC with unaligned length (7 bytes) */
+ZTEST(crc_32_tests, test_crc_32_bit_unaligned_7_bytes)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_7[] = {0x67, 0x3F, 0x90, 0xC9, 0x25, 0xF0, 0x4A};
+	struct crc_params params = {
+		.data_in = data_7,
+		.len = 7,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW 7-byte output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference(data_7, 7);
+	LOG_INF("32-bit CRC SW 7-byte output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch (7-byte unaligned): 0x%X != 0x%X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: 32-bit CRC with unaligned length (1 byte — all SW fallback) */
+ZTEST(crc_32_tests, test_crc_32_bit_unaligned_1_byte)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_1[] = {0xAB};
+	struct crc_params params = {
+		.data_in = data_1,
+		.len = 1,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW 1-byte output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference(data_1, 1);
+	LOG_INF("32-bit CRC SW 1-byte output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch (1-byte unaligned): 0x%X != 0x%X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: 32-bit CRC with exactly 4-byte aligned length */
+ZTEST(crc_32_tests, test_crc_32_bit_aligned_4_bytes)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_4[] = {0x67, 0x3F, 0x90, 0xC9};
+	struct crc_params params = {
+		.data_in = data_4,
+		.len = 4,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW 4-byte output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference(data_4, 4);
+	LOG_INF("32-bit CRC SW 4-byte output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch (4-byte aligned): 0x%X != 0x%X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: 32-bit CRC with 8-byte aligned length */
+ZTEST(crc_32_tests, test_crc_32_bit_aligned_8_bytes)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_8[] = {0x67, 0x3F, 0x90, 0xC9, 0x25, 0xF0, 0x4A, 0xB1};
+	struct crc_params params = {
+		.data_in = data_8,
+		.len = 8,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("32-bit CRC HW 8-byte output: 0x%X", crc_output);
+
+	software_output = crc32_full_reference(data_8, 8);
+	LOG_INF("32-bit CRC SW 8-byte output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch (8-byte aligned): 0x%X != 0x%X",
+		      crc_output, software_output);
+}
+
+ZTEST(crc_32_tests, test_crc_32_bit_single_byte)
+{
+	uint32_t crc_output;
+	uint32_t software_output;
+	uint8_t single_byte[] = {0x55};
+	struct crc_params params = {
+		.data_in = single_byte,
+		.len = ARRAY_SIZE(single_byte),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output =
+		crc32_full_reference(single_byte, ARRAY_SIZE(single_byte));
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+ZTEST(crc_32_tests, test_crc_32_bit_misaligned_ptr_aligned_len)
+{
+	uint32_t crc_output = 0U;
+	uint8_t raw_data[] = {0xA5, 0x67, 0x3F, 0x90, 0xC9,
+			      0x25, 0xF0, 0x4A, 0xB1};
+	const uint8_t *misaligned = &raw_data[1];
+
+	zassert_true((((uintptr_t)misaligned) & 0x3U) != 0U,
+		     "test buffer is unexpectedly aligned");
+
+	crc32_validate_native_mode(misaligned, 8U, &crc_output);
+}
+
+ZTEST(crc_32_tests, test_crc_32_bit_misaligned_ptr_tail_len)
+{
+	uint32_t crc_output = 0U;
+	uint8_t raw_data[] = {0x5A, 0x67, 0x3F, 0x90, 0xC9, 0x25, 0xF0, 0x4A};
+	const uint8_t *misaligned = &raw_data[1];
+
+	zassert_true((((uintptr_t)misaligned) & 0x3U) != 0U,
+		     "test buffer is unexpectedly aligned");
+
+	crc32_validate_native_mode(misaligned, 7U, &crc_output);
+}
+
+ZTEST(crc_32_tests, test_stress_vector_123456789)
+{
+	uint32_t crc_hw = 0;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = crc_check_string,
+		.len = CRC_CHECK_STRING_LEN,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_TRUE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_set_polynomial(crc_dev, CRC32_POLY_NORMAL), 0,
+		      "set CRC-32 polynomial failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute failed");
+
+	crc_sw = crc32_full_reference(crc_check_string, CRC_CHECK_STRING_LEN);
+
+	zassert_equal(crc_hw, crc_sw,
+		      "CRC-32 full known vector mismatch: HW=0x%X SW=0x%X",
+		      crc_hw, crc_sw);
+}
+
+ZTEST(crc_32_tests, test_stress_32x_std_repeat)
+{
+	uint32_t crc_first = 0;
+	uint32_t crc_repeat = 0;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_first,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute first failed");
+
+	crc_sw = crc32_full_reference((const uint8_t *)crc_test_data,
+				      crc_test_data_len);
+	zassert_equal(crc_first, crc_sw,
+		      "CRC-32 full HW/SW mismatch: HW=0x%X SW=0x%X", crc_first,
+		      crc_sw);
+
+	for (int i = 0; i < 50; i++) {
+		params.data_out = &crc_repeat;
+		zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0,
+			      "seed iter %d failed", i);
+		zassert_equal(crc_compute(crc_dev, &params), 0,
+			      "compute iter %d failed", i);
+		zassert_equal(crc_first, crc_repeat,
+			      "CRC-32 full repeatability iter %d: 0x%X != 0x%X",
+			      i, crc_first, crc_repeat);
+	}
+}
+
+ZTEST(crc_32_tests, test_stress_unaligned_7_bytes)
+{
+	uint32_t crc_hw = 0;
+	uint32_t crc_sw;
+	uint8_t unaligned_data[7] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE};
+	struct crc_params params = {
+		.data_in = unaligned_data,
+		.len = sizeof(unaligned_data),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_TRUE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_set_polynomial(crc_dev, CRC32_POLY_NORMAL), 0,
+		      "set CRC-32 polynomial failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute failed");
+
+	crc_sw = crc32_full_reference(unaligned_data, sizeof(unaligned_data));
+
+	zassert_equal(crc_hw, crc_sw,
+		      "CRC-32 full unaligned tail mismatch: HW=0x%X SW=0x%X",
+		      crc_hw, crc_sw);
+}
+
+ZTEST_SUITE(crc_32_tests, NULL, NULL, crc_32_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_32 */

--- a/tests/drivers/crc/src/test_crc_32c.c
+++ b/tests/drivers/crc/src/test_crc_32c.c
@@ -1,0 +1,383 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_32C)
+
+static void crc_32c_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC32C);
+}
+
+/* CRC-32C polynomial constants now defined in test_crc_common.h */
+
+/* Known CRC-32C check value: CRC32C("123456789") = 0xE3069283 */
+#define CRC32C_CHECK_VALUE 0xE3069283UL
+
+static void crc32c_validate(const uint8_t *data, size_t len, bool custom_poly,
+			    uint32_t *crc_output)
+{
+	struct crc_params params = {
+		.data_in = data,
+		.len = len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = custom_poly,
+		.data_out = crc_output,
+	};
+	uint32_t software_output;
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0,
+		      "CRC set seed failed");
+	if (custom_poly) {
+		zassert_equal(crc_set_polynomial(crc_dev, CRC32C_HW_POLY), 0,
+			      "CRC set CRC-32C polynomial failed");
+	}
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+
+	software_output = crc32c_full_reference(data, len);
+	zassert_equal(*crc_output, software_output,
+		      "HW/SW CRC-32C mismatch: HW=0x%08X SW=0x%08X",
+		      *crc_output, software_output);
+}
+
+/* ZTC-NEW: Basic CRC-32C (Castagnoli) with standard test vector */
+ZTEST(crc_32c_tests, test_crc_32c_basic)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = crc_check_string,
+		.len = CRC_CHECK_STRING_LEN,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("CRC-32C HW output for '123456789': 0x%08X", crc_output);
+
+	software_output =
+		crc32c_full_reference(crc_check_string, CRC_CHECK_STRING_LEN);
+	LOG_INF("CRC-32C SW output for '123456789': 0x%08X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC-32C mismatch: HW=0x%08X SW=0x%08X", crc_output,
+		      software_output);
+
+	/* Validate against known check value */
+	zassert_equal(
+		software_output, CRC32C_CHECK_VALUE,
+		"CRC-32C known vector mismatch: got=0x%08X expected=0x%08X",
+		software_output, CRC32C_CHECK_VALUE);
+
+	LOG_INF("CRC-32C '123456789' = 0x%08X (expected 0x%08X)",
+		software_output, (uint32_t)CRC32C_CHECK_VALUE);
+	LOG_INF("CRC-32C '123456789' check passed.");
+}
+
+ZTEST(crc_32c_tests, test_crc_32c_custom_poly_matches_native)
+{
+	uint32_t crc_output = 0U;
+
+	crc32c_validate(crc_check_string, CRC_CHECK_STRING_LEN, true,
+			&crc_output);
+	zassert_equal(crc_output, CRC32C_CHECK_VALUE,
+		      "CRC-32C custom polynomial mismatch: 0x%08X", crc_output);
+}
+
+/* ZTC-NEW: CRC-32C with test_data (HW vs SW) */
+ZTEST(crc_32c_tests, test_crc_32c_test_data)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("CRC-32C HW test_data output: 0x%08X", crc_output);
+
+	software_output = crc32c_full_reference((const uint8_t *)crc_test_data,
+						crc_test_data_len);
+	LOG_INF("CRC-32C SW test_data output: 0x%08X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC-32C mismatch: HW=0x%08X SW=0x%08X", crc_output,
+		      software_output);
+}
+
+/* ZTC-NEW: CRC-32C with reflect output disabled */
+ZTEST(crc_32c_tests, test_crc_32c_reflect_output_disable)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("CRC-32C HW reflect-disabled output: 0x%08X", crc_output);
+
+	software_output = crc32_driver_reference(
+		(const uint8_t *)crc_test_data, crc_test_data_len, 0xFFFFFFFFU,
+		true, true, false, true, CRC32C_HW_POLY, CRC32C_SW_POLY_REFL);
+	LOG_INF("CRC-32C SW reflect-disabled output: 0x%08X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "CRC-32C reflect-disabled mismatch: HW=0x%08X SW=0x%08X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: CRC-32C with unaligned 5-byte input */
+ZTEST(crc_32c_tests, test_crc_32c_unaligned_5_bytes)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_5[] = {0x67, 0x3F, 0x90, 0xC9, 0x25};
+	struct crc_params params = {
+		.data_in = data_5,
+		.len = 5,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("CRC-32C HW 5-byte output: 0x%08X", crc_output);
+
+	software_output = crc32c_full_reference(data_5, 5);
+	LOG_INF("CRC-32C SW 5-byte output: 0x%08X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC-32C mismatch (5-byte): HW=0x%08X SW=0x%08X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: CRC-32C with single byte input */
+ZTEST(crc_32c_tests, test_crc_32c_single_byte)
+{
+	uint32_t crc_output, software_output;
+	uint8_t data_1[] = {0xAB};
+	struct crc_params params = {
+		.data_in = data_1,
+		.len = 1,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0,
+		      "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("CRC-32C HW single-byte output: 0x%08X", crc_output);
+
+	software_output = crc32c_full_reference(data_1, 1);
+	LOG_INF("CRC-32C SW single-byte output: 0x%08X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC-32C mismatch (1-byte): HW=0x%08X SW=0x%08X",
+		      crc_output, software_output);
+}
+
+/* ZTC-NEW: CRC-32C vs CRC-32 — verify different */
+/* polynomials produce different results */
+ZTEST(crc_32c_tests, test_crc_32c_vs_crc32_different)
+{
+	uint32_t crc_32c_out = 0, crc_32_out = 0;
+	uint32_t crc_32c_sw;
+	uint32_t crc_32_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_32c_out,
+	};
+
+	/* Compute native CRC-32C */
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC32C);
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "CRC-32C compute failed");
+	crc_32c_sw = crc32c_full_reference((const uint8_t *)crc_test_data,
+					   crc_test_data_len);
+	zassert_equal(crc_32c_out, crc_32c_sw,
+		      "CRC-32C native mismatch: HW=0x%08X SW=0x%08X",
+		      crc_32c_out, crc_32c_sw);
+
+	/*
+	 * Switch to native CRC-32 to verify algorithm selection, not just the
+	 * programmed polynomial.
+	 */
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC32);
+	params.data_out = &crc_32_out;
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFF), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "CRC-32 compute failed");
+	crc_32_sw = crc32_full_reference((const uint8_t *)crc_test_data,
+					 crc_test_data_len);
+	zassert_equal(crc_32_out, crc_32_sw,
+		      "CRC-32 native mismatch: HW=0x%08X SW=0x%08X", crc_32_out,
+		      crc_32_sw);
+
+	LOG_INF("CRC-32C=0x%08X, CRC-32=0x%08X", crc_32c_out, crc_32_out);
+
+	zassert_not_equal(crc_32c_out, crc_32_out,
+			  "CRC-32C and CRC-32 matched unexpectedly: 0x%08X",
+			  crc_32c_out);
+}
+
+ZTEST(crc_32c_tests, test_crc_32c_misaligned_ptr_aligned_len)
+{
+	uint32_t crc_output = 0U;
+	uint8_t raw_data[] = {0xA5, 0x67, 0x3F, 0x90, 0xC9,
+			      0x25, 0xF0, 0x4A, 0xB1};
+	const uint8_t *misaligned = &raw_data[1];
+
+	zassert_true((((uintptr_t)misaligned) & 0x3U) != 0U,
+		     "test buffer is unexpectedly aligned");
+
+	crc32c_validate(misaligned, 8U, false, &crc_output);
+}
+
+ZTEST(crc_32c_tests, test_crc_32c_misaligned_ptr_tail_len)
+{
+	uint32_t crc_output = 0U;
+	uint8_t raw_data[] = {0x5A, 0x67, 0x3F, 0x90, 0xC9, 0x25, 0xF0, 0x4A};
+	const uint8_t *misaligned = &raw_data[1];
+
+	zassert_true((((uintptr_t)misaligned) & 0x3U) != 0U,
+		     "test buffer is unexpectedly aligned");
+
+	crc32c_validate(misaligned, 7U, false, &crc_output);
+}
+
+ZTEST(crc_32c_tests, test_stress_unaligned_std_tail)
+{
+	uint32_t crc_hw = 0;
+	uint32_t crc_sw;
+	uint8_t unaligned_data[7] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE};
+	struct crc_params params = {
+		.data_in = unaligned_data,
+		.len = sizeof(unaligned_data),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute failed");
+
+	crc_sw = crc32c_full_reference(unaligned_data, sizeof(unaligned_data));
+
+	zassert_equal(crc_hw, crc_sw,
+		      "CRC-32C full unaligned tail mismatch: HW=0x%X SW=0x%X",
+		      crc_hw, crc_sw);
+}
+
+ZTEST(crc_32c_tests, test_stress_aligned_8_bytes)
+{
+	uint32_t crc_hw = 0;
+	uint32_t crc_sw;
+	uint8_t aligned_data[8] = {0x12, 0x34, 0x56, 0x78,
+				   0x9A, 0xBC, 0xDE, 0xF0};
+	struct crc_params params = {
+		.data_in = aligned_data,
+		.len = sizeof(aligned_data),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute failed");
+
+	crc_sw = crc32c_full_reference(aligned_data, sizeof(aligned_data));
+
+	zassert_equal(crc_hw, crc_sw,
+		      "CRC-32C full aligned tail mismatch: HW=0x%X SW=0x%X",
+		      crc_hw, crc_sw);
+}
+
+ZTEST(crc_32c_tests, test_stress_aligned_4_bytes)
+{
+	uint32_t crc_hw = 0;
+	uint32_t crc_sw;
+	uint8_t aligned_data[4] = {0x12, 0x34, 0x56, 0x78};
+	struct crc_params params = {
+		.data_in = aligned_data,
+		.len = sizeof(aligned_data),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0xFFFFFFFFU), 0, "seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute failed");
+
+	crc_sw = crc32c_full_reference(aligned_data, sizeof(aligned_data));
+
+	zassert_equal(crc_hw, crc_sw,
+		      "CRC-32C full aligned 4-byte mismatch: HW=0x%X SW=0x%X",
+		      crc_hw, crc_sw);
+}
+
+ZTEST_SUITE(crc_32c_tests, NULL, NULL, crc_32c_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_32C */

--- a/tests/drivers/crc/src/test_crc_8.c
+++ b/tests/drivers/crc/src/test_crc_8.c
@@ -1,0 +1,238 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_8)
+
+static void crc_8_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+	crc_test_force_hw_algo(TEST_CRC_HW_ALGO_CRC8_CCITT);
+}
+
+/* ZTC-1184: Basic 8-bit CRC */
+ZTEST(crc_8_tests, test_crc_8_bit)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC8_PRIME, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	LOG_INF("8-bit CRC SW output: 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1375: 8-bit CRC with reflected output */
+ZTEST(crc_8_tests, test_crc_8_bit_reflect_output_en)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC8_PRIME, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 8);
+	LOG_INF("8-bit CRC SW output (reflected): 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1390: 8-bit CRC with bit/byte swap */
+ZTEST(crc_8_tests, test_crc_8_bit_swap_en)
+{
+	uint32_t crc_output, software_output;
+	uint8_t input[] = {0x67, 0x37};
+	uint8_t reflected_input[] = {0xE6, 0xEC};
+	struct crc_params params = {
+		.data_in = (uint8_t *)input,
+		.len = ARRAY_SIZE(input),
+		.bit_swap = CRC_TRUE,
+		.byte_swap = CRC_TRUE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC8_PRIME, reflected_input, sizeof(reflected_input));
+	LOG_INF("8-bit CRC SW output (swapped): 0x%X", software_output);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-1392: 8-bit CRC with inverted output */
+ZTEST(crc_8_tests, test_crc_8_bit_invert_output_en)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC8_PRIME, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = (software_output ^ 0xFF);
+	LOG_INF("8-bit CRC SW output (inverted): 0x%X", software_output);
+
+	crc_output = (crc_output & 0xFF);
+
+	zassert_equal(crc_output, software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", crc_output,
+		      software_output);
+}
+
+/* ZTC-NEW: 8-bit CRC with single byte input */
+ZTEST(crc_8_tests, test_crc_8_bit_single_byte)
+{
+	uint32_t crc_output, software_output;
+	uint8_t single_byte[] = {0x55};
+	struct crc_params params = {
+		.data_in = single_byte,
+		.len = 1,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW single byte output: 0x%X", crc_output);
+
+	software_output = gen_crc(CRC8_PRIME, single_byte, 1);
+	LOG_INF("8-bit CRC SW single byte output: 0x%X", software_output);
+
+	zassert_equal((crc_output & 0xFF), software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", (crc_output & 0xFF),
+		      software_output);
+}
+
+/* ZTC-NEW: 8-bit CRC with non-zero seed */
+ZTEST(crc_8_tests, test_crc_8_bit_nonzero_seed)
+{
+	uint32_t crc_seed0 = 0, crc_seedFF = 0;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_seed0,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "seed 0 failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute seed 0");
+
+	params.data_out = &crc_seedFF;
+	zassert_equal(crc_set_seed(crc_dev, 0xFF), 0, "seed FF failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "compute seed FF");
+
+	LOG_INF("8-bit CRC seed=0x00: 0x%X, seed=0xFF: 0x%X", crc_seed0,
+		crc_seedFF);
+
+	zassert_not_equal((crc_seed0 & 0xFF), (crc_seedFF & 0xFF),
+			  "Different seeds produced same 8-bit CRC: 0x%X",
+			  (crc_seed0 & 0xFF));
+}
+
+/* ZTC-NEW: 8-bit CRC with reflect + invert combined */
+ZTEST(crc_8_tests, test_crc_8_bit_reflect_invert_combined)
+{
+	uint32_t crc_output, software_output;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_TRUE,
+		.invert = CRC_TRUE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(crc_set_seed(crc_dev, 0x00), 0, "CRC set seed failed");
+	zassert_equal(crc_compute(crc_dev, &params), 0, "CRC compute failed");
+	LOG_INF("8-bit CRC HW reflect+invert output: 0x%X", crc_output);
+
+	software_output =
+		gen_crc(CRC8_PRIME, (const unsigned char *)crc_test_data,
+			crc_test_data_len);
+	software_output = bit_reflect_n(software_output, 8);
+	software_output = (software_output ^ 0xFF);
+	LOG_INF("8-bit CRC SW reflect+invert output: 0x%X", software_output);
+
+	zassert_equal((crc_output & 0xFF), software_output,
+		      "HW/SW CRC mismatch: 0x%X != 0x%X", (crc_output & 0xFF),
+		      software_output);
+}
+
+ZTEST_SUITE(crc_8_tests, NULL, NULL, crc_8_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_8 */

--- a/tests/drivers/crc/src/test_crc_stress.c
+++ b/tests/drivers/crc/src/test_crc_stress.c
@@ -1,0 +1,962 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "software_crc.h"
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(alif_crc_test);
+
+#if IS_ENABLED(CONFIG_TEST_CRC_STRESS)
+
+static void crc_stress_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	crc_test_verify_device();
+}
+
+#if !IS_ENABLED(CONFIG_TEST_CRC_8) && !IS_ENABLED(CONFIG_TEST_CRC_16) &&       \
+	!IS_ENABLED(CONFIG_TEST_CRC_16_ALT) &&                                 \
+	!IS_ENABLED(CONFIG_TEST_CRC_32) && !IS_ENABLED(CONFIG_TEST_CRC_32C)
+#error "CONFIG_TEST_CRC_STRESS requires at least one CRC algorithm test"
+#endif
+
+/*
+ * The stress suite is runtime-driven so a single image can exercise every
+ * enabled CRC algorithm. For 8-bit and 16-bit modes the public API only
+ * exposes the native hardware algorithms, while 32-bit modes additionally
+ * exercise the custom-polynomial path.
+ */
+struct stress_runtime_cfg {
+	const char *name;
+	enum test_crc_hw_algo hw_algo;
+	int sw_id;
+	uint8_t bits;
+	uint32_t mask;
+	uint32_t poly_normal;
+	uint32_t poly_reflected;
+	bool use_custom_poly;
+};
+
+static const struct stress_runtime_cfg stress_runtime_cfgs[] = {
+#if IS_ENABLED(CONFIG_TEST_CRC_8)
+	{
+		.name = "crc8-ccitt",
+		.hw_algo = TEST_CRC_HW_ALGO_CRC8_CCITT,
+		.sw_id = CRC8_PRIME,
+		.bits = 8U,
+		.mask = 0xFFU,
+		.use_custom_poly = false,
+	},
+#endif
+#if IS_ENABLED(CONFIG_TEST_CRC_16)
+	{
+		.name = "crc16-ccitt",
+		.hw_algo = TEST_CRC_HW_ALGO_CRC16_CCITT,
+		.sw_id = CRC16_802_15_4,
+		.bits = 16U,
+		.mask = 0xFFFFU,
+		.use_custom_poly = false,
+	},
+#endif
+#if IS_ENABLED(CONFIG_TEST_CRC_16_ALT)
+	{
+		.name = "crc16",
+		.hw_algo = TEST_CRC_HW_ALGO_CRC16,
+		.sw_id = CRC16_ALT,
+		.bits = 16U,
+		.mask = 0xFFFFU,
+		.use_custom_poly = false,
+	},
+#endif
+#if IS_ENABLED(CONFIG_TEST_CRC_32)
+	{
+		.name = "crc32",
+		.hw_algo = TEST_CRC_HW_ALGO_CRC32,
+		.sw_id = -1,
+		.bits = 32U,
+		.mask = 0xFFFFFFFFU,
+		.poly_normal = CRC32_CUSTOM_HW_POLY,
+		.poly_reflected = CRC32_CUSTOM_SW_POLY_REFL,
+		.use_custom_poly = true,
+	},
+#endif
+#if IS_ENABLED(CONFIG_TEST_CRC_32C)
+	{
+		.name = "crc32c",
+		.hw_algo = TEST_CRC_HW_ALGO_CRC32C,
+		.sw_id = -1,
+		.bits = 32U,
+		.mask = 0xFFFFFFFFU,
+		.poly_normal = CRC32_CUSTOM_HW_POLY,
+		.poly_reflected = CRC32_CUSTOM_SW_POLY_REFL,
+		.use_custom_poly = true,
+	},
+#endif
+};
+
+static const uint8_t all_zeros[64] = {0};
+
+static uint32_t stress_sw_reference(const struct stress_runtime_cfg *cfg,
+				    const uint8_t *data, size_t len)
+{
+	if (cfg->bits == 32U) {
+		return crc32_driver_reference(
+			data, len, 0x00000000U, false, false, false, false,
+			cfg->poly_normal, cfg->poly_reflected);
+	}
+
+	return gen_crc(cfg->sw_id, data, len);
+}
+
+static uint32_t
+stress_apply_output_transforms(const struct stress_runtime_cfg *cfg,
+			       uint32_t crc, bool reflect, bool invert)
+{
+	if (reflect) {
+		crc = bit_reflect_n(crc, cfg->bits);
+	}
+
+	if (invert) {
+		crc ^= cfg->mask;
+	}
+
+	return crc & cfg->mask;
+}
+
+static uint32_t stress_sw_reference_with_params(
+	const struct stress_runtime_cfg *cfg, const uint8_t *data, size_t len,
+	uint32_t seed, bool bit_swap, bool byte_swap, bool reflect, bool invert)
+{
+	if (cfg->bits == 32U) {
+		return crc32_driver_reference(
+			data, len, seed, bit_swap, byte_swap, reflect, invert,
+			cfg->poly_normal, cfg->poly_reflected);
+	}
+
+	zassert_equal(seed, 0U, "%s seed model not implemented", cfg->name);
+	zassert_false(bit_swap || byte_swap,
+		      "%s swap model not implemented for %u-bit CRC", cfg->name,
+		      cfg->bits);
+
+	return stress_apply_output_transforms(
+		cfg, gen_crc(cfg->sw_id, data, len), reflect, invert);
+}
+
+static void stress_select_runtime_algo(const struct stress_runtime_cfg *cfg,
+				       struct crc_params *params)
+{
+	crc_test_force_hw_algo(cfg->hw_algo);
+	params->custom_poly = cfg->use_custom_poly;
+}
+
+static int stress_prepare_seed_and_poly(const struct stress_runtime_cfg *cfg,
+					struct crc_params *params,
+					uint32_t seed)
+{
+	int ret;
+
+	stress_select_runtime_algo(cfg, params);
+
+	ret = crc_set_seed(crc_dev, seed);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (cfg->use_custom_poly) {
+		ret = crc_set_polynomial(crc_dev, cfg->poly_normal);
+	}
+
+	return ret;
+}
+
+#define STRESS_RUN_FOR_EACH_CFG(fn)                                            \
+	do {                                                                   \
+		for (size_t cfg_idx = 0;                                       \
+		     cfg_idx < ARRAY_SIZE(stress_runtime_cfgs); cfg_idx++) {   \
+			fn(&stress_runtime_cfgs[cfg_idx]);                     \
+		}                                                              \
+	} while (false)
+
+/* ================================================================== */
+/* STRESS-1: Repeatability — same input must always produce same CRC  */
+/* ================================================================== */
+static void stress_repeatability_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_first = 0U;
+	uint32_t crc_repeat = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_first,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s first compute failed", cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_first & cfg->mask, crc_sw,
+		      "%s HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_first & cfg->mask, crc_sw);
+
+	for (int i = 0; i < 50; i++) {
+		params.data_out = &crc_repeat;
+		zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U),
+			      0, "%s seed iter %d failed", cfg->name, i);
+		zassert_equal(crc_compute(crc_dev, &params), 0,
+			      "%s compute iter %d failed", cfg->name, i);
+		zassert_equal(crc_first & cfg->mask, crc_repeat & cfg->mask,
+			      "%s repeat mismatch iter %d: 0x%X != 0x%X",
+			      cfg->name, i, crc_first & cfg->mask,
+			      crc_repeat & cfg->mask);
+	}
+
+	LOG_INF("STRESS-1 [%s]: 50 iterations identical CRC=0x%X", cfg->name,
+		crc_first & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_repeatability)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_repeatability_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-2: Back-to-back compute without re-seeding                  */
+/* ================================================================== */
+static void
+stress_back_to_back_no_reseed_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_a = 0U;
+	uint32_t crc_b = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_a,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0, "%s compute A failed",
+		      cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_a & cfg->mask, crc_sw,
+		      "%s HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_a & cfg->mask, crc_sw);
+
+	params.data_out = &crc_b;
+	zassert_equal(crc_compute(crc_dev, &params), 0, "%s compute B failed",
+		      cfg->name);
+	zassert_equal(crc_a & cfg->mask, crc_b & cfg->mask,
+		      "%s back-to-back mismatch: A=0x%X B=0x%X", cfg->name,
+		      crc_a & cfg->mask, crc_b & cfg->mask);
+
+	LOG_INF("STRESS-2 [%s]: A=0x%X B=0x%X", cfg->name, crc_a & cfg->mask,
+		crc_b & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_back_to_back_no_reseed)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_back_to_back_no_reseed_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-5: All-zeros input (various lengths)                        */
+/* ================================================================== */
+static void stress_all_zeros_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	static const uint32_t lengths[] = {1U, 2U, 4U, 8U, 16U, 32U, 64U};
+	uint32_t crc_prev = 0U;
+	uint32_t crc_curr = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = all_zeros,
+		.len = 0U,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_curr,
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(lengths); i++) {
+		params.len = lengths[i];
+		zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U),
+			      0, "%s seed len %u failed", cfg->name,
+			      lengths[i]);
+		zassert_equal(crc_compute(crc_dev, &params), 0,
+			      "%s compute len %u failed", cfg->name,
+			      lengths[i]);
+
+		crc_sw = stress_sw_reference(cfg, all_zeros, lengths[i]);
+		zassert_equal(crc_curr & cfg->mask, crc_sw,
+			      "%s zeros len %u mismatch: HW=0x%X SW=0x%X",
+			      cfg->name, lengths[i], crc_curr & cfg->mask,
+			      crc_sw);
+
+		if ((i > 0U) && (crc_curr == crc_prev)) {
+			LOG_INF("STRESS-5 [%s]: equal CRC len %u and %u",
+				cfg->name, lengths[i - 1U], lengths[i]);
+		}
+
+		LOG_INF("STRESS-5 [%s]: zeros len=%u CRC=0x%X", cfg->name,
+			lengths[i], crc_curr & cfg->mask);
+		crc_prev = crc_curr;
+	}
+}
+
+ZTEST(crc_stress_tests, test_stress_all_zeros)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_all_zeros_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-7: Rapid repeated compute — detect register state leakage   */
+/* ================================================================== */
+static void
+stress_rapid_100_iterations_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_ref = 0U;
+	uint32_t crc_curr = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_check_string,
+		.len = CRC_CHECK_STRING_LEN,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_ref,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s reference compute failed", cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, crc_check_string,
+				     CRC_CHECK_STRING_LEN);
+	zassert_equal(crc_ref & cfg->mask, crc_sw,
+		      "%s HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_ref & cfg->mask, crc_sw);
+
+	for (int i = 0; i < 100; i++) {
+		params.data_out = &crc_curr;
+		zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U),
+			      0, "%s seed iter %d failed", cfg->name, i);
+		zassert_equal(crc_compute(crc_dev, &params), 0,
+			      "%s compute iter %d failed", cfg->name, i);
+		zassert_equal(crc_ref & cfg->mask, crc_curr & cfg->mask,
+			      "%s rapid mismatch iter %d: 0x%X != 0x%X",
+			      cfg->name, i, crc_ref & cfg->mask,
+			      crc_curr & cfg->mask);
+	}
+
+	LOG_INF("STRESS-7 [%s]: 100 rapid iterations OK, CRC=0x%X", cfg->name,
+		crc_ref & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_rapid_100_iterations)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_rapid_100_iterations_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-8: Alternating param combos — detect stale register bits    */
+/* ================================================================== */
+static void
+stress_alternating_params_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_plain = 0U;
+	uint32_t crc_reflect = 0U;
+	uint32_t crc_invert = 0U;
+	uint32_t crc_plain2 = 0U;
+	uint32_t sw_plain;
+	uint32_t sw_reflect;
+	uint32_t sw_invert;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_plain,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s plain seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s plain compute failed", cfg->name);
+
+	sw_plain = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_plain & cfg->mask, sw_plain,
+		      "%s plain HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_plain & cfg->mask, sw_plain);
+
+	params.reflect = CRC_TRUE;
+	params.data_out = &crc_reflect;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s reflect seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s reflect compute failed", cfg->name);
+	sw_reflect = stress_sw_reference_with_params(cfg, crc_test_data,
+						     crc_test_data_len, 0x00U,
+						     false, false, true, false);
+	zassert_equal(crc_reflect & cfg->mask, sw_reflect,
+		      "%s reflect HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_reflect & cfg->mask, sw_reflect);
+
+	params.reflect = CRC_FALSE;
+	params.invert = CRC_TRUE;
+	params.data_out = &crc_invert;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s invert seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s invert compute failed", cfg->name);
+	sw_invert = stress_sw_reference_with_params(cfg, crc_test_data,
+						    crc_test_data_len, 0x00U,
+						    false, false, false, true);
+	zassert_equal(crc_invert & cfg->mask, sw_invert,
+		      "%s invert HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_invert & cfg->mask, sw_invert);
+
+	params.invert = CRC_FALSE;
+	params.data_out = &crc_plain2;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s plain2 seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s plain2 compute failed", cfg->name);
+
+	zassert_not_equal(crc_plain & cfg->mask, crc_reflect & cfg->mask,
+			  "%s plain and reflect matched: 0x%X", cfg->name,
+			  crc_plain & cfg->mask);
+	zassert_not_equal(crc_plain & cfg->mask, crc_invert & cfg->mask,
+			  "%s plain and invert matched: 0x%X", cfg->name,
+			  crc_plain & cfg->mask);
+	zassert_equal(crc_plain & cfg->mask, crc_plain2 & cfg->mask,
+		      "%s stale register state: 0x%X != 0x%X", cfg->name,
+		      crc_plain & cfg->mask, crc_plain2 & cfg->mask);
+
+	LOG_INF("STRESS-8 [%s]: p=0x%X r=0x%X i=0x%X p2=0x%X", cfg->name,
+		crc_plain & cfg->mask, crc_reflect & cfg->mask,
+		crc_invert & cfg->mask, crc_plain2 & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_alternating_params)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_alternating_params_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-9: HW output width validation                               */
+/* ================================================================== */
+static void
+stress_output_width_check_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_output = 0xDEADBEEFU;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0, "%s compute failed",
+		      cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_output & cfg->mask, crc_sw,
+		      "%s HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_output & cfg->mask, crc_sw);
+	zassert_equal(crc_output & ~cfg->mask, 0U,
+		      "%s upper bits set unexpectedly: raw=0x%08X", cfg->name,
+		      crc_output);
+
+	LOG_INF("STRESS-9 [%s]: raw HW output=0x%08X", cfg->name, crc_output);
+}
+
+ZTEST(crc_stress_tests, test_stress_output_width_check)
+{
+	bool ran = false;
+
+	for (size_t cfg_idx = 0; cfg_idx < ARRAY_SIZE(stress_runtime_cfgs);
+	     cfg_idx++) {
+		const struct stress_runtime_cfg *cfg =
+			&stress_runtime_cfgs[cfg_idx];
+
+		if (cfg->bits == 32U) {
+			continue;
+		}
+
+		ran = true;
+		stress_output_width_check_for_cfg(cfg);
+	}
+
+	if (!ran) {
+		ztest_test_skip();
+	}
+}
+
+/* ================================================================== */
+/* STRESS-10: Known vector "123456789" — cross-check with SW          */
+/* ================================================================== */
+static void
+stress_known_vector_123456789_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_hw = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = crc_check_string,
+		.len = CRC_CHECK_STRING_LEN,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0, "%s compute failed",
+		      cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, crc_check_string,
+				     CRC_CHECK_STRING_LEN);
+	zassert_equal(crc_hw & cfg->mask, crc_sw,
+		      "%s known vector mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_hw & cfg->mask, crc_sw);
+
+	LOG_INF("STRESS-10 [%s]: '123456789' HW=0x%X SW=0x%X", cfg->name,
+		crc_hw & cfg->mask, crc_sw);
+}
+
+ZTEST(crc_stress_tests, test_stress_known_vector_123456789)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_known_vector_123456789_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-11: Large data — 256 bytes repeated pattern                 */
+/* ================================================================== */
+static void stress_large_data_256_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	static uint8_t large_buf[256];
+	uint32_t crc_hw = 0U;
+	uint32_t crc_hw2 = 0U;
+	uint32_t crc_sw;
+	struct crc_params params = {
+		.data_in = large_buf,
+		.len = sizeof(large_buf),
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(large_buf); i++) {
+		large_buf[i] = (uint8_t)(i & 0xFFU);
+	}
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s first 256-byte compute failed", cfg->name);
+
+	crc_sw = stress_sw_reference(cfg, large_buf, sizeof(large_buf));
+	zassert_equal(crc_hw & cfg->mask, crc_sw,
+		      "%s 256-byte mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_hw & cfg->mask, crc_sw);
+
+	params.data_out = &crc_hw2;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s repeat seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s repeat 256-byte compute failed", cfg->name);
+	zassert_equal(crc_hw & cfg->mask, crc_hw2 & cfg->mask,
+		      "%s non-deterministic 256-byte CRC: 0x%X != 0x%X",
+		      cfg->name, crc_hw & cfg->mask, crc_hw2 & cfg->mask);
+
+	LOG_INF("STRESS-11 [%s]: 256-byte CRC=0x%X", cfg->name,
+		crc_hw & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_large_data_256)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_large_data_256_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-12: Bit-flip sensitivity — flipping one bit must change CRC */
+/* ================================================================== */
+static void
+stress_bit_flip_sensitivity_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint8_t buf_orig[crc_test_data_len];
+	uint8_t buf_flipped[crc_test_data_len];
+	uint32_t crc_orig = 0U;
+	uint32_t crc_flipped = 0U;
+	uint32_t sw_orig;
+	uint32_t sw_flipped;
+	struct crc_params params = {
+		.data_in = buf_orig,
+		.len = sizeof(buf_orig),
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_orig,
+	};
+
+	memcpy(buf_orig, crc_test_data, sizeof(buf_orig));
+	memcpy(buf_flipped, crc_test_data, sizeof(buf_flipped));
+	buf_flipped[4] ^= 0x01U;
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s original compute failed", cfg->name);
+
+	sw_orig = stress_sw_reference(cfg, buf_orig, sizeof(buf_orig));
+	zassert_equal(crc_orig & cfg->mask, sw_orig,
+		      "%s original HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_orig & cfg->mask, sw_orig);
+
+	params.data_in = buf_flipped;
+	params.data_out = &crc_flipped;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s flipped seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s flipped compute failed", cfg->name);
+
+	sw_flipped = stress_sw_reference(cfg, buf_flipped, sizeof(buf_flipped));
+	zassert_equal(crc_flipped & cfg->mask, sw_flipped,
+		      "%s flipped HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_flipped & cfg->mask, sw_flipped);
+	zassert_not_equal(crc_orig & cfg->mask, crc_flipped & cfg->mask,
+			  "%s bit flip undetected: 0x%X == 0x%X", cfg->name,
+			  crc_orig & cfg->mask, crc_flipped & cfg->mask);
+
+	LOG_INF("STRESS-12 [%s]: orig=0x%X flipped=0x%X", cfg->name,
+		crc_orig & cfg->mask, crc_flipped & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_bit_flip_sensitivity)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_bit_flip_sensitivity_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-13: Reflect + Invert combined — verify orthogonality        */
+/* ================================================================== */
+static void
+stress_reflect_invert_orthogonal_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_none = 0U;
+	uint32_t crc_ref = 0U;
+	uint32_t crc_inv = 0U;
+	uint32_t crc_both = 0U;
+	uint32_t sw_none;
+	uint32_t sw_ref;
+	uint32_t sw_inv;
+	uint32_t sw_both;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_none,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s none seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s none compute failed", cfg->name);
+
+	sw_none = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_none & cfg->mask, sw_none,
+		      "%s baseline HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_none & cfg->mask, sw_none);
+
+	params.reflect = CRC_TRUE;
+	params.data_out = &crc_ref;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s reflect seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s reflect compute failed", cfg->name);
+	sw_ref = stress_sw_reference_with_params(cfg, crc_test_data,
+						 crc_test_data_len, 0x00U,
+						 false, false, true, false);
+	zassert_equal(crc_ref & cfg->mask, sw_ref,
+		      "%s reflect HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_ref & cfg->mask, sw_ref);
+
+	params.reflect = CRC_FALSE;
+	params.invert = CRC_TRUE;
+	params.data_out = &crc_inv;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s invert seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s invert compute failed", cfg->name);
+	sw_inv = stress_sw_reference_with_params(cfg, crc_test_data,
+						 crc_test_data_len, 0x00U,
+						 false, false, false, true);
+	zassert_equal(crc_inv & cfg->mask, sw_inv,
+		      "%s invert HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_inv & cfg->mask, sw_inv);
+
+	params.reflect = CRC_TRUE;
+	params.invert = CRC_TRUE;
+	params.data_out = &crc_both;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s both seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s both compute failed", cfg->name);
+	sw_both = stress_sw_reference_with_params(cfg, crc_test_data,
+						  crc_test_data_len, 0x00U,
+						  false, false, true, true);
+	zassert_equal(crc_both & cfg->mask, sw_both,
+		      "%s reflect+invert HW/SW mismatch: HW=0x%X SW=0x%X",
+		      cfg->name, crc_both & cfg->mask, sw_both);
+
+	zassert_not_equal(crc_none & cfg->mask, crc_ref & cfg->mask,
+			  "%s none == reflect", cfg->name);
+	zassert_not_equal(crc_none & cfg->mask, crc_inv & cfg->mask,
+			  "%s none == invert", cfg->name);
+	zassert_not_equal(crc_none & cfg->mask, crc_both & cfg->mask,
+			  "%s none == both", cfg->name);
+	zassert_not_equal(crc_ref & cfg->mask, crc_inv & cfg->mask,
+			  "%s reflect == invert", cfg->name);
+	zassert_not_equal(crc_ref & cfg->mask, crc_both & cfg->mask,
+			  "%s reflect == both", cfg->name);
+	zassert_not_equal(crc_inv & cfg->mask, crc_both & cfg->mask,
+			  "%s invert == both", cfg->name);
+
+	LOG_INF("STRESS-13 [%s]: none=0x%X ref=0x%X inv=0x%X both=0x%X",
+		cfg->name, crc_none & cfg->mask, crc_ref & cfg->mask,
+		crc_inv & cfg->mask, crc_both & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_reflect_invert_orthogonal)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_reflect_invert_orthogonal_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-14: Swap sensitivity — bit_swap and byte_swap               */
+/* ================================================================== */
+static void
+stress_swap_sensitivity_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_nosw = 0U;
+	uint32_t crc_bitsw = 0U;
+	uint32_t crc_bytesw = 0U;
+	uint32_t crc_bothsw = 0U;
+	uint32_t sw_nosw;
+	uint32_t sw_bitsw = 0U;
+	uint32_t sw_bytesw = 0U;
+	uint32_t sw_bothsw = 0U;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_nosw,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s no-swap seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s no-swap compute failed", cfg->name);
+
+	sw_nosw = stress_sw_reference(cfg, crc_test_data, crc_test_data_len);
+	zassert_equal(crc_nosw & cfg->mask, sw_nosw,
+		      "%s baseline HW/SW mismatch: HW=0x%X SW=0x%X", cfg->name,
+		      crc_nosw & cfg->mask, sw_nosw);
+
+	params.bit_swap = CRC_TRUE;
+	params.byte_swap = CRC_FALSE;
+	params.data_out = &crc_bitsw;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s bit-swap seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s bit-swap compute failed", cfg->name);
+
+	params.bit_swap = CRC_FALSE;
+	params.byte_swap = CRC_TRUE;
+	params.data_out = &crc_bytesw;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s byte-swap seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s byte-swap compute failed", cfg->name);
+
+	params.bit_swap = CRC_TRUE;
+	params.byte_swap = CRC_TRUE;
+	params.data_out = &crc_bothsw;
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s both-swap seed failed", cfg->name);
+	zassert_equal(crc_compute(crc_dev, &params), 0,
+		      "%s both-swap compute failed", cfg->name);
+
+	if (cfg->bits == 32U) {
+		sw_bitsw = stress_sw_reference_with_params(
+			cfg, crc_test_data, crc_test_data_len, 0x00U, true,
+			false, false, false);
+		sw_bytesw = stress_sw_reference_with_params(
+			cfg, crc_test_data, crc_test_data_len, 0x00U, false,
+			true, false, false);
+		sw_bothsw = stress_sw_reference_with_params(
+			cfg, crc_test_data, crc_test_data_len, 0x00U, true,
+			true, false, false);
+		zassert_equal(crc_bitsw & cfg->mask, sw_bitsw,
+			      "%s bit-swap HW/SW mismatch: HW=0x%X SW=0x%X",
+			      cfg->name, crc_bitsw & cfg->mask, sw_bitsw);
+		zassert_equal(crc_bytesw & cfg->mask, sw_bytesw,
+			      "%s byte-swap HW/SW mismatch: HW=0x%X SW=0x%X",
+			      cfg->name, crc_bytesw & cfg->mask, sw_bytesw);
+		zassert_equal(crc_bothsw & cfg->mask, sw_bothsw,
+			      "%s both-swap HW/SW mismatch: HW=0x%X SW=0x%X",
+			      cfg->name, crc_bothsw & cfg->mask, sw_bothsw);
+	}
+
+	zassert_not_equal(crc_nosw & cfg->mask, crc_bitsw & cfg->mask,
+			  "%s no swap == bit swap", cfg->name);
+	zassert_not_equal(crc_nosw & cfg->mask, crc_bytesw & cfg->mask,
+			  "%s no swap == byte swap", cfg->name);
+	zassert_not_equal(crc_nosw & cfg->mask, crc_bothsw & cfg->mask,
+			  "%s no swap == both swap", cfg->name);
+
+	LOG_INF("STRESS-14 [%s]: nosw=0x%X bitsw=0x%X bytesw=0x%X both=0x%X",
+		cfg->name, crc_nosw & cfg->mask, crc_bitsw & cfg->mask,
+		crc_bytesw & cfg->mask, crc_bothsw & cfg->mask);
+}
+
+ZTEST(crc_stress_tests, test_stress_swap_sensitivity)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_swap_sensitivity_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-NEG: Edge-case input validation                             */
+/* ================================================================== */
+static void
+stress_zero_length_input_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_hw = 0xDEADBEEFU;
+	uint8_t dummy = 0xAAU;
+	int ret;
+	struct crc_params params = {
+		.data_in = &dummy,
+		.len = 0U,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_hw,
+	};
+
+	zassert_equal(stress_prepare_seed_and_poly(cfg, &params, 0x00U), 0,
+		      "%s seed failed", cfg->name);
+
+	ret = crc_compute(crc_dev, &params);
+	zassert_equal(ret, -EINVAL,
+		      "%s len=0 should fail with -EINVAL (ret=%d)", cfg->name,
+		      ret);
+
+	LOG_INF("STRESS-NEG [%s]: len=0 rejected with %d", cfg->name, ret);
+}
+
+ZTEST(crc_stress_tests, test_stress_zero_length_input)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_zero_length_input_for_cfg);
+}
+
+/* ================================================================== */
+/* STRESS-NEG-NULL: Safe NULL field validation                        */
+/* ================================================================== */
+static void stress_null_pointers_for_cfg(const struct stress_runtime_cfg *cfg)
+{
+	uint32_t crc_output = 0U;
+	struct crc_params params = {
+		.data_in = (uint8_t *)crc_test_data,
+		.len = crc_test_data_len,
+		.bit_swap = CRC_FALSE,
+		.byte_swap = CRC_FALSE,
+		.reflect = CRC_FALSE,
+		.invert = CRC_FALSE,
+		.custom_poly = CRC_FALSE,
+		.data_out = &crc_output,
+	};
+
+	/*
+	 * Kernel-mode callers hit the inline wrappers in crc.h directly, so
+	 * passing a NULL device or NULL params pointer would fault before the
+	 * driver gets a chance to validate them. Only NULL payload members are
+	 * safe to exercise from this test binary.
+	 */
+	stress_select_runtime_algo(cfg, &params);
+
+	params.data_in = NULL;
+	zassert_equal(crc_compute(crc_dev, &params), -EINVAL,
+		      "%s NULL data_in should fail with -EINVAL", cfg->name);
+
+	params.data_in = (uint8_t *)crc_test_data;
+	params.data_out = NULL;
+	zassert_equal(crc_compute(crc_dev, &params), -EINVAL,
+		      "%s NULL data_out should fail with -EINVAL", cfg->name);
+
+	LOG_INF("STRESS-NEG-NULL [%s]: safe NULL field checks passed",
+		cfg->name);
+}
+
+ZTEST(crc_stress_tests, test_stress_null_pointers)
+{
+	STRESS_RUN_FOR_EACH_CFG(stress_null_pointers_for_cfg);
+}
+
+ZTEST_SUITE(crc_stress_tests, NULL, NULL, crc_stress_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_CRC_STRESS */

--- a/tests/drivers/crc/testcase.yaml
+++ b/tests/drivers/crc/testcase.yaml
@@ -1,0 +1,346 @@
+common:
+  tags: drivers crc
+  depends_on: crc
+  harness: ztest
+
+tests:
+  drivers.crc.crc0_8_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_16_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_16=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_16_bit_alt:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_16_ALT=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_32_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_32=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc1_8_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_16_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_16=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_16_bit_alt:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_16_ALT=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_32_bit:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_32=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc0_32c:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_32C=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc1_32c:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_32C=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc0_8_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_16_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_16=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_16_bit_alt_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_16_ALT=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc0_32_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_32=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc1_8_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_16_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_16=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_32_bit_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_32=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc1_16_bit_alt_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_16_ALT=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc0_32c_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_32C=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc1_32c_stress:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_32C=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+
+  drivers.crc.crc0_all:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+      - CONFIG_TEST_CRC_16=y
+      - CONFIG_TEST_CRC_16_ALT=y
+      - CONFIG_TEST_CRC_32=y
+      - CONFIG_TEST_CRC_32C=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc0.overlay
+
+  drivers.crc.crc1_all:
+    platform_allow:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_configs:
+      - CONFIG_TEST_CRC_8=y
+      - CONFIG_TEST_CRC_16=y
+      - CONFIG_TEST_CRC_16_ALT=y
+      - CONFIG_TEST_CRC_32=y
+      - CONFIG_TEST_CRC_32C=y
+      - CONFIG_TEST_CRC_STRESS=y
+    extra_dtc_overlay_files:
+      - boards/crc1.overlay
+


### PR DESCRIPTION
Add additional tests to extend CRC coverage for CRC8, CRC16, CRC32 and CRC32C. The tests validate software CRC calculations and improve stress and functional verification of the driver.