### PR TITLE
manifest: update zephyr revision to usb msc sample app support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: de4da65b024990ca5e49c23849424070d4ba463c
+      revision: 21bd2c432ad2fafb244f2637616ea3df8bb6febe
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated Zephyr revision to usb msc sample app
with sd card support.
it depends on https://github.com/alifsemi/zephyr_alif/pull/427