### PR TITLE
WM8904 codec sample app

### DIFF
--- a/samples/drivers/i2s_codec/CMakeLists.txt
+++ b/samples/drivers/i2s_codec/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i2s_codec)
+
+target_sources(app PRIVATE src/main.c)
+

--- a/samples/drivers/i2s_codec/Kconfig
+++ b/samples/drivers/i2s_codec/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+source "Kconfig.zephyr"
+
+config SAMPLE_FREQ
+	int "Sample rate"
+	help
+	  Sample frequency of the system.

--- a/samples/drivers/i2s_codec/prj.conf
+++ b/samples/drivers/i2s_codec/prj.conf
@@ -1,0 +1,14 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+
+CONFIG_I2S=y
+CONFIG_I2C=y
+CONFIG_HEAP_MEM_POOL_SIZE=81920
+CONFIG_SAMPLE_FREQ=48000
+CONFIG_WM8904=y

--- a/samples/drivers/i2s_codec/src/main.c
+++ b/samples/drivers/i2s_codec/src/main.c
@@ -1,0 +1,195 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <errno.h>
+
+#include <zephyr/audio/codec.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
+#define I2S_CODEC_TX DT_ALIAS(i2s_codec_tx)
+
+#define SAMPLE_FREQUENCY CONFIG_SAMPLE_FREQ
+#define SAMPLE_BIT_WIDTH 24U
+#define CHANNEL_COUNT 2U
+
+/*
+ * The DesignWare I2S driver uses 32-bit containers for samples wider than
+ * 16 bits, so we stream the 24-bit clip as stereo 32-bit words.
+ */
+#define BYTES_PER_CHANNEL_SAMPLE sizeof(uint32_t)
+#define FRAMES_PER_BLOCK 256U
+#define BLOCK_SIZE (FRAMES_PER_BLOCK * CHANNEL_COUNT * BYTES_PER_CHANNEL_SAMPLE)
+#define BLOCK_COUNT 8U
+#define TIMEOUT_MS 2000U
+
+#define TONE_HZ 1000U
+#define TONE_HIGH_LEVEL 0x500000U
+#define TONE_LOW_LEVEL 0xB00000U
+#define TONE_TOGGLE_FRAMES MAX(1U, SAMPLE_FREQUENCY / (TONE_HZ * 2U))
+#define TONE_TOTAL_FRAMES (SAMPLE_FREQUENCY * 2U)
+
+K_MEM_SLAB_DEFINE_STATIC(tx_mem_slab, BLOCK_SIZE, BLOCK_COUNT, 4);
+
+static int configure_codec(const struct device *codec_dev)
+{
+	struct audio_codec_cfg audio_cfg = {0};
+	int ret;
+
+	audio_cfg.dai_route = AUDIO_ROUTE_PLAYBACK;
+	audio_cfg.dai_type = AUDIO_DAI_TYPE_I2S;
+	audio_cfg.dai_cfg.i2s.word_size = SAMPLE_BIT_WIDTH;
+	audio_cfg.dai_cfg.i2s.channels = CHANNEL_COUNT;
+	audio_cfg.dai_cfg.i2s.format = I2S_FMT_DATA_FORMAT_I2S;
+	audio_cfg.dai_cfg.i2s.options = I2S_OPT_FRAME_CLK_MASTER;
+	audio_cfg.dai_cfg.i2s.frame_clk_freq = SAMPLE_FREQUENCY;
+	audio_cfg.dai_cfg.i2s.mem_slab = &tx_mem_slab;
+	audio_cfg.dai_cfg.i2s.block_size = BLOCK_SIZE;
+	audio_cfg.dai_cfg.i2s.timeout = TIMEOUT_MS;
+
+	ret = audio_codec_configure(codec_dev, &audio_cfg);
+	if (ret < 0) {
+		printk("Failed to configure codec: %d\n", ret);
+		return ret;
+	}
+
+	audio_codec_start_output(codec_dev);
+
+	return 0;
+}
+
+static int configure_i2s_tx(const struct device *i2s_dev)
+{
+	struct i2s_config i2s_cfg = {
+		.word_size = SAMPLE_BIT_WIDTH,
+		.channels = CHANNEL_COUNT,
+		.format = I2S_FMT_DATA_FORMAT_I2S,
+		.options = I2S_OPT_FRAME_CLK_MASTER | I2S_OPT_BIT_CLK_MASTER,
+		.frame_clk_freq = SAMPLE_FREQUENCY,
+		.mem_slab = &tx_mem_slab,
+		.block_size = BLOCK_SIZE,
+		.timeout = TIMEOUT_MS,
+	};
+	int ret;
+
+	ret = i2s_configure(i2s_dev, I2S_DIR_TX, &i2s_cfg);
+	if (ret < 0) {
+		printk("Failed to configure I2S TX: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static size_t fill_tone_block(uint32_t *tx_block, size_t sample_offset)
+{
+	const size_t frames = MIN((size_t)FRAMES_PER_BLOCK,
+				 TONE_TOTAL_FRAMES - sample_offset);
+
+	for (size_t i = 0; i < frames; ++i) {
+		const size_t frame_index = sample_offset + i;
+		const bool high = (((frame_index / TONE_TOGGLE_FRAMES) & 0x1U) == 0U);
+		const uint32_t sample = high ? TONE_HIGH_LEVEL : TONE_LOW_LEVEL;
+
+		tx_block[2U * i] = sample;
+		tx_block[(2U * i) + 1U] = sample;
+	}
+
+	return frames;
+}
+
+static int play_tone_sample(const struct device *i2s_dev)
+{
+	size_t sample_offset = 0U;
+	bool started = false;
+
+	while (sample_offset < TONE_TOTAL_FRAMES) {
+		void *tx_block;
+		size_t frames;
+		size_t bytes;
+		int ret;
+
+		ret = k_mem_slab_alloc(&tx_mem_slab, &tx_block, K_FOREVER);
+		if (ret < 0) {
+			printk("Failed to allocate TX block: %d\n", ret);
+			return ret;
+		}
+
+		frames = fill_tone_block((uint32_t *)tx_block, sample_offset);
+		bytes = frames * CHANNEL_COUNT * BYTES_PER_CHANNEL_SAMPLE;
+
+		ret = i2s_write(i2s_dev, tx_block, bytes);
+		if (ret < 0) {
+			k_mem_slab_free(&tx_mem_slab, tx_block);
+			printk("Failed to queue TX block: %d\n", ret);
+			return ret;
+		}
+
+		if (!started) {
+			ret = i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_START);
+			if (ret < 0) {
+				printk("Failed to start I2S TX: %d\n", ret);
+				(void)i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_DROP);
+				return ret;
+			}
+
+			started = true;
+		}
+
+		sample_offset += frames;
+	}
+
+	return i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
+}
+
+int main(void)
+{
+	const struct device *const i2s_dev_codec = DEVICE_DT_GET(I2S_CODEC_TX);
+	const struct device *const codec_dev = DEVICE_DT_GET(DT_NODELABEL(audio_codec));
+	int ret;
+
+	printk("Playing tone sample at %u Hz\n", SAMPLE_FREQUENCY);
+
+	if (!device_is_ready(i2s_dev_codec)) {
+		printk("%s is not ready\n", i2s_dev_codec->name);
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(codec_dev)) {
+		printk("%s is not ready\n", codec_dev->name);
+		return -ENODEV;
+	}
+
+	ret = configure_codec(codec_dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(1000);
+
+	ret = configure_i2s_tx(i2s_dev_codec);
+	if (ret < 0) {
+		audio_codec_stop_output(codec_dev);
+		return ret;
+	}
+
+	ret = play_tone_sample(i2s_dev_codec);
+	if (ret < 0) {
+		audio_codec_stop_output(codec_dev);
+		printk("Tone sample playback failed: %d\n", ret);
+		return ret;
+	}
+
+	audio_codec_stop_output(codec_dev);
+	printk("Tone sample playback complete\n");
+
+	return 0;
+}

--- a/snippets/i2s-codec/README.rst
+++ b/snippets/i2s-codec/README.rst
@@ -1,0 +1,41 @@
+.. _snippet-i2s-codec:
+
+I2S Codec Application
+######################
+
+Overview
+********
+
+This snippet selects the appropriate overlay fragment to enable the I2S controller and WM8904 codec for the
+`i2s_codec` sample.
+
+The sample entry point is :zephyr_file:`samples/drivers/i2s_codec/src/main.c`. It:
+
+* configures the WM8904 codec for I2S playback,
+* configures the I2S TX path with a small static memory slab,
+* generates a simple 1 kHz tone in software instead of storing a PCM file in flash,
+* streams stereo 24-bit samples using 32-bit containers, and
+* plays the tone for a short, fixed duration.
+
+Building and Running
+********************
+
+Example command to build:
+
+.. code-block:: console
+
+   west build -b alif_b1_dk/ab1c1f4m51820hh/rtss_he -S i2s-codec ../alif/samples/drivers/i2s_codec -p
+   OR
+   west build -b alif_b1_dk/ab1c1f4m51820hh/rtss_he ../alif/samples/drivers/i2s_codec -p -- -DSNIPPET=i2s-codec
+
+The application can be found under :zephyr_file:`samples/drivers/i2s_codec` in the Zephyr tree.
+
+Application Output
+*******************
+
+Expected console output is similar to:
+
+.. code-block:: console
+
+   Playing tone sample at 48000 Hz
+   Tone sample playback complete

--- a/snippets/i2s-codec/e1c_b1_rtss.overlay
+++ b/snippets/i2s-codec/e1c_b1_rtss.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/ {
+	aliases {
+		i2s-codec-tx = &i2s0;
+	};
+};
+
+&i2s0 {
+	status = "okay";
+};
+
+&pinctrl_i2s0 {
+	group0 {
+		pinmux = <PIN_P2_4__I2S0_SDI_B>,
+			 <PIN_P2_5__I2S0_SDO_B>,
+			 <PIN_P1_6__I2S0_SCLK_A>,
+			 <PIN_P1_7__I2S0_WS_A>;
+	};
+};
+
+&i2c1 {
+	status = "okay";
+
+	audio_codec: wm8904@1a {
+		compatible = "cirrus,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
+};

--- a/snippets/i2s-codec/e4_e8_rtss_ak.overlay
+++ b/snippets/i2s-codec/e4_e8_rtss_ak.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/ {
+	aliases {
+		i2s-codec-tx = &i2s2;
+	};
+};
+
+&i2s2 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+
+	audio_codec: wm8904@1a {
+		compatible = "cirrus,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
+};

--- a/snippets/i2s-codec/e4_e8_rtss_dk.overlay
+++ b/snippets/i2s-codec/e4_e8_rtss_dk.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/ {
+	aliases {
+		i2s-codec-tx = &i2s3;
+	};
+};
+
+&i2s3 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+
+	audio_codec: wm8904@1a {
+		compatible = "cirrus,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
+};

--- a/snippets/i2s-codec/snippet.yml
+++ b/snippets/i2s-codec/snippet.yml
@@ -1,0 +1,13 @@
+name: i2s-codec
+boards:
+  /alif_(e1c|b1)_dk.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: e1c_b1_rtss.overlay
+
+  /alif_(e4|e8)_ak.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: e4_e8_rtss_ak.overlay
+
+  /alif_(e4|e8)_dk.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: e4_e8_rtss_dk.overlay


### PR DESCRIPTION
* configures the WM8904 codec for I2S playback,
* configures the I2S TX path with a small static memory slab,
* generates a simple 1 kHz tone in software instead of storing a PCM file in flash,  
* streams stereo 24-bit samples using 32-bit containers, and
* plays the tone for a short, fixed duration.