### PR TITLE
manifest: update zephyr_alif revision for libisp change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 2badbfe0b0aeaaba49cbdee0a03b2a5153d2c33b
+      revision: pull/443/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the zephyr_alif revision to include libisp_gcc.a in hal_alif.

This PR refers to https://github.com/alifsemi/zephyr_alif/pull/443