### PR TITLE
samples: drivers: dma: add dma_scatter_gather sample

### DIFF
--- a/samples/drivers/dma_scatter_gather/CMakeLists.txt
+++ b/samples/drivers/dma_scatter_gather/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+
+# Apply the alif-dma snippet automatically for manual builds.
+# Twister/CI builds use extra_args: -S alif-dma in sample.yaml instead.
+if(NOT alif-dma IN_LIST SNIPPET)
+  set(SNIPPET alif-dma ${SNIPPET} CACHE STRING "" FORCE)
+endif()
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dma_scatter_gather)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/dma_scatter_gather/README.rst
+++ b/samples/drivers/dma_scatter_gather/README.rst
@@ -1,0 +1,51 @@
+.. _dma-scatter-gather-sample:
+
+DMA Scatter-Gather Sample
+##########################
+
+Overview
+********
+
+This sample demonstrates scatter-gather DMA support using the PL330 DMA driver.
+
+Three memory blocks of different sizes are chained together and transferred in a
+single DMA operation without CPU involvement between blocks. The sample uses
+memory-to-memory transfers so no peripheral or hardware setup is required.
+
+Building and Running
+********************
+
+The application requires the ``alif-dma`` snippet to select the
+correct DMA controller node for the target core:
+
+- **RTSS-HE** (Ensemble HE, E1C, Balletto): uses ``dma2``
+- **RTSS-HP** (Ensemble HP): uses ``dma1``
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/dma_scatter_gather
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build flash
+   :gen-args: -S alif-dma
+
+To build for RTSS-HP:
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/dma_scatter_gather
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
+   :goals: build flash
+   :gen-args: -S alif-dma
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   [00:00:00.000,000] <inf> dma_pl330: Device dma2@400c0000 initialized
+   *** Booting Zephyr OS build fcc8b4926c15 ***
+   [00:00:00.000,000] <inf> dma_sg_test: DMA scatter-gather test starting
+   [00:00:00.000,000] <inf> dma_sg_test: Starting scatter-gather: block1=64 bytes, block2=128 bytes, block3=32 bytes
+   [00:00:00.000,000] <inf> dma_sg_test: DMA scatter-gather complete on channel 0
+   [00:00:00.000,000] <inf> dma_sg_test: PASS: block1 (64 bytes)
+   [00:00:00.000,000] <inf> dma_sg_test: PASS: block2 (128 bytes)
+   [00:00:00.000,000] <inf> dma_sg_test: PASS: block3 (32 bytes)
+   [00:00:00.000,000] <inf> dma_sg_test: All blocks passed

--- a/samples/drivers/dma_scatter_gather/prj.conf
+++ b/samples/drivers/dma_scatter_gather/prj.conf
@@ -1,0 +1,12 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=3
+CONFIG_DMA=y
+CONFIG_DMA_LOG_LEVEL_INF=n

--- a/samples/drivers/dma_scatter_gather/sample.yaml
+++ b/samples/drivers/dma_scatter_gather/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: DMA Scatter-Gather Sample
+tests:
+  sample.drivers.dma.scatter_gather:
+    tags: drivers dma
+    platform_allow: ensemble balletto
+    depends_on: dma
+    extra_args: -S alif-dma

--- a/samples/drivers/dma_scatter_gather/snippets/alif-dma/rtss_he.overlay
+++ b/samples/drivers/dma_scatter_gather/snippets/alif-dma/rtss_he.overlay
@@ -1,0 +1,21 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/* RTSS-HE core: DMA2 is the local DMA controller */
+
+/ {
+	aliases {
+		test-dma = &dma2;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};

--- a/samples/drivers/dma_scatter_gather/snippets/alif-dma/rtss_hp.overlay
+++ b/samples/drivers/dma_scatter_gather/snippets/alif-dma/rtss_hp.overlay
@@ -1,0 +1,21 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/* RTSS-HP core: DMA1 is the local DMA controller */
+
+/ {
+	aliases {
+		test-dma = &dma1;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/samples/drivers/dma_scatter_gather/snippets/alif-dma/snippet.yml
+++ b/samples/drivers/dma_scatter_gather/snippets/alif-dma/snippet.yml
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+name: alif-dma
+
+boards:
+  /alif_.*/.*/rtss_he/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: rtss_he.overlay
+
+  /alif_.*/.*/rtss_hp/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: rtss_hp.overlay

--- a/samples/drivers/dma_scatter_gather/src/main.c
+++ b/samples/drivers/dma_scatter_gather/src/main.c
@@ -1,0 +1,299 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * DMA Scatter-Gather Test Application
+ *
+ * This application demonstrates DMA scatter-gather functionality by transferring
+ * three separate blocks of data from source buffers to destination buffers.
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(dma_sg_test, LOG_LEVEL_INF);
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/sys/atomic.h>
+#include <string.h>
+#include <errno.h>
+#include <soc_common.h>
+
+/* DMA device and channel configuration */
+#define DMA_NODE    DT_ALIAS(test_dma)
+
+#if !DT_NODE_EXISTS(DMA_NODE)
+#error "test-dma devicetree alias is not defined; apply the alif-dma snippet"
+#elif !DT_NODE_HAS_STATUS_OKAY(DMA_NODE)
+#error "test-dma devicetree node is disabled; enable it in your overlay"
+#endif
+
+#define DMA_CHANNEL 0
+
+/* Block sizes for scatter-gather transfer */
+#define BLOCK1_SIZE 64
+#define BLOCK2_SIZE 128
+#define BLOCK3_SIZE 32
+
+/* Source and destination buffers, aligned for DMA word size */
+static uint8_t src1[BLOCK1_SIZE] __aligned(sizeof(uint32_t));
+static uint8_t src2[BLOCK2_SIZE] __aligned(sizeof(uint32_t));
+static uint8_t src3[BLOCK3_SIZE] __aligned(sizeof(uint32_t));
+
+static uint8_t dst1[BLOCK1_SIZE] __aligned(sizeof(uint32_t));
+static uint8_t dst2[BLOCK2_SIZE] __aligned(sizeof(uint32_t));
+static uint8_t dst3[BLOCK3_SIZE] __aligned(sizeof(uint32_t));
+
+/* Synchronization primitives for DMA completion */
+static K_SEM_DEFINE(dma_done, 0, 1);
+static atomic_t dma_error = ATOMIC_INIT(0);
+
+/*
+ * DMA completion callback function
+ *
+ * Called when DMA transfer completes or encounters an error.
+ * Signals the main thread via semaphore.
+ */
+static void dma_callback(const struct device *dev, void *user_data, uint32_t channel, int status)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+
+	if (status < 0) {
+		LOG_ERR("DMA error on channel %d: %d", channel, status);
+		atomic_set(&dma_error, status);
+	} else {
+		LOG_INF("DMA scatter-gather complete on channel %d", channel);
+		atomic_set(&dma_error, 0);
+	}
+	k_sem_give(&dma_done);
+}
+
+/*
+ * Fill a buffer with a pattern
+ *
+ * Fills the buffer with incrementing values starting from the given pattern.
+ */
+static void fill_buffer(uint8_t *buf, size_t size, uint8_t pattern)
+{
+	for (size_t i = 0; i < size; i++) {
+		buf[i] = pattern + (uint8_t)i;
+	}
+}
+
+/*
+ * Clear destination buffers
+ *
+ * Sets all destination buffers to zero to ensure clean verification.
+ */
+static void clear_buffers(void)
+{
+	memset(dst1, 0, sizeof(dst1));
+	memset(dst2, 0, sizeof(dst2));
+	memset(dst3, 0, sizeof(dst3));
+}
+
+/*
+ * Setup scatter-gather block configurations
+ *
+ * Creates a linked list of DMA block configurations for the three transfer blocks.
+ * Each block specifies source/destination addresses, size, and address adjustment.
+ */
+static int setup_scatter_gather_blocks(struct dma_block_config *blocks)
+{
+	/* Block 3 (last in chain) */
+	blocks[2] = (struct dma_block_config){
+		.source_address = (uintptr_t)src3,
+		.dest_address = (uintptr_t)dst3,
+		.block_size = BLOCK3_SIZE,
+		.source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.next_block = NULL,
+	};
+
+	/* Block 2 */
+	blocks[1] = (struct dma_block_config){
+		.source_address = (uintptr_t)src2,
+		.dest_address = (uintptr_t)dst2,
+		.block_size = BLOCK2_SIZE,
+		.source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.next_block = &blocks[2],
+	};
+
+	/* Block 1 (head) */
+	blocks[0] = (struct dma_block_config){
+		.source_address = (uintptr_t)src1,
+		.dest_address = (uintptr_t)dst1,
+		.block_size = BLOCK1_SIZE,
+		.source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+		.next_block = &blocks[1],
+	};
+
+	return 0;
+}
+
+/*
+ * Configure and start DMA transfer
+ *
+ * Sets up DMA configuration with scatter-gather blocks and starts the transfer.
+ */
+static int configure_and_start_dma(const struct device *dma_dev,
+				 struct dma_block_config *head_block)
+{
+	struct dma_config dma_cfg = {
+		.channel_direction = MEMORY_TO_MEMORY,
+		.source_data_size = 4,
+		.dest_data_size = 4,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,	/* burst=1 keeps alignment simple for this test */
+		.dma_slot = 0,
+		.block_count = 3,
+		.head_block = head_block,
+		.dma_callback = dma_callback,
+		.user_data = NULL,
+	};
+
+	int ret = dma_config(dma_dev, DMA_CHANNEL, &dma_cfg);
+
+	if (ret) {
+		LOG_ERR("dma_config failed: %d", ret);
+		return ret;
+	}
+
+	ret = dma_start(dma_dev, DMA_CHANNEL);
+	if (ret) {
+		LOG_ERR("dma_start failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * Wait for DMA completion
+ *
+ * Blocks until DMA transfer completes or times out.
+ */
+static int wait_for_completion(void)
+{
+	int ret = k_sem_take(&dma_done, K_SECONDS(1));
+
+	if (ret) {
+		LOG_ERR("DMA timed out");
+		return ret;
+	}
+
+	return atomic_get(&dma_error);
+}
+
+/*
+ * Verify transfer results
+ *
+ * Compares source and destination buffers for each block to ensure correct transfer.
+ */
+static int verify_transfer(void)
+{
+	int pass = 1;
+
+	if (memcmp(src1, dst1, BLOCK1_SIZE) != 0) {
+		LOG_ERR("FAIL: block1 mismatch");
+		pass = 0;
+	} else {
+		LOG_INF("PASS: block1 (%zu bytes)", (size_t)BLOCK1_SIZE);
+	}
+
+	if (memcmp(src2, dst2, BLOCK2_SIZE) != 0) {
+		LOG_ERR("FAIL: block2 mismatch");
+		pass = 0;
+	} else {
+		LOG_INF("PASS: block2 (%zu bytes)", (size_t)BLOCK2_SIZE);
+	}
+
+	if (memcmp(src3, dst3, BLOCK3_SIZE) != 0) {
+		LOG_ERR("FAIL: block3 mismatch");
+		pass = 0;
+	} else {
+		LOG_INF("PASS: block3 (%zu bytes)", (size_t)BLOCK3_SIZE);
+	}
+
+	return pass ? 0 : -EIO;
+}
+
+/*
+ * Run scatter-gather test
+ *
+ * Main test function that sets up data, configures DMA, starts transfer,
+ * waits for completion, and verifies results.
+ */
+static int run_scatter_gather_test(const struct device *dma_dev)
+{
+	static struct dma_block_config blocks[3];
+	int ret;
+
+	/* Setup test data */
+	fill_buffer(src1, BLOCK1_SIZE, 0xA0);
+	fill_buffer(src2, BLOCK2_SIZE, 0xB0);
+	fill_buffer(src3, BLOCK3_SIZE, 0xC0);
+	clear_buffers();
+
+	/* Setup scatter-gather blocks */
+	ret = setup_scatter_gather_blocks(blocks);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure and start DMA */
+	ret = configure_and_start_dma(dma_dev, &blocks[0]);
+	if (ret) {
+		return ret;
+	}
+
+	LOG_INF("Starting scatter-gather: block1=%zu bytes, block2=%zu bytes, block3=%zu bytes",
+		(size_t)BLOCK1_SIZE, (size_t)BLOCK2_SIZE, (size_t)BLOCK3_SIZE);
+
+	/* Wait for completion */
+	ret = wait_for_completion();
+	if (ret) {
+		dma_stop(dma_dev, DMA_CHANNEL);
+		return ret;
+	}
+
+	/* Verify results */
+	return verify_transfer();
+}
+
+/*
+ * Main application entry point
+ *
+ * Initializes DMA device and runs the scatter-gather test.
+ */
+int main(void)
+{
+	const struct device *dma_dev = DEVICE_DT_GET(DMA_NODE);
+	int ret;
+
+	LOG_INF("DMA scatter-gather test starting");
+
+	if (!device_is_ready(dma_dev)) {
+		LOG_ERR("DMA device not ready");
+		return -ENODEV;
+	}
+
+	ret = run_scatter_gather_test(dma_dev);
+	if (ret == 0) {
+		LOG_INF("All blocks passed");
+	} else {
+		LOG_ERR("Test failed");
+	}
+
+	return ret;
+}

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 79c4c07c145348229bf38894c826cb318d5837b5
+      revision: 819a722
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Add memory-to-memory scatter-gather DMA test application for Alif Ensemble and Balletto devices. Tests block chaining support added to the PL330 DMA driver.

Depends : https://github.com/alifsemi/zephyr_alif/pull/442