### PR TITLE
samples: executorch: kws_ethosu: add E1C and B1DK support

### DIFF
--- a/samples/modules/executorch/kws_ethosu/CMakeLists.txt
+++ b/samples/modules/executorch/kws_ethosu/CMakeLists.txt
@@ -216,18 +216,18 @@ add_custom_command(
 add_custom_target(gen_model_header DEPENDS ${_model_pte_header})
 add_dependencies(app gen_model_header)
 
-if(DEFINED CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE)
-  target_compile_definitions(
-    app PRIVATE
-    ET_ARM_METHOD_ALLOCATOR_POOL_SIZE=${CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE}
-  )
-endif()
-if(DEFINED CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE)
-  target_compile_definitions(
-    app PRIVATE
-    ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE}
-  )
-endif()
+# Memory pool sizes — Kconfig is the single source of truth.
+# Board-specific defaults (SRAM0 vs DTCM) are handled by Kconfig defaults
+# (see SOC_FAMILY_BALLETTO / SOC_SERIES_E1C guards in Kconfig).
+# Section placement is handled by DT_NODE_HAS_STATUS in main.cpp.
+target_compile_definitions(
+  app PRIVATE
+  ET_ARM_METHOD_ALLOCATOR_POOL_SIZE=${CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE}
+  ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE}
+)
+
+message(STATUS "ExecutorTorch: Method pool: ${CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE} bytes")
+message(STATUS "ExecutorTorch: Temp pool:   ${CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE} bytes")
 
 target_link_libraries(app PRIVATE libexecutorch)
 if(EXECUTORCH_OPS_LIB)

--- a/samples/modules/executorch/kws_ethosu/Kconfig
+++ b/samples/modules/executorch/kws_ethosu/Kconfig
@@ -10,20 +10,26 @@ menu "executorch KWS sample configuration"
 
 config EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE
 	int "Method allocator pool size in bytes"
+	default 65536 if SOC_FAMILY_BALLETTO
+	default 65536 if SOC_SERIES_E1C
 	default 1572864
 	depends on EXECUTORCH
 	help
 	  Size of the method allocator pool in bytes. This memory is used
 	  for allocating ExecuTorch method instances and their metadata.
-	  Default is 1.5MB for KWS model requirements.
+	  Default is 64KB for boards without SRAM0 (B1, E1C) which use DTCM,
+	  and 1.5MB for boards with SRAM0 (E3/E4/E7/E8).
 
 config EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE
 	int "Temporary allocator pool size in bytes"
+	default 65536 if SOC_FAMILY_BALLETTO
+	default 65536 if SOC_SERIES_E1C
 	default 1572864
 	depends on EXECUTORCH
 	help
 	  Size of the temporary allocator pool in bytes. This memory is used
 	  for temporary allocations during model execution such as Ethos-U
-	  scratch memory. Default is 1.5MB for KWS model requirements.
+	  scratch memory. Default is 64KB for boards without SRAM (B1, E1C),
+	  and 1.5MB for boards with SRAM (E3/E4/E7/E8).
 
 endmenu

--- a/samples/modules/executorch/kws_ethosu/README.rst
+++ b/samples/modules/executorch/kws_ethosu/README.rst
@@ -53,6 +53,10 @@ Supported Boards
 +-------+--------+---------+-------------------------+
 | Board | U55    | U85     | Status                  |
 +=======+========+=========+=========================+
+| B1    | Yes    | No      | **Tested**              |
++-------+--------+---------+-------------------------+
+| E1C   | Yes    | No      | **Tested**              |
++-------+--------+---------+-------------------------+
 | E7    | Yes    | No      | **Tested**              |
 +-------+--------+---------+-------------------------+
 | E8    | Yes    | Yes     | **Tested**              |
@@ -63,10 +67,6 @@ Supported Boards
 +-------+--------+---------+-------------------------+
 | Board | U55    | U85     | Notes                   |
 +=======+========+=========+=========================+
-| B1    | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
-| E1C   | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
 | E3    | Yes    | No      | U55 only                |
 +-------+--------+---------+-------------------------+
 | E4    | Yes    | Yes     | Dual NPU                |
@@ -232,7 +232,7 @@ Building for Alif E7 DK (HP Core with U55)
 
 .. code-block:: console
 
-   west build -b alif_e7_dk/ae722f80f55d5xx0/rtss_hp \
+   west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
        -S ethos-u55-enable \
        alif/samples/modules/executorch/kws_ethosu/ -- \
        -DET_PTE_FILE_PATH=./kws_u55_256.pte \
@@ -244,7 +244,31 @@ Building for Alif E7 DK (HE Core with U55-128)
 
 .. code-block:: console
 
-   west build -b alif_e7_dk/ae722f80f55d5as0/rtss_he \
+   west build -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
+       -S ethos-u55-enable \
+       alif/samples/modules/executorch/kws_ethosu/ -- \
+       -DET_PTE_FILE_PATH=./kws_u55_128.pte \
+       -DET_PTE_SECTION=.rodata.model \
+       -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+
+Building for Alif E1C DK (HE Core with U55-128)
+===============================================
+
+.. code-block:: console
+
+   west build -b alif_e1c_dk/ae1c1f4051920hh/rtss_he \
+       -S ethos-u55-enable \
+       alif/samples/modules/executorch/kws_ethosu/ -- \
+       -DET_PTE_FILE_PATH=./kws_u55_128.pte \
+       -DET_PTE_SECTION=.rodata.model \
+       -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+
+Building for Alif B1 DK (HE Core with U55-128)
+==============================================
+
+.. code-block:: console
+
+   west build -b alif_b1_dk/ab1c1f4m51820ph0/rtss_he \
        -S ethos-u55-enable \
        alif/samples/modules/executorch/kws_ethosu/ -- \
        -DET_PTE_FILE_PATH=./kws_u55_128.pte \

--- a/samples/modules/executorch/kws_ethosu/sample.yaml
+++ b/samples/modules/executorch/kws_ethosu/sample.yaml
@@ -5,6 +5,7 @@ common:
   tags: executorch ml npu ethos-u kws
   depends_on: executorch arm_ethos_u
 tests:
+  # Ensemble boards with SRAM0 (E7/E8) - 1.5MB pools in SRAM
   sample.executorch.kws_ethosu.e8_hp:
     build_only: true
     platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
@@ -13,7 +14,14 @@ tests:
     platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_he
   sample.executorch.kws_ethosu.e7_hp:
     build_only: true
-    platform_allow: alif_e7_dk/ae722f80f55d5xx0/rtss_hp
+    platform_allow: alif_e7_dk/ae722f80f55d5xx/rtss_hp
   sample.executorch.kws_ethosu.e7_he:
     build_only: true
-    platform_allow: alif_e7_dk/ae722f80f55d5as0/rtss_he
+    platform_allow: alif_e7_dk/ae722f80f55d5xx/rtss_he
+  # Boards without SRAM0 (E1C, B1) - 64KB pools in DTCM
+  sample.executorch.kws_ethosu.e1c_he:
+    build_only: true
+    platform_allow: alif_e1c_dk/ae1c1f4051920hh/rtss_he
+  sample.executorch.kws_ethosu.b1_he:
+    build_only: true
+    platform_allow: alif_b1_dk/ab1c1f4m51820ph0/rtss_he

--- a/samples/modules/executorch/kws_ethosu/src/main.cpp
+++ b/samples/modules/executorch/kws_ethosu/src/main.cpp
@@ -55,34 +55,48 @@ extern "C" executorch::runtime::Error
 executorch_delegate_EthosUBackend_registered(void);
 #endif
 
-#if !defined(ET_ARM_METHOD_ALLOCATOR_POOL_SIZE)
-#define ET_ARM_METHOD_ALLOCATOR_POOL_SIZE (1572864)
-#endif
-const size_t method_allocation_pool_size = ET_ARM_METHOD_ALLOCATOR_POOL_SIZE;
-unsigned char __attribute__((
-    section(".alif_sram0.tensor_arena"),
-    aligned(16))) method_allocation_pool[method_allocation_pool_size];
+/*
+ * Memory section placement for Alif boards:
+ *
+ * Boards WITH sram0 (E3/E4/E7/E8):
+ *   - Use .alif_sram0 sections for tensor arena (fast, 4MB SRAM)
+ *
+ * Boards WITHOUT sram0 (E1C, B1):
+ *   - Use default BSS placement in DTCM
+ *
+ * Pool sizes are configured via Kconfig (see EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE
+ * and EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE) and passed through CMakeLists.txt as
+ * compile definitions.
+ */
+#include <zephyr/devicetree.h>
 
-#if !defined(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
-#define ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE (1572864)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram0), okay)
+#define ET_TENSOR_ARENA_ATTR __attribute__((section(".alif_sram0.tensor_arena"), aligned(16)))
+#define ET_ETHOSU_SCRATCH_ATTR __attribute__((section(".alif_sram0.ethosu_scratch"), aligned(16)))
+#else
+#define ET_TENSOR_ARENA_ATTR __attribute__((aligned(16)))
+#define ET_ETHOSU_SCRATCH_ATTR __attribute__((aligned(16)))
 #endif
 
 #if !defined(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
 #define ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x600
 #endif
 
+const size_t method_allocation_pool_size = ET_ARM_METHOD_ALLOCATOR_POOL_SIZE;
+ET_TENSOR_ARENA_ATTR
+unsigned char method_allocation_pool[ET_ARM_METHOD_ALLOCATOR_POOL_SIZE];
+
 const size_t temp_allocation_pool_size =
     ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
-unsigned char __attribute__((
-    section(".alif_sram0.tensor_arena"),
-    aligned(16))) temp_allocation_pool[temp_allocation_pool_size];
+ET_TENSOR_ARENA_ATTR
+unsigned char temp_allocation_pool[ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
 
 #if defined(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
 extern "C" {
 size_t ethosu_fast_scratch_size =
     ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
-unsigned char __attribute__((section(".alif_sram0.ethosu_scratch"), aligned(16)))
-dedicated_sram[ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
+ET_ETHOSU_SCRATCH_ATTR
+unsigned char dedicated_sram[ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
 unsigned char* ethosu_fast_scratch = dedicated_sram;
 }
 #endif


### PR DESCRIPTION
Add board support for E1C and B1DK with automatic memory pool configuration based on SRAM availability.