### PR TITLE
manifest: update zephyr to pick up mpu table updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 3c118bc4e0e1e366655e71018cd72f742ebc99f1
+      revision: d197c6bfb6c17b6a54c2bf8fb90aab9afeda1783
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pick up mpu table updates for the MRAM storage area to support mcuboot use cases.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/437