### PR TITLE
manifest: update zephyr_alif revision for ARX3A0 change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 22667b6ae71f6e27e2fcfb3820192a241cbf4136
+      revision: 080b30f9d58346fff93731ccb48a395c92a0ed10
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update the zephyr_alif revision to include ARX3A0 exposure support.

This PR depends on: alifsemi/zephyr_alif/pull/465.
This PR depends on: alifsemi/hal_alif/pull/113