### PR TITLE
samples: drivers: uart: add echo_dma test application

### DIFF
--- a/samples/drivers/uart/echo_dma/CMakeLists.txt
+++ b/samples/drivers/uart/echo_dma/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(uart_echo_dma)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/uart/echo_dma/README.rst
+++ b/samples/drivers/uart/echo_dma/README.rst
@@ -1,0 +1,87 @@
+.. zephyr:code-sample:: uart_echo_dma
+   :name: UART Echo DMA
+   :relevant-api: uart_async
+
+   Read data from the Shell UART using DMA RX and echo it back using DMA TX.
+
+Overview
+********
+
+This sample demonstrates how to use the UART driver with DMA based
+transfers using the asynchronous UART API.
+
+The application receives data over Shell UART using DMA and echoes the
+received line back after the user presses the Enter key.
+
+The application separates the debug console and Shell UART (DMA):
+
+* **Console UART** – used only for debug output via ``printk``.
+* **Shell UART** – used for RX and TX using DMA.
+
+The console UART cannot be used as a DMA UART in this sample. The UART
+instance used for the console is initialized before the DMA controller
+during system boot. Since the UART DMA configuration depends on the
+DMA controller device, using the console UART for DMA may cause a
+device initialization dependency violation during build.
+
+In such a case the build may fail with an error similar to:
+
+.. code-block:: console
+
+    ERROR: Device initialization priority validation failed, the sequence
+    of initialization calls does not match the devicetree dependencies.
+    ERROR: /soc/uart@XXXX <uart_ns16550_init> is initialized before its
+    dependency /soc/dmax@XXXX <dma_pl330_initialize>
+    (PRE_KERNEL_1 < POST_KERNEL)
+
+For this reason, a **separate Shell UART instance must be used for DMA based
+communication**, while the console UART remains dedicated for debug
+output.
+
+When a user types characters on the Shell UART(DMA) and presses Enter,
+the application echoes the received line back over the same UART
+using DMA transmit.
+
+Building and Running
+********************
+
+Build and flash the sample as follows, replacing the board name with
+your target board.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/uart/echo_dma
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build flash
+   :gen-args: -S alif-dk
+   :compact:
+
+After flashing:
+
+1. Connect to the **console UART** to see debug messages.
+2. Open a terminal connected to the **Shell UART(DMA)**.
+3. Type anything and press **Enter** on Shell UART.
+
+The application will echo the received line back using DMA transmit.
+
+Sample Output
+=============
+
+Console UART (debug output):
+
+.. code-block:: console
+
+    UART DMA Echo Test
+    Enabling UART RX DMA
+    RX buffer request
+    Type anything on Shell UART and press ENTER!
+    DMA TX done
+    DMA TX done
+    DMA TX done
+
+Shell UART (DMA) terminal:
+
+.. code-block:: console
+
+    Hi! How are you!
+    Echo:
+    Hi! How are you!

--- a/samples/drivers/uart/echo_dma/prj.conf
+++ b/samples/drivers/uart/echo_dma/prj.conf
@@ -1,0 +1,17 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_UART_ASYNC_API=y
+
+CONFIG_DMA=y
+CONFIG_DMA_PL330=y
+
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048

--- a/samples/drivers/uart/echo_dma/sample.yaml
+++ b/samples/drivers/uart/echo_dma/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: UART driver DMA sample
+tests:
+  sample.drivers.uart.echo_dma:
+    integration_platforms:
+      - alif_e8_dk
+    tags:
+      - serial
+      - uart
+    filter: CONFIG_SERIAL and
+            CONFIG_UART_ASYNC_API and
+            CONFIG_DMA and
+            CONFIG_UART_INTERRUPT_DRIVEN and
+            dt_chosen_enabled("zephyr,shell-uart")
+    harness: keyboard

--- a/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_balletto_dk.overlay
+++ b/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_balletto_dk.overlay
@@ -1,0 +1,55 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Note:
+ * The console UART cannot be used as a DMA UART in this sample. The UART
+ * instance used for the console is initialized before the DMA controller
+ * during system boot. Since the UART DMA configuration depends on the
+ * DMA controller device, using the console UART for DMA may cause a
+ * device initialization dependency violation during build.
+ *
+ * ERROR: Device initialization priority validation failed, the sequence
+ *  of initialization calls does not match the devicetree dependencies.
+ * ERROR: /soc/uart@XXXX <uart_ns16550_init> is initialized before its
+ *  dependency /soc/dmax@XXXX <dma_pl330_initialize>
+ *  (PRE_KERNEL_1 < POST_KERNEL)
+ */
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+#define UART2_DMA_RX_REQ 10
+#define UART2_DMA_TX_REQ 18
+
+/ {
+	chosen {
+		/* Shell UART is used for DMA transfers. */
+		zephyr,shell-uart = &uart2;
+		zephyr,console = &lpuart;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&uart2 {
+	/* Encoded parameters (channel, dma_group, handshake) */
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) UART2_DMA_RX_REQ>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) UART2_DMA_TX_REQ>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&lpuart {
+	status = "okay";
+};

--- a/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_ensemble_dk.overlay
+++ b/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_ensemble_dk.overlay
@@ -1,0 +1,55 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Note:
+ * The console UART cannot be used as a DMA UART in this sample. The UART
+ * instance used for the console is initialized before the DMA controller
+ * during system boot. Since the UART DMA configuration depends on the
+ * DMA controller device, using the console UART for DMA may cause a
+ * device initialization dependency violation during build.
+ *
+ * ERROR: Device initialization priority validation failed, the sequence
+ *  of initialization calls does not match the devicetree dependencies.
+ * ERROR: /soc/uart@XXXX <uart_ns16550_init> is initialized before its
+ *  dependency /soc/dmax@XXXX <dma_pl330_initialize>
+ *  (PRE_KERNEL_1 < POST_KERNEL)
+ */
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+#define UART2_DMA_RX_REQ 10
+#define UART2_DMA_TX_REQ 18
+
+/ {
+	chosen {
+		/* Shell UART is used for DMA transfers. */
+		zephyr,shell-uart = &uart2;
+		zephyr,console = &uart4;
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&uart2 {
+	/* Encoded parameters (channel, dma_group, handshake) */
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(0, 0, 1) UART2_DMA_RX_REQ>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(1, 0, 1) UART2_DMA_TX_REQ>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&uart4 {
+	status = "okay";
+};

--- a/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_ensemble_e1c_dk.overlay
+++ b/samples/drivers/uart/echo_dma/snippets/alif-dk/alif_ensemble_e1c_dk.overlay
@@ -1,0 +1,55 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Note:
+ * The console UART cannot be used as a DMA UART in this sample. The UART
+ * instance used for the console is initialized before the DMA controller
+ * during system boot. Since the UART DMA configuration depends on the
+ * DMA controller device, using the console UART for DMA may cause a
+ * device initialization dependency violation during build.
+ *
+ * ERROR: Device initialization priority validation failed, the sequence
+ *  of initialization calls does not match the devicetree dependencies.
+ * ERROR: /soc/uart@XXXX <uart_ns16550_init> is initialized before its
+ *  dependency /soc/dmax@XXXX <dma_pl330_initialize>
+ *  (PRE_KERNEL_1 < POST_KERNEL)
+ */
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+#define UART2_DMA_RX_REQ 10
+#define UART2_DMA_TX_REQ 18
+
+/ {
+	chosen {
+		/* Shell UART is used for DMA transfers. */
+		zephyr,shell-uart = &uart2;
+		zephyr,console = &lpuart;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&uart2 {
+	/* Encoded parameters (channel, dma_group, handshake) */
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) UART2_DMA_RX_REQ>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) UART2_DMA_TX_REQ>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&lpuart {
+	status = "okay";
+};

--- a/samples/drivers/uart/echo_dma/snippets/alif-dk/snippet.yml
+++ b/samples/drivers/uart/echo_dma/snippets/alif-dk/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+name: alif-dk
+
+boards:
+  /alif_b1_dk/.*/rtss_he/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_balletto_dk.overlay
+
+  /alif_e1c_dk/.*/rtss_he/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_ensemble_e1c_dk.overlay
+
+  /alif_(e7|e8)_dk/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_ensemble_dk.overlay

--- a/samples/drivers/uart/echo_dma/src/main.c
+++ b/samples/drivers/uart/echo_dma/src/main.c
@@ -1,0 +1,182 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/sys/printk.h>
+#include <string.h>
+
+#define UART_NODE DT_CHOSEN(zephyr_shell_uart)
+
+#define RX_TIMEOUT       50
+#define RX_DMA_BUF_SIZE  64
+#define TX_DMA_BUF_SIZE  64
+
+static const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+
+static uint8_t rx_dma_buf_a[RX_DMA_BUF_SIZE];
+static uint8_t rx_dma_buf_b[RX_DMA_BUF_SIZE];
+static uint8_t *next_rx_buf = rx_dma_buf_b;
+static uint8_t tx_dma_buf[TX_DMA_BUF_SIZE];
+
+static size_t tx_len;
+
+static struct k_sem line_ready;
+static struct k_sem tx_done;
+
+/*
+ * The application receives data over Shell UART using DMA and
+ * echoes the received line back after the user presses the Enter key.
+ */
+static void uart_cb(const struct device *dev,
+					struct uart_event *evt,
+					void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (evt->type) {
+
+	case UART_RX_RDY: {
+		uint8_t *data = &evt->data.rx.buf[evt->data.rx.offset];
+		size_t len = evt->data.rx.len;
+
+		for (size_t i = 0; i < len; i++) {
+			uint8_t c = data[i];
+
+			if (tx_len < TX_DMA_BUF_SIZE) {
+				tx_dma_buf[tx_len++] = c;
+			} else if (tx_len == TX_DMA_BUF_SIZE) {
+				printk("Warning: input truncated at %d bytes\n",
+				       TX_DMA_BUF_SIZE);
+				tx_len++;
+			}
+
+			/* detect ENTER */
+			if (c == '\r' || c == '\n') {
+				k_sem_give(&line_ready);
+			}
+		}
+		break;
+	}
+
+	case UART_TX_DONE:
+		printk("DMA TX done\n");
+		k_sem_give(&tx_done);
+		break;
+
+	case UART_TX_ABORTED:
+		printk("DMA TX aborted\n");
+		k_sem_give(&tx_done);
+		break;
+
+	case UART_RX_BUF_REQUEST:
+		printk("RX buffer request\n");
+		uart_rx_buf_rsp(dev, next_rx_buf, RX_DMA_BUF_SIZE);
+		next_rx_buf = (next_rx_buf == rx_dma_buf_a)
+			    ? rx_dma_buf_b : rx_dma_buf_a;
+		break;
+
+	case UART_RX_DISABLED:
+		printk("RX disabled -> re-enabling DMA RX\n");
+		uart_rx_enable(dev, next_rx_buf, RX_DMA_BUF_SIZE, RX_TIMEOUT);
+		next_rx_buf = (next_rx_buf == rx_dma_buf_a)
+			    ? rx_dma_buf_b : rx_dma_buf_a;
+		break;
+
+	default:
+		break;
+	}
+}
+
+/* small helper API for DMA TX */
+static int dma_uart_send(const uint8_t *data, size_t len)
+{
+	int ret;
+
+	ret = uart_tx(uart_dev, data, len, SYS_FOREVER_US);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* wait until DMA TX finishes */
+	k_sem_take(&tx_done, K_FOREVER);
+
+	return 0;
+}
+
+int main(void)
+{
+	int ret = 0;
+
+	if (!device_is_ready(uart_dev)) {
+		printk("UART device not ready\n");
+		return 0;
+	}
+
+	printk("\nUART DMA Echo Test\n");
+
+	k_sem_init(&line_ready, 0, 1);
+	k_sem_init(&tx_done, 0, 1);
+
+	ret = uart_callback_set(uart_dev, uart_cb, NULL);
+	if (ret < 0) {
+		printk("Error setting UART callback: %d\n", ret);
+		return ret;
+	}
+
+	printk("Enabling UART RX DMA\n");
+
+	ret = uart_rx_enable(uart_dev, rx_dma_buf_a, RX_DMA_BUF_SIZE, RX_TIMEOUT);
+	if (ret < 0) {
+		printk("Error enabling UART RX DMA: %d\n", ret);
+		return ret;
+	}
+
+	printk("Type anything on Shell UART and press ENTER! \r\n");
+
+	while (1) {
+		/* indefinitely wait for the user input */
+		k_sem_take(&line_ready, K_FOREVER);
+
+		if (tx_len > 0) {
+			uint8_t echo_buf[TX_DMA_BUF_SIZE];
+			size_t echo_len;
+			unsigned int key;
+
+			/* snapshot the RX buffer under IRQ lock */
+			key = irq_lock();
+			echo_len = (tx_len > TX_DMA_BUF_SIZE)
+				 ? TX_DMA_BUF_SIZE : tx_len;
+			memcpy(echo_buf, tx_dma_buf, echo_len);
+			tx_len = 0;
+			irq_unlock(key);
+
+			/* print "Echo" message via DMA to shell UART */
+			ret = dma_uart_send((const uint8_t *)"Echo:\r\n", sizeof("Echo:\r\n") - 1);
+			if (ret < 0) {
+				printk("Error sending UART TX DMA: %d\n", ret);
+			}
+
+			/* echo back user input via DMA to shell UART */
+			ret = dma_uart_send(echo_buf, echo_len);
+			if (ret < 0) {
+				printk("Error sending UART TX DMA: %d\n", ret);
+			}
+
+			/* send newline via DMA to shell UART */
+			ret = dma_uart_send((const uint8_t *)"\r\n", sizeof("\r\n") - 1);
+			if (ret < 0) {
+				printk("Error sending UART TX DMA: %d\n", ret);
+			}
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION
Add "echo_dma" test application to validate UART DMA functionality.

The sample demonstrates UART data transmission and reception using DMA-based transfers and echoes received data back to the sender.