### PR TITLE
samples: drivers: i2c_dw: fix target-read-requested-callback

### DIFF
--- a/doc/release_notes/source/release_note.rst
+++ b/doc/release_notes/source/release_note.rst
@@ -422,6 +422,8 @@ Bug Fixes
      - Corrected SRAM1 mapping from ``0x08000000`` to ``0x02400000``
    * - Touchscreen
      - Fixed issue where touch screen events were intermittently dropped
+   * - I2C
+     - Fixed I2C target ``read_requested`` and ``read_processed`` callback handling
 
 Planned Deprecations
 --------------------

--- a/samples/drivers/i2c_dw/README.rst
+++ b/samples/drivers/i2c_dw/README.rst
@@ -30,12 +30,14 @@ The overlay used in the snippet configures i2c master and slave instances.
 Sample Output
 =============
 .. code-block:: console
-        Received a byte in slave : 0xaa
-        Received a byte in slave : 0xab
-        Received a byte in slave : 0xac
-        Received a byte in slave : 0xad
-        Master wrote 0xaa 0xab 0xac 0xad to slave
-        Read requested from Master and send 0x60 from slave
-        Read processed_cb called
-        Master received Data 0x60 From Slave
-        <repeats endlessly>
+   Received a byte in slave : 0xaa
+   Received a byte in slave : 0xab
+   Received a byte in slave : 0xac
+   Received a byte in slave : 0xad
+   Master wrote 0xaa 0xab 0xac 0xad to slave
+   Read requested from Master and send 0x50 from slave
+   Read processed from Master and send 0x51 from slave
+   Read processed from Master and send 0x52 from slave
+   Read processed from Master and send 0x53 from slave
+   Master received following data from the Slave:0x50 0x51 0x52 0x53
+   ...continues, with the slave TX bytes incrementing on subsequent iterations

--- a/samples/drivers/i2c_dw/src/main.c
+++ b/samples/drivers/i2c_dw/src/main.c
@@ -87,9 +87,12 @@ int i2c_target_write_requested_cb(struct i2c_target_config *config)
 {
 	return 0;
 }
+
+static volatile uint8_t slv_tx_data = 0x50;
+
 int i2c_target_read_requested_cb(struct i2c_target_config *config, uint8_t *val)
 {
-	*val = 0x60;
+	*val = slv_tx_data++;
 	printk("Read requested from Master and send 0x%x from slave\n", *val);
 	return 0;
 }
@@ -100,7 +103,8 @@ int i2c_target_write_received_cb(struct i2c_target_config *config, uint8_t val)
 }
 int i2c_target_read_processed_cb(struct i2c_target_config *config, uint8_t *val)
 {
-	printk("Read processed_cb called\n");
+	*val = slv_tx_data++;
+	printk("Read processed from Master and send 0x%x from slave\n", *val);
 	return 0;
 }
 

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 9bca98ae74dc24b2d68d32591eaa0746fb8d6841
+      revision: ff5c4824ee705b53845c29ee2c92bf81149ce60d
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
- Send slave data in both read_requested and read_processed callbacks.
- It is required to send first byte of the message in read_requested callback and the remaining data in read_processed callback.

This PR points to https://github.com/alifsemi/zephyr_alif/pull/438.