### PR TITLE
tests: drivers: i3c: Add comprehensive I3C driver test suite

### DIFF
--- a/tests/drivers/i3c/CMakeLists.txt
+++ b/tests/drivers/i3c/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i3c)
+
+set(I3C_COMMON_SOURCES src/i3c_common.c)
+
+set(I3C_DISCOVERY_SOURCES src/i3c_discovery.c ${I3C_COMMON_SOURCES})
+
+set(I3C_CCC_SOURCES src/i3c_ccc.c ${I3C_COMMON_SOURCES})
+
+set(I3C_IBI_SOURCES src/i3c_ibi.c ${I3C_COMMON_SOURCES})
+
+set(I3C_NEGATIVE_SOURCES src/i3c_negative.c ${I3C_COMMON_SOURCES})
+
+set(I3C_STRESS_SOURCES src/i3c_stress.c ${I3C_COMMON_SOURCES})
+
+set(I3C_SENSOR_SOURCES src/i3c_sensor.c ${I3C_COMMON_SOURCES})
+
+
+if(CONFIG_I3C_DISCOVERY_TESTS)
+  target_sources(app PRIVATE ${I3C_DISCOVERY_SOURCES})
+endif()
+
+if(CONFIG_I3C_CCC_TESTS)
+  target_sources(app PRIVATE ${I3C_CCC_SOURCES})
+endif()
+
+if(CONFIG_I3C_IBI_TESTS)
+  target_sources(app PRIVATE ${I3C_IBI_SOURCES})
+endif()
+
+if(CONFIG_I3C_NEGATIVE_TESTS)
+  target_sources(app PRIVATE ${I3C_NEGATIVE_SOURCES})
+endif()
+
+if(CONFIG_I3C_STRESS_TESTS)
+  target_sources(app PRIVATE ${I3C_STRESS_SOURCES})
+endif()
+
+if(CONFIG_I3C_SENSOR_TESTS)
+  target_sources(app PRIVATE ${I3C_SENSOR_SOURCES})
+endif()
+

--- a/tests/drivers/i3c/Kconfig
+++ b/tests/drivers/i3c/Kconfig
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+menu "I3C test options"
+
+config I3C_ALL_TESTS
+	bool "Enable all I3C test suites"
+	select I3C_DISCOVERY_TESTS
+	select I3C_CCC_TESTS
+	select I3C_IBI_TESTS
+	select I3C_NEGATIVE_TESTS
+	select I3C_STRESS_TESTS
+	help
+	  This option enables all standard I3C test suites including
+	  discovery tests, Common Command Code (CCC) tests, In-Band
+	  Interrupt (IBI) tests, negative tests, and stress tests.
+	  This is a convenience option for running comprehensive I3C
+	  controller validation. Note that I3C_SENSOR_TESTS is not
+	  included as it requires specific sensor hardware.
+
+config I3C_DISCOVERY_TESTS
+	bool "Enable I3C discovery test suite"
+	help
+	  This option enables the I3C discovery test suite which validates
+	  the Dynamic Address Assignment (DAA) process, Provisional ID (PID)
+	  retrieval, target enumeration, RSTDAA broadcast commands, and
+	  various discovery-related CCCs. These tests verify that the I3C
+	  controller can properly discover and configure devices on the bus.
+
+config I3C_CCC_TESTS
+	bool "Enable I3C CCC test suite"
+	help
+	  This option enables the Common Command Code (CCC) test suite
+	  which tests mandatory and optional CCCs including GETPID,
+	  GETBCR, GETDCR, GETSTATUS, GETMRL, SETMWL, GETMWL, ENEC,
+	  DISEC, RSTACT, and GETCAPS. These tests verify that the I3C
+	  controller can properly send and receive CCC commands to targets.
+
+config I3C_IBI_TESTS
+	bool "Enable I3C IBI test suite"
+	help
+	  This option enables the In-Band Interrupt (IBI) test suite which
+	  validates IBI capability detection via BCR register, ENEC and
+	  DISEC commands for enabling/disabling interrupts, and transfer
+	  operations with IBI enabled. These tests verify that the I3C
+	  controller can handle in-band interrupt requests from targets.
+
+config I3C_NEGATIVE_TESTS
+	bool "Enable I3C negative test suite"
+	help
+	  This option enables the negative test suite which validates
+	  error handling for invalid dynamic addresses, null buffer
+	  transfers, zero-length transfers, oversized transfers, and
+	  CCC commands to invalid targets. These tests verify that the
+	  I3C controller properly handles and reports error conditions.
+
+config I3C_STRESS_TESTS
+	bool "Enable I3C stress test suite"
+	help
+	  This option enables the stress test suite which performs
+	  repeated operations including GETPID calls, read endurance
+	  tests, multi-message endurance tests, and CCC transfer
+	  interleave tests. These tests verify controller stability
+	  and reliability under sustained load across multiple targets.
+
+config I3C_SENSOR_TESTS
+	bool "Enable I3C sensor test suite"
+	help
+	  This option enables the sensor test suite which validates
+	  real I3C sensor devices including the BMI323 accelerometer
+	  and gyroscope, and the ICM42670 motion sensor. These tests
+	  require the actual sensor hardware to be connected and
+	  configured in the device tree. Enable this only when testing
+	  with physical sensor devices present on the I3C bus.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/tests/drivers/i3c/README.rst
+++ b/tests/drivers/i3c/README.rst
@@ -1,0 +1,106 @@
+.. _i3c_ztest:
+
+I3C Driver Tests
+################
+
+Overview
+========
+
+This test suite validates I3C controller and target communication for MIPI I3C
+Basic v1.0 specification compliance. The tests use Zephyr ZTest framework with
+per-test setup/teardown hooks to ensure clean bus state.
+
+Test Framework
+==============
+
+The test suite uses ZTest's ``test_before`` and ``test_after`` hooks:
+
+- **suite_setup**: Initializes I3C controller, configures SDR mode, validates bus ready
+- **test_before**: Verifies devices have dynamic addresses from prior DAA
+- **test_after**: Empty teardown hook (reserved for future use)
+
+.. important::
+
+   **DAA (Dynamic Address Assignment) is performed ONCE externally** before any
+   test suites run - typically by system initialization or application setup.
+   Tests do NOT perform RSTDAA+DAA because:
+
+   1. Repeated RSTDAA causes address increments when devices are on bus
+      but not registered in device tree (hot-join scenario)
+   2. Driver may not handle repeated controller resets properly
+   3. Zephyr does not support hot-join - all devices must be in DT
+
+   If you see "PID not in registered device list" warnings with incrementing
+   addresses (0x0f, 0x10, 0x11...), ensure ALL physical devices are declared
+   in the device tree overlay, or perform a single RSTDAA+DAA before tests.
+
+   To perform DAA before tests, ensure your application or test main calls::
+
+      i3c_test_do_rstdaa_daa(ctrl);  /* Once, before ztest_run() */
+
+Test Suites
+===========
+
+- **discovery**: Bus discovery, DAA, target enumeration, address assignment
+- **ccc**: Common Command Codes (GETPID, GETBCR, GETDCR, SETNEWDA, etc.)
+- **ibi**: In-Band Interrupt capability and event handling
+- **negative**: Error conditions and negative scenarios
+- **stress**: Endurance tests under repeated operations
+- **sensor**: Sensor integration tests for BMI323
+
+Key Files
+=========
+
+- ``src/i3c_discovery.c``: Discovery and DAA test suite
+- ``src/i3c_ccc.c``: CCC command test suite
+- ``src/i3c_ibi.c``: IBI test suite
+- ``src/i3c_negative.c``: Negative test suite
+- ``src/i3c_stress.c``: Stress test suite
+- ``src/i3c_sensor.c``: Sensor integration test suite
+- ``src/i3c_common.c``: Common test utilities
+- ``src/i3c_common.h``: Common definitions
+- ``boards/i3c_test.overlay``: Device tree overlay
+
+Building and Running
+====================
+
+Build and run all tests:
+
+.. code-block:: console
+
+   west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp tests/drivers/i3c \
+     -DDTC_OVERLAY_FILE=boards/i3c_test.overlay \
+     -DCONFIG_I3C_ALL_TESTS=y
+   west flash
+
+Build with specific test suite:
+
+.. code-block:: console
+
+   west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp tests/drivers/i3c \
+     -DDTC_OVERLAY_FILE=boards/i3c_test.overlay \
+     -DCONFIG_I3C_DISCOVERY_TESTS=y
+
+Test Suite Selection
+====================
+
+Enable test suites via Kconfig:
+
+- ``CONFIG_I3C_DISCOVERY_TESTS=y``: Discovery tests
+- ``CONFIG_I3C_CCC_TESTS=y``: CCC tests
+- ``CONFIG_I3C_IBI_TESTS=y``: IBI tests
+- ``CONFIG_I3C_NEGATIVE_TESTS=y``: Negative tests
+- ``CONFIG_I3C_STRESS_TESTS=y``: Stress tests
+- ``CONFIG_I3C_SENSOR_TESTS=y``: Sensor tests
+- ``CONFIG_I3C_ALL_TESTS=y``: All test suites
+
+Configuration Options
+=====================
+
+Key options in ``prj.conf``:
+
+- ``CONFIG_I3C=y``: Enable I3C driver
+- ``CONFIG_SENSOR=y``: Enable sensor subsystem
+- ``CONFIG_BMI323=y``: Enable BMI323 sensor driver
+- ``CONFIG_ZTEST_STACK_SIZE=4096``: Test thread stack size
+

--- a/tests/drivers/i3c/boards/i3c_test.overlay
+++ b/tests/drivers/i3c/boards/i3c_test.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/ {
+	aliases {
+		/*
+		 * Add aliases here for each I3C target device.
+		 * Uncomment to enable, comment to disable.
+		 */
+		bmi323 = &bmi323;
+	};
+
+};
+
+&i3c0 {
+	status = "okay";
+	od-thigh-min-ns = <41>;
+	od-tlow-min-ns = <200>;
+
+	/*
+	 * BMI323 I3C sensor
+	 * PID: 0x077010431000 (manufacturer part-specific)
+	 * reg format: <static_addr pid_high pid_low>
+	 * - static_addr: 0x69 (7-bit I2C legacy address)
+	 * - pid_high: 0x0770 (MSB of 48-bit PID)
+	 * - pid_low: 0x10431000 (LSB of 48-bit PID)
+	 */
+	bmi323: bmi323@690000077010431000 {
+		compatible = "bosch,bmi323";
+		reg = <0x69 0x0770 0x10431000>;
+		assigned-address = <0x09>;
+		int-gpios = <&gpio8 4 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+};
+
+&gpio8 {
+	status = "okay";
+};

--- a/tests/drivers/i3c/prj.conf
+++ b/tests/drivers/i3c/prj.conf
@@ -1,0 +1,20 @@
+# Core I3C and test configuration
+CONFIG_TEST=y
+CONFIG_I3C=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=4096
+
+# Memory slab for runtime I3C descriptors (8 = max DAT positions)
+CONFIG_I3C_NUM_OF_DESC_MEM_SLABS=8
+
+# Sensor support for BMI323 and ICM42670 tests
+CONFIG_SENSOR=y
+CONFIG_BMI323=y
+
+# Required dependencies
+CONFIG_CLOCK_CONTROL=y
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=3
+CONFIG_I3C_LOG_LEVEL_DBG=n
+CONFIG_HEAP_MEM_POOL_SIZE=1024
+

--- a/tests/drivers/i3c/src/i3c_ccc.c
+++ b/tests/drivers/i3c/src/i3c_ccc.c
@@ -1,0 +1,508 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include <inttypes.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_ccc, LOG_LEVEL_INF);
+
+static const struct device *ctrl;
+
+/**
+ * @brief CCC test suite setup function
+ *
+ * Initializes I3C controller and resets bus to clean SDR state.
+ * All CCC tests use I3C_TEST_FOR_EACH_MODE macro to iterate
+ * through enabled speed modes (SDR by default).
+ *
+ * @return NULL on success, asserts on failure
+ */
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/* Configure SDR mode only.
+	 * NOTE: Zephyr does not support hot-join. DAA must be done by
+	 * application or device initialization before tests run.
+	 * We do NOT perform RSTDAA+DAA here because:
+	 * 1. If all suites run at once, repeated RSTDAA causes address
+	 *    increments and driver state issues
+	 * 2. If suites run individually, system/DT init should have
+	 *    already performed DAA
+	 */
+	i3c_test_reset_to_sdr(ctrl);
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	struct i3c_device_desc *desc;
+	int found = 0;
+
+	ARG_UNUSED(fixture);
+
+	/* Verify devices were assigned addresses by prior DAA */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			found++;
+		}
+	}
+
+	if (found == 0) {
+		LOG_WRN("No devices with dynamic address - ensure DAA completed before tests");
+		ztest_test_skip();
+	}
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_ccc, NULL, suite_setup, test_before, test_after, NULL);
+
+/**
+ * @brief Test GETPID (Get Provisional ID) CCC command
+ *
+ * Retrieves 48-bit provisional ID from each target across all
+ * speed modes. PID contains manufacturer ID and unique device ID.
+ *
+ * Test flow:
+ * 1. Iterate through all speed modes
+ * 2. For each target, send GETPID CCC
+ * 3. Verify response (6 bytes received)
+ */
+ZTEST(i3c_ccc, test_getpid)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		/* Delay after mode change for targets to stabilize */
+		k_msleep(50);
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t pid[6];
+			int ret = i3c_do_ccc_getpid(ctrl, desc->dynamic_addr,
+						    pid, 6);
+
+			/* Per I3C spec, GETPID is mandatory. */
+			zassert_true(ret == 6,
+				     "GETPID failed DA=0x%02x %s: %d (exp 6)",
+				     desc->dynamic_addr,
+				     i3c_test_mode_name(mode), ret);
+
+			/* Verify PID matches descriptor */
+			uint64_t pid_from_ccc = ((uint64_t)pid[0] << 40) |
+						((uint64_t)pid[1] << 32) |
+						((uint64_t)pid[2] << 24) |
+						((uint64_t)pid[3] << 16) |
+						((uint64_t)pid[4] << 8) |
+						pid[5];
+			LOG_INF("DA=0x%02x PID: CCC=0x%012" PRIx64
+				" desc=0x%012" PRIx64,
+				desc->dynamic_addr, pid_from_ccc, desc->pid);
+			zassert_equal(pid_from_ccc, desc->pid,
+				      "PID mismatch DA=0x%02x",
+				      desc->dynamic_addr);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test GETBCR (Bus Characteristics Register) and
+ *        GETDCR (Device Characteristics Register) CCC commands
+ *
+ * Retrieves bus and device characteristics from each target.
+ * BCR contains target capabilities, DCR contains device role.
+ *
+ * Per I3C specification, GETBCR and GETDCR are mandatory CCCs.
+ * Test verifies both values match the device descriptor.
+ */
+ZTEST(i3c_ccc, test_getbcr_getdcr)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t bcr, dcr;
+			int ret;
+
+			/* Per I3C spec, GETBCR is mandatory */
+			ret = i3c_do_ccc_getbcr(ctrl, desc->dynamic_addr, &bcr);
+			zassert_ok(ret,
+				   "GETBCR failed DA=0x%02x %s",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode));
+
+			/* Verify BCR matches descriptor */
+			LOG_INF("DA=0x%02x BCR: CCC=0x%02x desc=0x%02x",
+				desc->dynamic_addr, bcr, desc->bcr);
+			zassert_equal(bcr, desc->bcr,
+				      "BCR mismatch DA=0x%02x",
+				      desc->dynamic_addr);
+
+			/* Per I3C spec, GETDCR is mandatory */
+			ret = i3c_do_ccc_getdcr(ctrl, desc->dynamic_addr, &dcr);
+			zassert_ok(ret,
+				   "GETDCR failed DA=0x%02x %s",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode));
+
+			/* Verify DCR matches descriptor */
+			zassert_equal(dcr, desc->dcr,
+				      "DCR mismatch DA=0x%02x %s",
+				      desc->dynamic_addr,
+				      i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test GETSTATUS CCC command
+ *
+ * Retrieves device status from each target. Status includes
+ * pending interrupts, protocol errors, and device state.
+ *
+ * Note: GETSTATUS may not be supported by all targets.
+ * Failures are logged as debug messages, not test failures.
+ */
+ZTEST(i3c_ccc, test_getstatus)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		bool tested = false;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint16_t status;
+			int ret = i3c_do_ccc_getstatus(ctrl, desc->dynamic_addr,
+						       &status);
+
+			/* GETSTATUS is optional - skip this target
+			 * if not supported
+			 */
+			if (ret == -ENOTSUP) {
+				continue;
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "GETSTATUS failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+			tested = true;
+		} I3C_TEST_END_EACH_TARGET
+
+		/* Skip only if no targets supported GETSTATUS in this mode */
+		if (!tested) {
+			ztest_test_skip();
+		}
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test GETMRL (Get Max Read Length) CCC command
+ *
+ * Retrieves maximum read length supported by each target.
+ * MRL indicates the maximum number of bytes target can
+ * return in a single read transaction.
+ *
+ * Note: GETMRL may not be supported by all targets.
+ */
+ZTEST(i3c_ccc, test_getmrl)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		bool tested = false;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint16_t mrl;
+			int ret = i3c_do_ccc_getmrl(ctrl, desc->dynamic_addr,
+						    &mrl);
+
+			/* GETMRL is optional - skip this target
+			 * if not supported
+			 */
+			if (ret == -ENOTSUP) {
+				continue;
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "GETMRL failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+
+			/* Per MIPI spec: MRL=0 means no limit */
+			if (mrl == 0) {
+				LOG_INF("DA=0x%02x MRL=0, skip",
+					desc->dynamic_addr);
+			} else {
+				zassert_true(mrl <= 0xFFFF,
+					     "MRL 0x%04x out of range on DA=0x%02x",
+					     mrl, desc->dynamic_addr);
+			}
+			tested = true;
+		} I3C_TEST_END_EACH_TARGET
+
+		/* Skip only if no targets supported GETMRL in this mode */
+		if (!tested) {
+			ztest_test_skip();
+		}
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test SETMWL (Set Max Write Length) CCC command
+ *
+ * Sets maximum write length to 64 bytes for each target.
+ * First retrieves current MWL, then attempts to set new value.
+ *
+ * Note: SETMWL may not be supported by all targets.
+ */
+ZTEST(i3c_ccc, test_setmwl)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		bool tested = false;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint16_t mwl, new_mwl;
+			int ret;
+
+			/* Get current MWL */
+			ret = i3c_do_ccc_getmwl(ctrl, desc->dynamic_addr, &mwl);
+			if (ret == -ENOTSUP) {
+				continue;
+			}
+			zassert_ok(ret, "GETMWL failed on DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+
+			/* Per MIPI I3C spec: MWL=0 means no limit */
+			if (mwl == 0) {
+				LOG_INF("DA=0x%02x MWL=0, skip SETMWL",
+					desc->dynamic_addr);
+				continue;
+			}
+
+			/* Set new MWL to 64 bytes */
+			ret = i3c_do_ccc_setmwl(ctrl, desc->dynamic_addr, 64);
+			if (ret == -ENOTSUP) {
+				continue;
+			}
+			zassert_ok(ret, "SETMWL failed on DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+
+			/* Verify MWL was set correctly */
+			ret = i3c_do_ccc_getmwl(ctrl, desc->dynamic_addr,
+						&new_mwl);
+			zassert_ok(ret, "GETMWL verify failed DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+			zassert_equal(new_mwl, 64,
+				    "MWL mismatch DA=0x%02x: exp 64, got %d",
+				    desc->dynamic_addr, new_mwl);
+
+			/* Restore original MWL */
+			ret = i3c_do_ccc_setmwl(ctrl, desc->dynamic_addr, mwl);
+			zassert_ok(ret,
+				   "SETMWL restore failed DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+			tested = true;
+		} I3C_TEST_END_EACH_TARGET
+
+		/* Skip only if no targets supported SETMWL in this mode */
+		if (!tested) {
+			ztest_test_skip();
+		}
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test RSTACT (Reset Action) CCC command
+ *
+ * Triggers reset action (0x00 = full reset) on each target.
+ * Verifies target responds to reset command.
+ *
+ * Note: RSTACT may not be supported by all targets.
+ */
+ZTEST(i3c_ccc, test_rstact)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			int ret = i3c_do_ccc_rstact(ctrl, desc->dynamic_addr,
+						    0x00);
+
+			/* RSTACT is optional - skip if not supported */
+			if (ret == -ENOTSUP) {
+				ztest_test_skip();
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "RSTACT failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test ENEC (Enable Events Command) directed CCC
+ *
+ * Enables interrupt events (bit 0 = INTR) on each target.
+ * Skips ghost targets (SA=0x00) that don't exist.
+ *
+ * Note: ENEC may not be supported by all targets.
+ * BMI323 and ICM42670 do not support this command.
+ */
+ZTEST(i3c_ccc, test_enec_direct)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			/* Skip ghost targets */
+			if (desc->static_addr == 0x00) {
+				continue;
+			}
+
+			int ret = i3c_do_ccc_enec(ctrl, desc->dynamic_addr,
+						  0x01);
+
+			/* ENEC is optional - skip if not supported */
+			if (ret == -ENOTSUP) {
+				ztest_test_skip();
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "ENEC failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test DISEC (Disable Events Command) directed CCC
+ *
+ * Disables interrupt events (bit 0 = INTR) on each target.
+ * Skips ghost targets (SA=0x00) that don't exist.
+ *
+ * Note: DISEC may not be supported by all targets.
+ * BMI323 and ICM42670 do not support this command.
+ */
+ZTEST(i3c_ccc, test_disec_direct)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			/* Skip ghost targets */
+			if (desc->static_addr == 0x00) {
+				continue;
+			}
+
+			int ret = i3c_do_ccc_disec(ctrl, desc->dynamic_addr,
+						   0x01);
+
+			/* DISEC is optional - skip if not supported */
+			if (ret == -ENOTSUP) {
+				ztest_test_skip();
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "DISEC failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test multiple event enable/disable sequence
+ *
+ * Enables multiple events (bits 0 and 1), then disables them.
+ * Tests ENEC and DISEC with multi-bit masks.
+ *
+ * Test flow:
+ * 1. Enable events 0 and 1
+ * 2. If successful, disable events 0 and 1
+ */
+ZTEST(i3c_ccc, test_multiple_events)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			int ret = i3c_do_ccc_enec(ctrl, desc->dynamic_addr,
+						  0x03);
+
+			/* ENEC/DISEC are optional - skip if not supported */
+			if (ret == -ENOTSUP) {
+				ztest_test_skip();
+			}
+
+			zassert_ok(ret, "ENEC multiple failed on DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+
+			ret = i3c_do_ccc_disec(ctrl, desc->dynamic_addr, 0x03);
+			zassert_ok(ret, "DISEC failed DA=0x%02x: %d",
+				   desc->dynamic_addr, ret);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test GETCAPS (Get Device Capabilities) CCC command
+ *
+ * Retrieves device capabilities byte from each target.
+ * CAPS indicates optional features supported by the device.
+ *
+ * Note: GETCAPS may not be supported by all targets.
+ */
+ZTEST(i3c_ccc, test_device_capabilities)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t caps[4];
+			int ret = i3c_do_ccc_getcaps(ctrl, desc->dynamic_addr,
+						     caps, 4);
+
+			/* GETCAPS is optional - skip if not supported */
+			if (ret == -ENOTSUP ||
+			    ret == -ENXIO) {
+				ztest_test_skip();
+			}
+
+			/* If supported, it must work correctly */
+			zassert_ok(ret,
+				   "GETCAPS failed DA=0x%02x %s: %d",
+				   desc->dynamic_addr,
+				   i3c_test_mode_name(mode), ret);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/**
+ * @brief Test ENEC broadcast CCC command
+ *
+ * Broadcasts ENEC command to all targets on the bus.
+ * Enables interrupt events (bit 0) on all targets simultaneously.
+ */
+ZTEST(i3c_ccc, test_enec_broadcast)
+{
+	int ret = i3c_do_ccc_enec_broadcast(ctrl, 0x01);
+
+	zassert_ok(ret, "ENEC broadcast failed");
+}
+
+/**
+ * @brief Test DISEC broadcast CCC command
+ *
+ * Broadcasts DISEC command to all targets on the bus.
+ * Disables interrupt events (bit 0) on all targets simultaneously.
+ */
+ZTEST(i3c_ccc, test_disec_broadcast)
+{
+	int ret = i3c_do_ccc_disec_broadcast(ctrl, 0x01);
+
+	zassert_ok(ret, "DISEC broadcast failed");
+}

--- a/tests/drivers/i3c/src/i3c_common.c
+++ b/tests/drivers/i3c/src/i3c_common.c
@@ -1,0 +1,830 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_common, LOG_LEVEL_INF);
+
+/* CCC wrapper functions */
+int i3c_do_ccc_rstdaa(const struct device *ctrl)
+{
+	return i3c_ccc_do_rstdaa_all(ctrl);
+}
+
+int i3c_do_ccc_entdaa(const struct device *ctrl)
+{
+	struct i3c_ccc_payload ccc = { .ccc.id = I3C_CCC_ENTDAA };
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_getpid(const struct device *ctrl, uint8_t da,
+		      uint8_t *pid, size_t len)
+{
+	if (!pid || len < 6) {
+		return -EINVAL;
+	}
+
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = pid,
+		.data_len = 6,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETPID,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	int ret = i3c_do_ccc(ctrl, &ccc);
+
+	if (ret < 0) {
+		return ret;
+	}
+	return target.num_xfer;
+}
+
+int i3c_do_ccc_getbcr(const struct device *ctrl, uint8_t da, uint8_t *bcr)
+{
+	if (!bcr) {
+		return -EINVAL;
+	}
+
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = bcr,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETBCR,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_getdcr(const struct device *ctrl, uint8_t da, uint8_t *dcr)
+{
+	if (!dcr) {
+		return -EINVAL;
+	}
+
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = dcr,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETDCR,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_setmwl(const struct device *ctrl, uint8_t da, uint16_t mwl)
+{
+	uint8_t data[2] = { (mwl >> 8) & 0xFF, mwl & 0xFF };
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 0,
+		.data = data,
+		.data_len = 2,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_SETMWL(false),
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_getmwl(const struct device *ctrl, uint8_t da, uint16_t *mwl)
+{
+	if (!mwl) {
+		return -EINVAL;
+	}
+
+	uint8_t data[2];
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = data,
+		.data_len = 2,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETMWL,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	int ret = i3c_do_ccc(ctrl, &ccc);
+
+	if (ret >= 0) {
+		*mwl = ((uint16_t)data[0] << 8) | data[1];
+	}
+	return ret;
+}
+
+int i3c_do_ccc_enec(const struct device *ctrl, uint8_t da, uint8_t events)
+{
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 0,
+		.data = &events,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_ENEC(false),
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_disec(const struct device *ctrl, uint8_t da, uint8_t events)
+{
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 0,
+		.data = &events,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_DISEC(false),
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_getmrl(const struct device *ctrl, uint8_t da, uint16_t *mrl)
+{
+	if (!mrl) {
+		return -EINVAL;
+	}
+
+	uint8_t data[2];
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = data,
+		.data_len = 2,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETMRL,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	int ret = i3c_do_ccc(ctrl, &ccc);
+
+	if (ret >= 0) {
+		*mrl = ((uint16_t)data[0] << 8) | data[1];
+	}
+	return ret;
+}
+
+int i3c_do_ccc_getstatus(const struct device *ctrl, uint8_t da,
+			 uint16_t *status)
+{
+	if (!status) {
+		return -EINVAL;
+	}
+
+	uint8_t data[2];
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = data,
+		.data_len = 2,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETSTATUS,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	int ret = i3c_do_ccc(ctrl, &ccc);
+
+	if (ret >= 0) {
+		*status = ((uint16_t)data[0] << 8) | data[1];
+	}
+	return ret;
+}
+
+int i3c_do_ccc_enec_broadcast(const struct device *ctrl, uint8_t events)
+{
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_ENEC(true),
+		.ccc.data = &events,
+		.ccc.data_len = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_disec_broadcast(const struct device *ctrl, uint8_t events)
+{
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_DISEC(true),
+		.ccc.data = &events,
+		.ccc.data_len = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_getcaps(const struct device *ctrl, uint8_t da,
+		       uint8_t *caps, size_t len)
+{
+	if (!caps || len == 0) {
+		return -EINVAL;
+	}
+
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 1,
+		.data = caps,
+		.data_len = len,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_GETCAPS,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+int i3c_do_ccc_rstact(const struct device *ctrl, uint8_t da, uint8_t action)
+{
+	struct i3c_ccc_target_payload target = {
+		.addr = da,
+		.rnw = 0,
+		.data = &action,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_RSTACT(false),
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+/* ENTHDR - Enter HDR Mode (Broadcast, no data needed) */
+int i3c_do_ccc_enthdr(const struct device *ctrl, uint8_t hdr_mode)
+{
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_ENTHDR(hdr_mode),
+	};
+
+	return i3c_do_ccc(ctrl, &ccc);
+}
+
+/* Transfer wrappers */
+int i3c_transfer_write(const struct device *ctrl, uint8_t da,
+		       const uint8_t *buf, size_t len)
+{
+	if (!buf || len == 0) {
+		return -EINVAL;
+	}
+
+	struct i3c_device_desc *desc = i3c_find_target(ctrl, da);
+
+	if (!desc) {
+		return -ENODEV;
+	}
+
+	struct i3c_msg msg = {
+		.buf = (uint8_t *)buf,
+		.len = len,
+		.flags = I3C_MSG_WRITE | I3C_MSG_STOP,
+	};
+
+	return i3c_transfer(desc, &msg, 1);
+}
+
+int i3c_transfer_read(const struct device *ctrl, uint8_t da,
+		      uint8_t *buf, size_t len)
+{
+	if (!buf || len == 0) {
+		return -EINVAL;
+	}
+
+	struct i3c_device_desc *desc = i3c_find_target(ctrl, da);
+
+	if (!desc) {
+		return -ENODEV;
+	}
+
+	struct i3c_msg msg = {
+		.buf = buf,
+		.len = len,
+		.flags = I3C_MSG_READ | I3C_MSG_STOP,
+	};
+
+	return i3c_transfer(desc, &msg, 1);
+}
+
+int i3c_transfer_write_read(const struct device *ctrl, uint8_t da,
+			    const uint8_t *write_buf, size_t write_len,
+			    uint8_t *read_buf, size_t read_len)
+{
+	if (!write_buf || !read_buf || write_len == 0 || read_len == 0) {
+		return -EINVAL;
+	}
+
+	struct i3c_device_desc *desc = i3c_find_target(ctrl, da);
+
+	if (!desc) {
+		return -ENODEV;
+	}
+
+	struct i3c_msg msgs[2] = {
+		{
+			.buf = (uint8_t *)write_buf,
+			.len = write_len,
+			.flags = I3C_MSG_WRITE | I3C_MSG_RESTART,
+		},
+		{
+			.buf = read_buf,
+			.len = read_len,
+			.flags = I3C_MSG_READ | I3C_MSG_STOP,
+		},
+	};
+
+	return i3c_transfer(desc, msgs, 2);
+}
+
+/* Register operations */
+int i3c_reg_read(const struct device *ctrl, uint8_t da, uint8_t reg,
+		 uint8_t *buf, size_t len)
+{
+	return i3c_transfer_write_read(ctrl, da, &reg, 1, buf, len);
+}
+
+int i3c_reg_write(const struct device *ctrl, uint8_t da, uint8_t reg,
+		  const uint8_t *buf, size_t len)
+{
+	if (!buf || len == 0) {
+		return -EINVAL;
+	}
+
+	struct i3c_device_desc *desc = i3c_find_target(ctrl, da);
+
+	if (!desc) {
+		return -ENODEV;
+	}
+
+	/* Allocate temp buffer for reg + data */
+	uint8_t *tmp = k_malloc(len + 1);
+
+	if (!tmp) {
+		return -ENOMEM;
+	}
+
+	tmp[0] = reg;
+	memcpy(&tmp[1], buf, len);
+
+	struct i3c_msg msg = {
+		.buf = tmp,
+		.len = len + 1,
+		.flags = I3C_MSG_WRITE | I3C_MSG_STOP,
+	};
+
+	int ret = i3c_transfer(desc, &msg, 1);
+
+	k_free(tmp);
+
+	return ret;
+}
+
+int i3c_reg8_read(const struct device *ctrl, uint8_t da,
+		  uint8_t reg, uint8_t *val)
+{
+	if (!val) {
+		return -EINVAL;
+	}
+	return i3c_reg_read(ctrl, da, reg, val, 1);
+}
+
+int i3c_reg8_write(const struct device *ctrl, uint8_t da,
+		   uint8_t reg, uint8_t val)
+{
+	return i3c_reg_write(ctrl, da, reg, &val, 1);
+}
+
+/* Target helpers */
+struct i3c_device_desc *i3c_find_target(const struct device *ctrl, uint8_t da)
+{
+	struct i3c_device_desc *desc;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr == da) {
+			return desc;
+		}
+	}
+
+	return NULL;
+}
+
+int i3c_get_target_count(const struct device *ctrl)
+{
+	int count = 0;
+	struct i3c_device_desc *desc;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		count++;
+	}
+
+	return count;
+}
+
+/* Chip ID validation */
+int i3c_check_chip_id(const struct device *ctrl, uint8_t da,
+		      uint8_t reg, uint8_t expected)
+{
+	uint8_t val;
+	int ret = i3c_reg8_read(ctrl, da, reg, &val);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (val != expected) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* Multi-target iteration helpers */
+int i3c_test_get_target_count(const struct device *ctrl)
+{
+	return i3c_get_target_count(ctrl);
+}
+
+int i3c_test_run_on_all_targets(const struct device *ctrl,
+				int (*test_fn)(const struct device *ctrl,
+					       uint8_t da))
+{
+	struct i3c_device_desc *desc;
+	int count = 0;
+	int errors = 0;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (count >= I3C_TEST_MAX_TARGETS) {
+			break;
+		}
+		int ret = test_fn(ctrl, desc->dynamic_addr);
+
+		if (ret < 0) {
+			errors++;
+		}
+		count++;
+	}
+
+	return errors > 0 ? -EIO : count;
+}
+
+/* ============================================================================
+ * Frequency Mode Implementation
+ * ============================================================================
+ * This provides runtime frequency mode testing with actual bus configuration.
+ *
+ * Modes:
+ *   SDR:    Standard I3C mode (12.5 MHz)
+ *   HDR-DDR: Double Data Rate mode (25 MHz)
+ */
+
+static const char * const mode_names[] = {
+	"SDR",
+#ifdef I3C_TEST_ENABLE_HDR_MODES
+	"HDR-DDR",
+	"HDR-TSP",
+	"HDR-TSL",
+#endif
+#ifdef I3C_TEST_ENABLE_I2C_FM
+	"I2C-FM",
+	"I2C-FM+"
+#endif
+};
+
+const char *i3c_test_mode_name(enum i3c_test_speed_mode mode)
+{
+	if (mode >= 0 && mode < I3C_TEST_NUM_MODES) {
+		return mode_names[mode];
+	}
+	return "UNKNOWN";
+}
+
+/* Current speed mode tracking
+ * Start as UNKNOWN to force initial configuration on first test run.
+ * If we start as SDR, we'd skip configuration thinking it's already done.
+ */
+static enum i3c_test_speed_mode current_mode = I3C_TEST_NUM_MODES;
+/**
+ * @brief Attach a target device to the I3C controller.
+ *
+ * Wrapper around i3c_attach_i3c_device for test use.
+ *
+ * @param ctrl I3C controller device
+ * @param desc Target device descriptor
+ * @return 0 on success, negative errno on failure
+ */
+int i3c_test_attach_target(const struct device *ctrl,
+			   struct i3c_device_desc *desc)
+{
+	int ret;
+
+	ret = i3c_attach_i3c_device(desc);
+	if (ret != 0) {
+		LOG_ERR("Failed to attach target: %d", ret);
+	}
+	return ret;
+}
+
+/**
+ * @brief Detach a target device from the I3C controller.
+ *
+ * Wrapper around i3c_detach_i3c_device for test use.
+ *
+ * @param ctrl I3C controller device
+ * @param desc Target device descriptor
+ * @return 0 on success, negative errno on failure
+ */
+int i3c_test_detach_target(const struct device *ctrl,
+			   struct i3c_device_desc *desc)
+{
+	int ret;
+
+	ret = i3c_detach_i3c_device(desc);
+	if (ret != 0) {
+		LOG_ERR("Failed to detach target: %d", ret);
+	}
+	return ret;
+}
+
+/**
+ * @brief Perform RSTDAA + DAA sequence for test setup.
+ *
+ * Designed for test_before() fixture. Runs a single RSTDAA+DAA
+ * sequence. Per MIPI I3C spec section 5.1.3, RSTDAA resets all
+ * dynamic addresses and ENTDAA rediscovers all targets.
+ *
+ * @param ctrl I3C controller device
+ * @return Number of assigned devices (>= 0), negative errno on failure
+ */
+int i3c_test_do_rstdaa_daa(const struct device *ctrl)
+{
+	struct i3c_device_desc *desc;
+	int assigned = 0;
+	int ret;
+
+	if (!ctrl) {
+		return -EINVAL;
+	}
+
+	ret = i3c_do_ccc_rstdaa(ctrl);
+	if (ret < 0) {
+		LOG_ERR("RSTDAA failed: %d", ret);
+		return ret;
+	}
+
+	k_msleep(100);
+
+	ret = i3c_recover_bus(ctrl);
+	if (ret < 0) {
+		LOG_DBG("Pre-DAA bus recovery returned: %d", ret);
+	}
+
+	k_msleep(100);
+
+	ret = i3c_do_daa(ctrl);
+	if (ret < 0) {
+		LOG_ERR("DAA failed: %d", ret);
+		return ret;
+	}
+
+	k_msleep(100);
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			assigned++;
+		}
+	}
+
+	LOG_INF("DAA completed, %d target(s) have dynamic addresses",
+		assigned);
+
+	return assigned;
+}
+
+/* Reset I3C bus to SDR mode - configures frequency only, NO RSTDAA+DAA */
+int i3c_test_reset_to_sdr(const struct device *ctrl)
+{
+	struct i3c_config_controller config;
+	int ret;
+
+	/* NOTE: We do NOT call i3c_recover_bus() here because it resets
+	 * the controller hardware, which clears the driver's device table.
+	 * This causes a mismatch: targets retain their dynamic addresses
+	 * from DAA, but the driver forgets them, leading to transfer failures.
+	 */
+
+	/* Skip reconfiguration if already in SDR mode.
+	 * i3c_configure() may reset the controller hardware, which destroys
+	 * driver/device state synchronization. Only configure if needed.
+	 */
+	if (current_mode == I3C_TEST_SDR) {
+		LOG_DBG("Already in SDR mode, skipping reconfiguration");
+		return 0;
+	}
+
+	/* Configure SDR mode at 12.5 MHz (matches device tree i3c-scl-hz) */
+	memset(&config, 0, sizeof(config));
+	config.scl.i3c = I3C_TEST_SDR_FREQ_HZ;
+	/* Set open drain timing to meet I3C spec requirements */
+	config.scl_od_min.high_ns = 41;
+	config.scl_od_min.low_ns = 200;
+	ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure SDR mode: %d", ret);
+		return ret;
+	}
+	LOG_INF("SDR mode configured at %u Hz", I3C_TEST_SDR_FREQ_HZ);
+
+	current_mode = I3C_TEST_SDR;
+	/* Delay for bus to stabilize */
+	k_msleep(100);
+
+	return 0;
+}
+
+uint32_t i3c_test_mode_frequency(enum i3c_test_speed_mode mode)
+{
+	switch (mode) {
+	case I3C_TEST_SDR:
+		return I3C_TEST_SDR_FREQ_HZ;
+#ifdef I3C_TEST_ENABLE_I2C_FM
+	case I3C_TEST_I2C_FM:
+		return I3C_TEST_I2C_FM_HZ;
+	case I3C_TEST_I2C_FMPLUS:
+		return I3C_TEST_I2C_FMPLUS_HZ;
+#endif
+
+#ifdef I3C_TEST_ENABLE_HDR_MODES
+	case I3C_TEST_HDR_DDR:
+	case I3C_TEST_HDR_TSP:
+	case I3C_TEST_HDR_TSL:
+		return I3C_TEST_HDR_FREQ_HZ;
+#endif
+	default:
+		return 0;
+	}
+}
+
+int i3c_test_set_speed_mode(const struct device *ctrl,
+			    enum i3c_test_speed_mode mode)
+{
+	struct i3c_config_controller config;
+	int ret;
+
+	if (!ctrl || mode < 0 || mode >= I3C_TEST_NUM_MODES) {
+		return -EINVAL;
+	}
+
+	/* Get current configuration */
+	ret = i3c_config_get(ctrl, I3C_CONFIG_CONTROLLER, &config);
+	if (ret < 0) {
+		LOG_WRN("Failed to get I3C config: %d", ret);
+		/* Continue with default values */
+		memset(&config, 0, sizeof(config));
+	}
+
+	switch (mode) {
+	case I3C_TEST_SDR:
+		/* Skip reconfiguration if already in SDR mode.
+		 * Repeated i3c_configure() calls may reset the controller,
+		 * causing driver/device state mismatch.
+		 */
+		if (current_mode == I3C_TEST_SDR) {
+			LOG_DBG("Already in SDR mode, skipping reconfiguration");
+			return 0;
+		}
+
+		/* Configure SDR mode at 12.5 MHz (matches DT i3c-scl-hz) */
+		config.scl.i3c = I3C_TEST_SDR_FREQ_HZ;
+		ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+		if (ret < 0) {
+			LOG_ERR("Failed to set SDR frequency: %d", ret);
+			return ret;
+		}
+		current_mode = mode;
+		LOG_INF("I3C bus SDR mode (%u Hz)", config.scl.i3c);
+		break;
+
+	/* HDR modes - disabled by default,
+	 * enable I3C_TEST_ENABLE_HDR_MODES if supported
+	 */
+#ifdef I3C_TEST_ENABLE_HDR_MODES
+	uint8_t hdr_mode;
+
+	case I3C_TEST_HDR_DDR:
+		hdr_mode = 0; /* ENTHDR0 = HDR-DDR */
+		goto configure_hdr;
+	case I3C_TEST_HDR_TSP:
+		hdr_mode = 1; /* ENTHDR1 = HDR-TSP */
+		goto configure_hdr;
+	case I3C_TEST_HDR_TSL:
+		hdr_mode = 2; /* ENTHDR2 = HDR-TSL */
+		goto configure_hdr;
+
+configure_hdr:
+		/* First ensure we're in SDR mode before attempting HDR entry */
+		if (current_mode != I3C_TEST_SDR) {
+			i3c_test_reset_to_sdr(ctrl);
+		}
+
+		/* HDR mode requires ENTHDR CCC to enter */
+		ret = i3c_do_ccc_enthdr(ctrl, hdr_mode);
+		if (ret < 0) {
+			LOG_WRN("Target(s) do not support %s mode: %d",
+				mode_names[mode], ret);
+			/* Reset to SDR - this includes DAA */
+			i3c_test_reset_to_sdr(ctrl);
+			return -ENOTSUP;
+		}
+
+		/* Set HDR frequency (25 MHz) after successful HDR entry */
+		config.scl.i3c = I3C_TEST_HDR_FREQ_HZ;
+		ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+		if (ret < 0) {
+			LOG_DBG("HDR config returned: %d", ret);
+			/* Non-fatal - driver may auto-configure for HDR */
+		}
+		current_mode = mode;
+		LOG_INF("I3C bus configured for %s mode (%u Hz)",
+			mode_names[mode], I3C_TEST_HDR_FREQ_HZ);
+		break;
+#endif
+
+#ifdef I3C_TEST_ENABLE_I2C_FM
+	case I3C_TEST_I2C_FM:
+		/* Configure I2C Fast Mode - 400 kHz */
+		config.scl.i2c = I3C_TEST_I2C_FM_HZ;
+		ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+		if (ret < 0) {
+			LOG_ERR("Failed to set I2C FM frequency: %d", ret);
+			return ret;
+		}
+		current_mode = mode;
+		LOG_INF("I3C bus I2C FM mode (%u Hz)", config.scl.i2c);
+		break;
+
+	case I3C_TEST_I2C_FMPLUS:
+		/* Configure I2C Fast Mode Plus - 1 MHz */
+		config.scl.i2c = I3C_TEST_I2C_FMPLUS_HZ;
+		ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+		if (ret < 0) {
+			LOG_ERR("Failed to set I2C FM+ frequency: %d", ret);
+			return ret;
+		}
+		current_mode = mode;
+		LOG_INF("I3C bus I2C FM+ mode (%u Hz)", config.scl.i2c);
+		break;
+#endif
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+enum i3c_test_speed_mode i3c_test_get_speed_mode(const struct device *ctrl)
+{
+	ARG_UNUSED(ctrl);
+	return current_mode;
+}

--- a/tests/drivers/i3c/src/i3c_common.h
+++ b/tests/drivers/i3c/src/i3c_common.h
@@ -1,0 +1,267 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef I3C_COMMON_H
+#define I3C_COMMON_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/i3c/ccc.h>
+#include <zephyr/devicetree.h>
+
+/* Max targets supported */
+#define I3C_TEST_MAX_TARGETS 8
+
+/* Target configuration from DT or Kconfig */
+#define I3C_CONTROLLER_NODE DT_NODELABEL(i3c0)
+
+/* Get target count from DT - count i3c devices on bus */
+#if DT_HAS_COMPAT_STATUS_OKAY(bosch_bmi323)
+#define I3C_TARGET_0_DA DT_PROP(DT_NODELABEL(bmi323), assigned_address)
+#else
+#define I3C_TARGET_0_DA 0x09
+#endif
+#define I3C_TEST_BMI323_ADDR I3C_TARGET_0_DA
+
+#if DT_HAS_COMPAT_STATUS_OKAY(invensense_icm42670p)
+#define I3C_TARGET_1_DA DT_PROP(DT_NODELABEL(icm42670), assigned_address)
+#define I3C_TEST_ICM42670_ADDR I3C_TARGET_1_DA
+#else
+#define I3C_TARGET_1_DA 0x0A
+#define I3C_TEST_ICM42670_ADDR 0x0A
+#endif
+
+/* Default targets array */
+#ifndef I3C_TEST_NUM_TARGETS
+#ifdef CONFIG_I3C_TEST_NUM_TARGETS
+#define I3C_TEST_NUM_TARGETS CONFIG_I3C_TEST_NUM_TARGETS
+#else
+#define I3C_TEST_NUM_TARGETS 2
+#endif
+#endif
+
+#ifndef I3C_TEST_TARGET_DA
+#ifdef CONFIG_I3C_TEST_TARGET_DA
+#define I3C_TEST_TARGET_DA CONFIG_I3C_TEST_TARGET_DA
+#else
+#define I3C_TEST_TARGET_DA I3C_TARGET_0_DA
+#endif
+#endif
+
+#ifndef I3C_TEST_CHIP_ID_REG
+#ifdef CONFIG_I3C_TEST_CHIP_ID_REG
+#define I3C_TEST_CHIP_ID_REG CONFIG_I3C_TEST_CHIP_ID_REG
+#else
+#define I3C_TEST_CHIP_ID_REG 0x00
+#endif
+#endif
+
+#ifndef I3C_TEST_CHIP_ID_VAL
+#ifdef CONFIG_I3C_TEST_CHIP_ID_VAL
+#define I3C_TEST_CHIP_ID_VAL CONFIG_I3C_TEST_CHIP_ID_VAL
+#else
+#define I3C_TEST_CHIP_ID_VAL 0x00
+#endif
+#endif
+
+/* I3C Common Command Codes - test wrappers */
+int i3c_do_ccc_rstdaa(const struct device *ctrl);
+
+int i3c_do_ccc_entdaa(const struct device *ctrl);
+
+int i3c_do_ccc_getpid(const struct device *ctrl, uint8_t da,
+		     uint8_t *pid, size_t len);
+
+int i3c_do_ccc_getbcr(const struct device *ctrl, uint8_t da, uint8_t *bcr);
+
+int i3c_do_ccc_getdcr(const struct device *ctrl, uint8_t da, uint8_t *dcr);
+
+int i3c_do_ccc_setmwl(const struct device *ctrl, uint8_t da, uint16_t mwl);
+
+int i3c_do_ccc_getmwl(const struct device *ctrl, uint8_t da, uint16_t *mwl);
+
+int i3c_do_ccc_getmrl(const struct device *ctrl, uint8_t da, uint16_t *mrl);
+
+int i3c_do_ccc_getstatus(const struct device *ctrl, uint8_t da,
+			 uint16_t *status);
+
+int i3c_do_ccc_enec(const struct device *ctrl, uint8_t da, uint8_t events);
+
+int i3c_do_ccc_disec(const struct device *ctrl, uint8_t da, uint8_t events);
+
+int i3c_do_ccc_enec_broadcast(const struct device *ctrl, uint8_t events);
+
+int i3c_do_ccc_disec_broadcast(const struct device *ctrl, uint8_t events);
+
+int i3c_do_ccc_getcaps(const struct device *ctrl, uint8_t da,
+		       uint8_t *caps, size_t len);
+
+int i3c_do_ccc_rstact(const struct device *ctrl, uint8_t da, uint8_t action);
+
+int i3c_do_ccc_enthdr(const struct device *ctrl, uint8_t hdr_mode);
+
+/* I3C Transfer operations */
+int i3c_transfer_write(const struct device *ctrl, uint8_t da,
+		       const uint8_t *buf, size_t len);
+
+int i3c_transfer_read(const struct device *ctrl, uint8_t da,
+		      uint8_t *buf, size_t len);
+
+int i3c_transfer_write_read(const struct device *ctrl, uint8_t da,
+			    const uint8_t *write_buf, size_t write_len,
+			    uint8_t *read_buf, size_t read_len);
+
+/* Register operations (write reg addr then read/write data) */
+int i3c_reg_read(const struct device *ctrl, uint8_t da, uint8_t reg,
+		 uint8_t *buf, size_t len);
+
+int i3c_reg_write(const struct device *ctrl, uint8_t da, uint8_t reg,
+		  const uint8_t *buf, size_t len);
+
+int i3c_reg8_read(const struct device *ctrl, uint8_t da,
+		  uint8_t reg, uint8_t *val);
+
+int i3c_reg8_write(const struct device *ctrl, uint8_t da,
+		   uint8_t reg, uint8_t val);
+
+/* Target helpers */
+struct i3c_device_desc *i3c_find_target(const struct device *ctrl, uint8_t da);
+int i3c_get_target_count(const struct device *ctrl);
+
+/* Target attach/detach for test setup/teardown */
+int i3c_test_attach_target(const struct device *ctrl,
+			   struct i3c_device_desc *desc);
+
+int i3c_test_detach_target(const struct device *ctrl,
+			   struct i3c_device_desc *desc);
+
+/* Chip ID validation */
+int i3c_check_chip_id(const struct device *ctrl, uint8_t da,
+		      uint8_t reg, uint8_t expected);
+
+/* ============================================================================
+ * Frequency Mode Support
+ * ============================================================================
+ * I3C bus speed modes:
+ *   - SDR: Single Data Rate (12.5 MHz typical)
+ *   - HDR-DDR: Double Data Rate mode (up to 25 MHz)
+ *   - HDR-TSP/TSL: Ternary symbol modes (up to 25 MHz)
+ *
+ * I2C Legacy speeds for mixed bus:
+ *   - FM: Fast Mode (400 kHz) - disabled by default
+ *   - FM+: Fast Mode Plus (1 MHz) - disabled by default
+ *
+ * HDR and I2C legacy modes are disabled by default as current targets
+ * only support SDR.
+ */
+
+/* Uncomment to enable I2C-FM (400 kHz) mode testing:
+ * #define I3C_TEST_ENABLE_I2C_FM
+ */
+
+/* Uncomment to enable HDR mode testing:
+ * #define I3C_TEST_ENABLE_HDR_MODES
+ */
+
+enum i3c_test_speed_mode {
+	/* I3C Native modes - tested first */
+	I3C_TEST_SDR = 0,        /* SDR (12.5 MHz) - always enabled */
+
+#ifdef I3C_TEST_ENABLE_HDR_MODES
+	/* HDR modes - require I3C SDR context, tested after SDR */
+	I3C_TEST_HDR_DDR = 1,    /* HDR-DDR (25 MHz) */
+	I3C_TEST_HDR_TSP = 2,    /* HDR-TSP (25 MHz) */
+	I3C_TEST_HDR_TSL = 3,    /* HDR-TSL (25 MHz) */
+#endif
+
+	/* I2C Legacy modes - tested last (require different bus context) */
+#ifdef I3C_TEST_ENABLE_I2C_FM
+	I3C_TEST_I2C_FM = 4,     /* I2C Fast Mode (400 kHz) */
+	I3C_TEST_I2C_FMPLUS = 5, /* I2C Fast Mode Plus (1 MHz) */
+#endif
+
+	I3C_TEST_NUM_MODES       /* Total supported modes */
+};
+
+/* I3C frequency values in Hz */
+#define I3C_TEST_SDR_FREQ_HZ      12500000U  /* 12.5 MHz */
+#define I3C_TEST_HDR_FREQ_HZ      25000000U  /* 25 MHz for all HDR modes */
+
+/* I2C legacy speed values in Hz */
+#define I3C_TEST_I2C_FM_HZ        400000U    /* 400 kHz I2C FM */
+#define I3C_TEST_I2C_FMPLUS_HZ    1000000U   /* 1 MHz I2C FM+ */
+
+/* Set current test speed mode */
+int i3c_test_set_speed_mode(const struct device *ctrl,
+			    enum i3c_test_speed_mode mode);
+
+/* Get current test speed mode */
+enum i3c_test_speed_mode i3c_test_get_speed_mode(const struct device *ctrl);
+
+/* Reset bus to SDR mode - configures frequency, does NOT do RSTDAA+DAA */
+int i3c_test_reset_to_sdr(const struct device *ctrl);
+
+/**
+ * @brief Perform RSTDAA + DAA for test setup.
+ *
+ * Runs the full sequence on every call. The RSTDAA CCC helper keeps
+ * cached target descriptors and address slots synchronized with the bus.
+ *
+ * @param ctrl I3C controller device
+ * @return Number of assigned devices (>= 0), negative errno on failure
+ */
+int i3c_test_do_rstdaa_daa(const struct device *ctrl);
+
+/* Run test on all speed modes */
+#define I3C_TEST_FOR_EACH_MODE(ctrl, mode) \
+	const struct device *_test_ctrl = (ctrl); \
+	enum i3c_test_speed_mode mode; \
+	int _mode_setup_ret; \
+	for (mode = I3C_TEST_SDR; mode < I3C_TEST_NUM_MODES; mode++) { \
+		_mode_setup_ret = i3c_test_set_speed_mode(_test_ctrl, mode); \
+		if (_mode_setup_ret == 0) { \
+			LOG_INF("Testing in %s mode (%u Hz)", \
+				i3c_test_mode_name(mode), \
+				i3c_test_mode_frequency(mode));
+
+#define I3C_TEST_END_EACH_MODE \
+		} \
+	} \
+	/* Return to SDR after HDR modes to ensure clean state */ \
+	if (mode != I3C_TEST_SDR) { \
+		i3c_test_reset_to_sdr(_test_ctrl); \
+	} \
+	(void)_test_ctrl;
+
+/* Get mode name and frequency for logging */
+const char *i3c_test_mode_name(enum i3c_test_speed_mode mode);
+uint32_t i3c_test_mode_frequency(enum i3c_test_speed_mode mode);
+
+/* Multi-target test execution macro */
+/* Run test code block on each target with assigned dynamic address.
+ * Skip if none found. Note: static_addr may be 0 for I3C-only devices.
+ */
+#define I3C_TEST_FOR_EACH_TARGET(ctrl, desc) \
+	struct i3c_device_desc *desc = NULL; \
+	int _target_found = 0; \
+	I3C_BUS_FOR_EACH_I3CDEV((ctrl), desc) { \
+		if (desc->dynamic_addr == 0) { \
+			continue; \
+		} \
+		_target_found = 1; \
+		{
+
+#define I3C_TEST_END_EACH_TARGET \
+		} \
+	} \
+	if (!_target_found) { \
+		ztest_test_skip(); \
+		(void)_target_found; \
+	}
+#endif

--- a/tests/drivers/i3c/src/i3c_discovery.c
+++ b/tests/drivers/i3c/src/i3c_discovery.c
@@ -1,0 +1,507 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_discovery, LOG_LEVEL_INF);
+
+static const struct device *ctrl;
+
+static int count_assigned_targets(void)
+{
+	struct i3c_device_desc *desc;
+	int count = 0;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/* Configure SDR mode only.
+	 * NOTE: Zephyr does not support hot-join. DAA must be done by
+	 * application or device initialization before tests run.
+	 * We do NOT perform RSTDAA+DAA here because:
+	 * 1. If all suites run at once, repeated RSTDAA causes address
+	 *    increments and driver state issues
+	 * 2. If suites run individually, system/DT init should have
+	 *    already performed DAA
+	 */
+	i3c_test_reset_to_sdr(ctrl);
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	struct i3c_device_desc *desc;
+	int found = 0;
+
+	ARG_UNUSED(fixture);
+
+	/* Verify devices were assigned addresses by prior DAA */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			found++;
+		}
+	}
+
+	if (found == 0) {
+		LOG_WRN("No devices with dynamic address - ensure DAA completed before tests");
+		ztest_test_skip();
+	}
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_discovery, NULL, suite_setup, test_before, test_after, NULL);
+
+ZTEST(i3c_discovery, test_controller_ready)
+{
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+}
+
+ZTEST(i3c_discovery, test_targets_discovered)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		int count = 0;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			count++;
+			LOG_DBG("Found target at DA=0x%02x in %s",
+				desc->dynamic_addr,
+				i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+		zassert_true(count > 0, "No I3C targets discovered in %s mode",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_discovery, test_valid_target_descriptors)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			zassert_not_equal(desc->dynamic_addr, 0,
+					  "DA cannot be 0 in %s",
+					  i3c_test_mode_name(mode));
+			zassert_not_equal(desc->pid, 0,
+					  "PID cannot be 0 in %s",
+					  i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_discovery, test_target_index_lookup_bounds)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		int count = 0;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			count++;
+		} I3C_TEST_END_EACH_TARGET
+		zassert_true(count > 0,
+			     "Should have at least one target in %s",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_discovery, test_rstdaa_broadcast)
+{
+	/* Record current addresses before RSTDAA */
+	struct i3c_device_desc *desc;
+	uint8_t prev_addrs[I3C_TEST_MAX_TARGETS] = {0};
+	int count = 0;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0 && count < I3C_TEST_MAX_TARGETS) {
+			prev_addrs[count++] = desc->dynamic_addr;
+		}
+	}
+
+	if (count == 0) {
+		ztest_test_skip();
+	}
+
+	/* Step 1: Send RSTDAA broadcast */
+	int ret = i3c_do_ccc_rstdaa(ctrl);
+
+	zassert_ok(ret, "RSTDAA failed: %d", ret);
+	k_msleep(50);
+
+	/* Step 2: Verify targets don't respond at old addresses */
+	for (int i = 0; i < count; i++) {
+		uint8_t bcr;
+		int check_ret = i3c_do_ccc_getbcr(ctrl, prev_addrs[i], &bcr);
+
+		zassert_true(check_ret < 0,
+			     "Target still responds at old DA=0x%02x after RSTDAA",
+			     prev_addrs[i]);
+	}
+
+	/* Step 3: Restore addresses via DAA */
+	ret = i3c_do_daa(ctrl);
+	if (ret < 0) {
+		k_msleep(100);
+		ret = i3c_do_daa(ctrl);
+	}
+	zassert_ok(ret, "DAA restore failed after RSTDAA: %d", ret);
+}
+
+ZTEST(i3c_discovery, test_entdaa)
+{
+	/* Record pre-test state */
+	struct i3c_device_desc *desc;
+	int prev_count = 0;
+
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0) {
+			prev_count++;
+		}
+	}
+
+	/* Step 1: RSTDAA */
+	int ret = i3c_do_ccc_rstdaa(ctrl);
+
+	zassert_ok(ret, "RSTDAA failed: %d", ret);
+
+	k_msleep(50);
+
+	/* Step 2: Run DAA. The controller API performs ENTDAA. */
+	ret = i3c_do_daa(ctrl);
+	if (ret < 0) {
+		k_msleep(100);
+		ret = i3c_do_daa(ctrl);
+	}
+	zassert_ok(ret, "DAA after RSTDAA failed: %d", ret);
+	zassert_equal(count_assigned_targets(), prev_count,
+		      "DAA assigned unexpected target count");
+}
+
+ZTEST(i3c_discovery, test_dynamic_addresses_in_valid_range)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t da = desc->dynamic_addr;
+
+			zassert_true(da >= 0x08 && da <= 0x77,
+				     "DA 0x%02x out of range in %s",
+				     da, i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_discovery, test_dynamic_addresses_unique)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		uint8_t addrs[I3C_TEST_MAX_TARGETS] = {0};
+		int count = 0;
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			for (int i = 0; i < count; i++) {
+				zassert_not_equal(addrs[i], desc->dynamic_addr,
+						  "Duplicate DA=0x%02x in %s mode",
+						  desc->dynamic_addr,
+						  i3c_test_mode_name(mode));
+			}
+			if (count < I3C_TEST_MAX_TARGETS) {
+				addrs[count++] = desc->dynamic_addr;
+			}
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_discovery, test_setnewda)
+{
+	struct i3c_device_desc *desc =
+		i3c_find_target(ctrl, I3C_TEST_TARGET_DA);
+
+	if (!desc) {
+		ztest_test_skip();
+	}
+
+	uint8_t old_da = desc->dynamic_addr;
+	uint8_t new_da = 0x0B;
+
+	/* Verify new address is free */
+	struct i3c_device_desc *check = i3c_find_target(ctrl, new_da);
+
+	if (check != NULL) {
+		new_da = 0x0C;
+		check = i3c_find_target(ctrl, new_da);
+		if (check != NULL) {
+			ztest_test_skip();
+		}
+	}
+
+	/* Step 1: Send SETNEWDA to change address */
+	uint8_t payload = new_da << 1;
+	struct i3c_ccc_target_payload target = {
+		.addr = old_da,
+		.rnw = 0,
+		.data = &payload,
+		.data_len = 1,
+	};
+	struct i3c_ccc_payload ccc = {
+		.ccc.id = I3C_CCC_SETNEWDA,
+		.targets.payloads = &target,
+		.targets.num_targets = 1,
+	};
+
+	int ret = i3c_do_ccc(ctrl, &ccc);
+
+	if (ret == -ENXIO) {
+		LOG_INF("SETNEWDA not supported by DA=0x%02x, skip", old_da);
+		ztest_test_skip();
+	}
+	zassert_ok(ret, "SETNEWDA failed: %d", ret);
+
+	/* Delay for device to switch internal address register */
+	k_msleep(50);
+
+	/* Update descriptor to reflect new address for subsequent operations */
+	desc->dynamic_addr = new_da;
+
+	/* Step 2: Verify target responds at NEW address */
+	uint8_t bcr;
+
+	ret = i3c_do_ccc_getbcr(ctrl, new_da, &bcr);
+	if (ret < 0) {
+		/* Device doesn't truly support SETNEWDA - restore and skip */
+		LOG_INF("No response at new DA 0x%02x, restore 0x%02x",
+			new_da, old_da);
+		desc->dynamic_addr = old_da;
+		payload = old_da << 1;
+		target.addr = new_da;
+		(void)i3c_do_ccc(ctrl, &ccc);
+		ztest_test_skip();
+	}
+
+	/* Step 3: Verify target does NOT respond at OLD address */
+	ret = i3c_do_ccc_getbcr(ctrl, old_da, &bcr);
+	zassert_true(ret < 0, "Target still responds at old DA=0x%02x", old_da);
+
+	/* Step 4: Restore original address */
+	payload = old_da << 1;
+	target.addr = new_da;
+	ret = i3c_do_ccc(ctrl, &ccc);
+	zassert_ok(ret, "SETNEWDA restore failed: %d", ret);
+
+	/* Update descriptor to reflect restored address */
+	desc->dynamic_addr = old_da;
+
+	/* Step 5: Verify restoration */
+	ret = i3c_do_ccc_getbcr(ctrl, old_da, &bcr);
+	zassert_ok(ret, "Target doesn't respond at restored DA=0x%02x", old_da);
+}
+
+ZTEST(i3c_discovery, test_setdasa)
+{
+	/* Per I3C spec: SETDASA assigns static address as dynamic address */
+	struct i3c_device_desc *dev = NULL;
+	int static_count = 0;
+
+	/* Count targets with static addresses */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, dev) {
+		if (dev->static_addr != 0) {
+			static_count++;
+		}
+	}
+
+	if (static_count == 0) {
+		ztest_test_skip();
+	}
+
+	/* Step 1: RSTDAA to clear dynamic addresses */
+	int ret = i3c_do_ccc_rstdaa(ctrl);
+
+	zassert_ok(ret, "RSTDAA failed: %d", ret);
+	k_msleep(50);
+
+	/* Step 2: Send SETDASA to each target with static address */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, dev) {
+		if (dev->static_addr == 0) {
+			continue;
+		}
+
+		/* Validate static address is in valid range */
+		zassert_true(dev->static_addr >= 0x08 &&
+			     dev->static_addr <= 0x77,
+			     "Static addr 0x%02x out of range",
+			     dev->static_addr);
+
+		/* SETDASA payload: static address shifted left */
+		uint8_t payload = dev->static_addr << 1;
+		struct i3c_ccc_target_payload target = {
+			.addr = dev->static_addr,
+			.rnw = 0,
+			.data = &payload,
+			.data_len = 1,
+		};
+		struct i3c_ccc_payload ccc = {
+			.ccc.id = I3C_CCC_SETDASA,
+			.targets.payloads = &target,
+			.targets.num_targets = 1,
+		};
+
+		ret = i3c_do_ccc(ctrl, &ccc);
+		if (ret < 0) {
+			/* SETDASA may not be supported by all targets */
+			LOG_DBG("SETDASA not supported SA=0x%02x: %d",
+				dev->static_addr, ret);
+			continue;
+		}
+
+		zassert_equal(ret, 0, "SETDASA failed for SA=0x%02x: %d",
+			      dev->static_addr, ret);
+
+		/* Update descriptor - dynamic_addr now equals static_addr */
+		dev->dynamic_addr = dev->static_addr;
+
+		/* Step 3: Verify target responds at assigned address */
+		uint8_t pid[6];
+		uint64_t pid_from_ccc;
+
+		ret = i3c_do_ccc_getpid(ctrl, dev->dynamic_addr, pid, 6);
+		zassert_ok(ret, "GETPID failed after SETDASA for SA=0x%02x: %d",
+			   dev->static_addr, ret);
+		pid_from_ccc = ((uint64_t)pid[0] << 40) |
+			       ((uint64_t)pid[1] << 32) |
+			       ((uint64_t)pid[2] << 24) |
+			       ((uint64_t)pid[3] << 16) |
+			       ((uint64_t)pid[4] << 8) | pid[5];
+		zassert_equal(pid_from_ccc, dev->pid,
+			      "PID mismatch after SETDASA for SA=0x%02x",
+			      dev->static_addr);
+	}
+}
+
+ZTEST(i3c_discovery, test_i2c_devices_valid_addresses)
+{
+	struct i3c_i2c_device_desc *i2c_desc;
+	struct i3c_device_desc *i3c_desc;
+	int i2c_count = 0;
+	int respond_count = 0;
+
+	I3C_BUS_FOR_EACH_I2CDEV(ctrl, i2c_desc) {
+		uint8_t dummy;
+		int ret;
+
+		i2c_count++;
+
+		/* Verify address in valid I2C range */
+		zassert_true(i2c_desc->addr >= 0x08 && i2c_desc->addr <= 0x77,
+			     "I2C addr 0x%02x out of valid range 0x08-0x77",
+			     i2c_desc->addr);
+
+		/* Check for address collision with I3C devices */
+		I3C_BUS_FOR_EACH_I3CDEV(ctrl, i3c_desc) {
+			if (i3c_desc->dynamic_addr == i2c_desc->addr) {
+				zassert_false(1,
+					      "Address collision: I2C device 0x%02x conflicts with I3C device",
+					      i2c_desc->addr);
+			}
+		}
+
+		/* Verify I2C device actually responds on the bus.
+		 * Use a simple probe read - even if it fails
+		 * (no such register),
+		 * the ACK from the device confirms it's present.
+		 */
+		ret = i3c_reg_read(ctrl, i2c_desc->addr, 0x00, &dummy, 1);
+		if (ret == 0 || ret == -EIO || ret == -ENXIO) {
+			/* ACK received (even if register read fails) */
+			respond_count++;
+			LOG_INF("I2C device at 0x%02x responds (ret=%d)",
+				i2c_desc->addr, ret);
+		} else {
+			LOG_WRN("I2C device at 0x%02x no response (ret=%d)",
+				i2c_desc->addr, ret);
+		}
+	}
+
+	/* If DT declares I2C devices, at least some should respond */
+	if (i2c_count > 0) {
+		zassert_true(respond_count > 0,
+			     "No I2C devices responded on bus (%d declared in DT)",
+			     i2c_count);
+		LOG_INF("I2C validation: %d/%d devices respond",
+			respond_count, i2c_count);
+	}
+}
+
+/**
+ * @brief Test SDR mode frequency compliance across all targets
+ *
+ * Tests register reads on every discovered target at multiple valid SDR
+ * frequencies. Per MIPI I3C spec, all I3C devices
+ * must operate up to 12.5 MHz SDR.
+ *
+ * Frequencies tested: 6.25 MHz and 12.5 MHz.
+ * Skips a frequency if the controller cannot configure it (hardware
+ * constraint) rather than failing the entire test.
+ */
+ZTEST(i3c_discovery, test_sdr_frequency_sweep)
+{
+	static const uint32_t sdr_freqs[] = { 6250000U, 12500000U };
+	struct i3c_config_controller config;
+	uint8_t buf[4];
+	int ret;
+
+	for (size_t fi = 0; fi < ARRAY_SIZE(sdr_freqs); fi++) {
+		uint32_t freq = sdr_freqs[fi];
+
+		memset(&config, 0, sizeof(config));
+		config.scl.i3c = freq;
+		/* Set Open Drain timing per I3C spec */
+		config.scl_od_min.high_ns = 41;
+		config.scl_od_min.low_ns = I3C_OD_TLOW_MIN_NS;
+
+		ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+		if (ret != 0) {
+			LOG_INF("Skip %u Hz: controller rejected (%d)",
+				freq, ret);
+			continue;
+		}
+
+		LOG_INF("Testing SDR at %u Hz", freq);
+		k_msleep(10);
+
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			ret = i3c_reg_read(ctrl, desc->dynamic_addr,
+					   I3C_TEST_CHIP_ID_REG, buf, 4);
+			if (ret < 0) {
+				LOG_INF("Reg read %u Hz DA=0x%02x: %d",
+					freq, desc->dynamic_addr, ret);
+			}
+		} I3C_TEST_END_EACH_TARGET
+	}
+
+	/* Restore standard SDR frequency */
+	memset(&config, 0, sizeof(config));
+	config.scl.i3c = I3C_TEST_SDR_FREQ_HZ;
+	config.scl_od_min.high_ns = 41;
+	config.scl_od_min.low_ns = I3C_OD_TLOW_MIN_NS;
+	ret = i3c_configure(ctrl, I3C_CONFIG_CONTROLLER, &config);
+	zassert_ok(ret,
+		   "Failed to restore %u Hz: %d",
+		   I3C_TEST_SDR_FREQ_HZ, ret);
+}

--- a/tests/drivers/i3c/src/i3c_ibi.c
+++ b/tests/drivers/i3c/src/i3c_ibi.c
@@ -1,0 +1,120 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_ibi, LOG_LEVEL_INF);
+
+/* Per MIPI I3C spec: BCR bit 1 = IBI Request Capable */
+#define I3C_IBI_CAPABLE BIT(1)
+
+static const struct device *ctrl;
+
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/* Configure SDR mode only.
+	 * NOTE: Zephyr does not support hot-join. DAA must be done by
+	 * application or device initialization before tests run.
+	 * We do NOT perform RSTDAA+DAA here because:
+	 * 1. If all suites run at once, repeated RSTDAA causes address
+	 *    increments and driver state issues
+	 * 2. If suites run individually, system/DT init should have
+	 *    already performed DAA
+	 */
+	i3c_test_reset_to_sdr(ctrl);
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	struct i3c_device_desc *desc;
+	int found = 0;
+
+	ARG_UNUSED(fixture);
+
+	/* Verify devices were assigned addresses by prior DAA */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			found++;
+		}
+	}
+
+	if (found == 0) {
+		LOG_WRN("No devices with dynamic address - ensure DAA completed before tests");
+		ztest_test_skip();
+	}
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_ibi, NULL, suite_setup, test_before, test_after, NULL);
+
+ZTEST(i3c_ibi, test_ibi_capability_in_bcr)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		struct i3c_device_desc *desc;
+		uint8_t bcr;
+		int ret;
+
+		desc = i3c_find_target(ctrl, I3C_TEST_TARGET_DA);
+		if (!desc) {
+			ztest_test_skip();
+		}
+
+		/* Verify BCR from descriptor matches GETBCR CCC result */
+		ret = i3c_do_ccc_getbcr(ctrl, desc->dynamic_addr, &bcr);
+		zassert_ok(ret, "GETBCR failed in %s mode: %d",
+			   i3c_test_mode_name(mode), ret);
+
+		zassert_equal(desc->bcr, bcr,
+			      "Descriptor BCR (0x%02x) mismatch with GETBCR (0x%02x) in %s mode",
+			      desc->bcr, bcr, i3c_test_mode_name(mode));
+
+		LOG_INF("Target at DA=0x%02x BCR=0x%02x IBI capable: %s in %s",
+			desc->dynamic_addr, bcr,
+			(bcr & I3C_IBI_CAPABLE) ? "yes" : "no",
+			i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_ibi, test_enable_disable_cycling)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		struct i3c_device_desc *desc;
+		int ret;
+
+		desc = i3c_find_target(ctrl, I3C_TEST_TARGET_DA);
+		if (!desc) {
+			ztest_test_skip();
+		}
+
+		/* Verify ENEC/DISEC cycling works correctly */
+		for (int i = 0; i < 3; i++) {
+			ret = i3c_do_ccc_enec(ctrl, desc->dynamic_addr, 0x01);
+			if (ret == -ENOTSUP) {
+				ztest_test_skip();
+			}
+			zassert_ok(ret, "ENEC cycle %d failed in %s mode: %d",
+				   i + 1, i3c_test_mode_name(mode), ret);
+
+			ret = i3c_do_ccc_disec(ctrl, desc->dynamic_addr, 0x01);
+			zassert_ok(ret, "DISEC cycle %d failed in %s mode: %d",
+				   i + 1, i3c_test_mode_name(mode), ret);
+		}
+	} I3C_TEST_END_EACH_MODE
+}

--- a/tests/drivers/i3c/src/i3c_negative.c
+++ b/tests/drivers/i3c/src/i3c_negative.c
@@ -1,0 +1,222 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_negative, LOG_LEVEL_INF);
+
+static const struct device *ctrl;
+
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/* Configure SDR mode only.
+	 * NOTE: Zephyr does not support hot-join. DAA must be done by
+	 * application or device initialization before tests run.
+	 * We do NOT perform RSTDAA+DAA here because:
+	 * 1. If all suites run at once, repeated RSTDAA causes address
+	 *    increments and driver state issues
+	 * 2. If suites run individually, system/DT init should have
+	 *    already performed DAA
+	 */
+	i3c_test_reset_to_sdr(ctrl);
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	struct i3c_device_desc *desc;
+	int found = 0;
+
+	ARG_UNUSED(fixture);
+
+	/* Verify devices were assigned addresses by prior DAA */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			found++;
+		}
+	}
+
+	if (found == 0) {
+		LOG_WRN("No devices with dynamic address - ensure DAA completed before tests");
+		ztest_test_skip();
+	}
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_negative, NULL, suite_setup, test_before, test_after, NULL);
+
+ZTEST(i3c_negative, test_invalid_dynamic_addresses)
+{
+	uint8_t buf[4];
+	int ret;
+
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		/* DA 0x00 is broadcast address - reserved, should fail */
+		ret = i3c_reg_read(ctrl, 0x00, I3C_TEST_CHIP_ID_REG, buf, 4);
+		zassert_true(ret < 0,
+			     "Transfer to DA 0x00 should fail in %s mode",
+			     i3c_test_mode_name(mode));
+
+		/* DA 0x07 is below valid range (0x08-0x77), should fail */
+		ret = i3c_reg_read(ctrl, 0x07, I3C_TEST_CHIP_ID_REG, buf, 4);
+		zassert_true(ret < 0,
+			     "Transfer to DA 0x07 should fail in %s mode",
+			     i3c_test_mode_name(mode));
+
+		/* DA 0x78 is above valid range (0x08-0x77), should fail */
+		ret = i3c_reg_read(ctrl, 0x78, I3C_TEST_CHIP_ID_REG, buf, 4);
+		zassert_true(ret < 0,
+			     "Transfer to DA 0x78 should fail in %s mode",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_negative, test_invalid_i2c_addresses)
+{
+	int ret;
+	uint8_t dummy_data = 0;
+	int rejected_count = 0;
+	int bus_fail_count = 0;
+
+	/* Test I2C addresses that should be invalid:
+	 * - 0x00-0x07: Reserved by I3C spec (broadcast, reserved)
+	 * - 0x78-0x7F: Reserved (7E is I3C broadcast, 7F reserved)
+	 * - 0x80+: Out of 7-bit address range
+	 *
+	 * Driver MAY reject at attach time OR allow attach but fail on bus.
+	 * Both are acceptable - we verify the address cannot be used.
+	 */
+
+	/* Test 0x00 - General Call address (reserved) */
+	struct i3c_i2c_device_desc i2c_desc_00 = {
+		.bus = ctrl,
+		.addr = 0x00,
+	};
+	ret = i3c_attach_i2c_device(&i2c_desc_00);
+	if (ret < 0) {
+		LOG_INF("I2C addr 0x00 rejected at attach: %d", ret);
+		rejected_count++;
+	} else {
+		/* Attach succeeded - verify it fails on actual bus transfer */
+		ret = i3c_transfer_write(ctrl, 0x00, &dummy_data, 1);
+		if (ret < 0) {
+			LOG_INF("I2C addr 0x00 failed on bus: %d", ret);
+			bus_fail_count++;
+		}
+		/* Cleanup - detach the invalid device */
+		i3c_detach_i2c_device(&i2c_desc_00);
+	}
+
+	/* Test 0x07 - Reserved address */
+	struct i3c_i2c_device_desc i2c_desc_07 = {
+		.bus = ctrl,
+		.addr = 0x07,
+	};
+	ret = i3c_attach_i2c_device(&i2c_desc_07);
+	if (ret < 0) {
+		LOG_INF("I2C addr 0x07 rejected at attach: %d", ret);
+		rejected_count++;
+	} else {
+		ret = i3c_transfer_write(ctrl, 0x07, &dummy_data, 1);
+		if (ret < 0) {
+			LOG_INF("I2C addr 0x07 failed on bus: %d", ret);
+			bus_fail_count++;
+		}
+		i3c_detach_i2c_device(&i2c_desc_07);
+	}
+
+	/* Test 0x78 - Above valid I2C range */
+	struct i3c_i2c_device_desc i2c_desc_78 = {
+		.bus = ctrl,
+		.addr = 0x78,
+	};
+	ret = i3c_attach_i2c_device(&i2c_desc_78);
+	if (ret < 0) {
+		LOG_INF("I2C addr 0x78 rejected at attach: %d", ret);
+		rejected_count++;
+	} else {
+		ret = i3c_transfer_write(ctrl, 0x78, &dummy_data, 1);
+		if (ret < 0) {
+			LOG_INF("I2C addr 0x78 failed on bus: %d", ret);
+			bus_fail_count++;
+		}
+		i3c_detach_i2c_device(&i2c_desc_78);
+	}
+
+	/* Test 0x7E - I3C broadcast address (must not be allowed as I2C) */
+	struct i3c_i2c_device_desc i2c_desc_7e = {
+		.bus = ctrl,
+		.addr = 0x7E,
+	};
+	ret = i3c_attach_i2c_device(&i2c_desc_7e);
+	if (ret < 0) {
+		LOG_INF("I2C addr 0x7E rejected at attach: %d", ret);
+		rejected_count++;
+	} else {
+		ret = i3c_transfer_write(ctrl, 0x7E, &dummy_data, 1);
+		if (ret < 0) {
+			LOG_INF("I2C addr 0x7E failed on bus: %d", ret);
+			bus_fail_count++;
+		}
+		i3c_detach_i2c_device(&i2c_desc_7e);
+	}
+
+	/* Summary: All 4 invalid addresses should fail somehow */
+	zassert_true(rejected_count > 0 || bus_fail_count > 0,
+		     "Invalid I2C addresses should be rejected at attach or fail on bus "
+		     "(rejected=%d, bus_fail=%d)",
+		     rejected_count, bus_fail_count);
+
+	LOG_INF("I2C validation: %d rejected, %d failed on bus",
+		rejected_count, bus_fail_count);
+}
+
+ZTEST(i3c_negative, test_transfer_null_buffer)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		int ret = i3c_transfer_write(ctrl, I3C_TEST_TARGET_DA, NULL, 2);
+
+		zassert_true(ret < 0, "NULL buffer should fail in %s mode",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_negative, test_zero_length_transfer)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		uint8_t data = 0;
+		int ret = i3c_transfer_write(ctrl, I3C_TEST_TARGET_DA,
+					     &data, 0);
+
+		zassert_true(ret < 0, "Zero length should fail in %s mode",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}
+
+ZTEST(i3c_negative, test_ccc_to_invalid_target)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		uint8_t pid[6];
+		int ret = i3c_do_ccc_getpid(ctrl, 0x00, pid, 6);
+
+		zassert_true(ret < 0,
+			     "CCC to invalid DA should fail in %s mode",
+			     i3c_test_mode_name(mode));
+	} I3C_TEST_END_EACH_MODE
+}

--- a/tests/drivers/i3c/src/i3c_sensor.c
+++ b/tests/drivers/i3c/src/i3c_sensor.c
@@ -1,0 +1,274 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/i3c/ccc.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include "i3c_common.h"
+
+#ifdef CONFIG_I3C_SENSOR_TESTS
+#include <zephyr/drivers/sensor.h>
+#endif
+
+LOG_MODULE_REGISTER(i3c_sensor, LOG_LEVEL_INF);
+
+static const struct device *ctrl;
+
+#ifdef CONFIG_I3C_SENSOR_TESTS
+#define BMI323_NODE   DT_NODELABEL(bmi323)
+#define ICM42670_NODE DT_NODELABEL(icm42670)
+static const struct device *bmi323_dev;
+static const struct device *icm42670_dev;
+#endif
+
+/**
+ * @brief Sensor test suite setup function
+ *
+ * Initializes I3C controller and resets bus to SDR mode.
+ * Performs DAA to ensure targets have dynamic addresses assigned.
+ *
+ * @return NULL on success, asserts on failure
+ */
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/*
+	 * Do NOT reset I3C bus here - use boot-assigned addresses.
+	 * RSTDAA would invalidate the cached addresses in sensor drivers.
+	 */
+	k_msleep(50);
+
+#ifdef CONFIG_I3C_SENSOR_TESTS
+	bmi323_dev = NULL;
+	icm42670_dev = NULL;
+#if DT_NODE_EXISTS(BMI323_NODE)
+	bmi323_dev = DEVICE_DT_GET(BMI323_NODE);
+	LOG_INF("BMI323 device: %s", bmi323_dev->name);
+#endif
+#if DT_NODE_EXISTS(ICM42670_NODE) && defined(CONFIG_ICM42X70)
+	icm42670_dev = DEVICE_DT_GET(ICM42670_NODE);
+	LOG_INF("ICM42670 device: %s", icm42670_dev->name);
+#endif
+#endif /* CONFIG_I3C_SENSOR_TESTS */
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	/*
+	 * Note: Sensor drivers cache I3C addresses at boot in i3c_dt_spec.
+	 * Do NOT run RSTDAA+DAA here — it would change device addresses
+	 * and break sensor driver communication. Use boot-assigned
+	 * addresses (from SETDASA) directly.
+	 */
+	k_msleep(50);
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_sensor, NULL, suite_setup, test_before, test_after, NULL);
+
+#ifdef CONFIG_I3C_SENSOR_TESTS
+
+/**
+ * @brief Test BMI323 sensor data read functionality
+ *
+ * Fetches accelerometer, gyroscope and temperature data from BMI323
+ * for 5 iterations. Verifies sensor communication over I3C bus.
+ */
+ZTEST(i3c_sensor, test_bmi323_data_read)
+{
+	struct sensor_value full_scale, sampling_freq, feat_mask;
+	struct sensor_value accel[3], gyro[3], temp;
+	int success_count = 0;
+	int fail_count = 0;
+	int ret;
+
+	if (bmi323_dev == NULL) {
+		LOG_WRN("BMI323 device pointer is NULL");
+		ztest_test_skip();
+		return;
+	}
+
+	LOG_INF("Checking BMI323 device readiness...");
+	zassert_true(device_is_ready(bmi323_dev), "BMI323 not ready");
+
+	/* Configure accelerometer: 2G range, high-performance mode, 100Hz */
+	full_scale.val1 = 2;    full_scale.val2 = 0;
+	feat_mask.val1  = 1;    feat_mask.val2  = 0;
+	sampling_freq.val1 = 100; sampling_freq.val2 = 0;
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_ACCEL_XYZ,
+			      SENSOR_ATTR_FULL_SCALE, &full_scale);
+	zassert_ok(ret, "BMI323 accel full_scale failed: %d", ret);
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_ACCEL_XYZ,
+			      SENSOR_ATTR_FEATURE_MASK, &feat_mask);
+	zassert_ok(ret, "BMI323 accel feature_mask failed: %d", ret);
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_ACCEL_XYZ,
+			      SENSOR_ATTR_SAMPLING_FREQUENCY, &sampling_freq);
+	zassert_ok(ret, "BMI323 accel sampling_freq failed: %d", ret);
+
+	/* Configure gyroscope: 500 dps, high-performance mode, 100Hz */
+	full_scale.val1 = 500;
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_GYRO_XYZ,
+			      SENSOR_ATTR_FULL_SCALE, &full_scale);
+	zassert_ok(ret, "BMI323 gyro full_scale failed: %d", ret);
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_GYRO_XYZ,
+			      SENSOR_ATTR_FEATURE_MASK, &feat_mask);
+	zassert_ok(ret, "BMI323 gyro feature_mask failed: %d", ret);
+
+	ret = sensor_attr_set(bmi323_dev, SENSOR_CHAN_GYRO_XYZ,
+			      SENSOR_ATTR_SAMPLING_FREQUENCY, &sampling_freq);
+	zassert_ok(ret, "BMI323 gyro sampling_freq failed: %d", ret);
+
+	/* Wait for sensor to enter high-performance mode */
+	k_msleep(50);
+
+	LOG_INF("Testing BMI323 - 20 iterations");
+
+	for (int iter = 0; iter < 20; iter++) {
+		ret = sensor_sample_fetch(bmi323_dev);
+		if (ret < 0) {
+			LOG_ERR("BMI323 sample fetch failed iter %d: %d",
+				iter + 1, ret);
+			fail_count++;
+			continue;
+		}
+		success_count++;
+
+		/* Read accelerometer with zassert */
+		ret = sensor_channel_get(bmi323_dev,
+					 SENSOR_CHAN_ACCEL_XYZ, accel);
+		zassert_ok(ret, "Accel read failed iter %d: %d", iter + 1, ret);
+		LOG_INF("Iter %d: Accel X=%d.%06d Y=%d.%06d Z=%d.%06d",
+			iter + 1,
+			accel[0].val1, accel[0].val2,
+			accel[1].val1, accel[1].val2,
+			accel[2].val1, accel[2].val2);
+
+		/* Read gyroscope with zassert */
+		ret = sensor_channel_get(bmi323_dev,
+					 SENSOR_CHAN_GYRO_XYZ, gyro);
+		zassert_ok(ret, "Gyro read failed iter %d: %d", iter + 1, ret);
+		LOG_INF("Iter %d: Gyro X=%d.%06d Y=%d.%06d Z=%d.%06d",
+			iter + 1,
+			gyro[0].val1, gyro[0].val2,
+			gyro[1].val1, gyro[1].val2,
+			gyro[2].val1, gyro[2].val2);
+
+		/* Temperature (optional) */
+		ret = sensor_channel_get(bmi323_dev,
+					 SENSOR_CHAN_DIE_TEMP, &temp);
+		if (ret == 0) {
+			LOG_INF("Iter %d: Temp %d.%06d C",
+				iter + 1, temp.val1, temp.val2);
+		}
+
+		k_msleep(20);
+	}
+
+	LOG_INF("BMI323 completed: %d success, %d failures",
+		success_count, fail_count);
+
+	zassert_equal(success_count, 20, "BMI323 failed %d/%d iterations",
+		      fail_count, 20);
+}
+
+#ifdef CONFIG_ICM42X70
+/**
+ * @brief Test ICM42670 sensor data read functionality
+ *
+ * ICM42670 is configured at boot from DT (accel-hz/fs, gyro-hz/fs).
+ * Fetches accelerometer, gyroscope and temperature for 20 iterations.
+ */
+ZTEST(i3c_sensor, test_icm42670_data_read)
+{
+	struct sensor_value accel[3], gyro[3], temp;
+	int success_count = 0;
+	int fail_count = 0;
+	int ret;
+
+	if (icm42670_dev == NULL) {
+		LOG_WRN("ICM42670 device pointer is NULL");
+		ztest_test_skip();
+		return;
+	}
+
+	LOG_INF("Checking ICM42670 device readiness...");
+	if (!device_is_ready(icm42670_dev)) {
+		LOG_WRN("ICM42670 not ready, skipping");
+		ztest_test_skip();
+		return;
+	}
+
+	LOG_INF("Testing ICM42670 - 20 iterations");
+
+	for (int iter = 0; iter < 20; iter++) {
+		ret = sensor_sample_fetch(icm42670_dev);
+		if (ret < 0) {
+			LOG_ERR("ICM42670 sample fetch failed iter %d: %d",
+				iter + 1, ret);
+			fail_count++;
+			continue;
+		}
+		success_count++;
+
+		ret = sensor_channel_get(icm42670_dev,
+					 SENSOR_CHAN_ACCEL_XYZ, accel);
+		zassert_ok(ret, "ICM42670 accel read failed iter %d: %d",
+			   iter + 1, ret);
+		LOG_INF("Iter %d: Accel X=%d.%06d Y=%d.%06d Z=%d.%06d",
+			iter + 1,
+			accel[0].val1, accel[0].val2,
+			accel[1].val1, accel[1].val2,
+			accel[2].val1, accel[2].val2);
+
+		ret = sensor_channel_get(icm42670_dev,
+					 SENSOR_CHAN_GYRO_XYZ, gyro);
+		zassert_ok(ret, "ICM42670 gyro read failed iter %d: %d",
+			   iter + 1, ret);
+		LOG_INF("Iter %d: Gyro X=%d.%06d Y=%d.%06d Z=%d.%06d",
+			iter + 1,
+			gyro[0].val1, gyro[0].val2,
+			gyro[1].val1, gyro[1].val2,
+			gyro[2].val1, gyro[2].val2);
+
+		ret = sensor_channel_get(icm42670_dev,
+					 SENSOR_CHAN_DIE_TEMP, &temp);
+		if (ret == 0) {
+			LOG_INF("Iter %d: Temp %d.%06d C",
+				iter + 1, temp.val1, temp.val2);
+		}
+
+		k_msleep(20);
+	}
+
+	LOG_INF("ICM42670 completed: %d success, %d failures",
+		success_count, fail_count);
+
+	zassert_equal(success_count, 20, "ICM42670 failed %d/%d iterations",
+		      fail_count, 20);
+}
+#endif /* CONFIG_ICM42X70 */
+
+#endif /* CONFIG_I3C_SENSOR_TESTS */

--- a/tests/drivers/i3c/src/i3c_stress.c
+++ b/tests/drivers/i3c/src/i3c_stress.c
@@ -1,0 +1,198 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include "i3c_common.h"
+
+LOG_MODULE_REGISTER(i3c_stress, LOG_LEVEL_INF);
+
+static const struct device *ctrl;
+
+static void *suite_setup(void)
+{
+	ctrl = DEVICE_DT_GET(I3C_CONTROLLER_NODE);
+	zassert_true(device_is_ready(ctrl), "I3C controller not ready");
+
+	/* Configure SDR mode only.
+	 * NOTE: Zephyr does not support hot-join. DAA must be done by
+	 * application or device initialization before tests run.
+	 * We do NOT perform RSTDAA+DAA here because:
+	 * 1. If all suites run at once, repeated RSTDAA causes address
+	 *    increments and driver state issues
+	 * 2. If suites run individually, system/DT init should have
+	 *    already performed DAA
+	 */
+	i3c_test_reset_to_sdr(ctrl);
+
+	return NULL;
+}
+
+static void test_before(void *fixture)
+{
+	struct i3c_device_desc *desc;
+	int found = 0;
+
+	ARG_UNUSED(fixture);
+
+	/* Verify devices were assigned addresses by prior DAA */
+	I3C_BUS_FOR_EACH_I3CDEV(ctrl, desc) {
+		if (desc->dynamic_addr != 0U) {
+			found++;
+		}
+	}
+
+	if (found == 0) {
+		LOG_WRN("No devices with dynamic address - ensure DAA completed before tests");
+		ztest_test_skip();
+	}
+}
+
+static void test_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST_SUITE(i3c_stress, NULL, suite_setup, test_before, test_after, NULL);
+
+ZTEST(i3c_stress, test_repeated_getpid)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t pid_buf[6];
+			int success_count = 0;
+
+			for (int i = 0; i < 10; i++) {
+				int ret = i3c_do_ccc_getpid(ctrl,
+						    desc->dynamic_addr,
+						    pid_buf, 6);
+
+				if (ret == 6) {
+					success_count++;
+				}
+			}
+
+			/* All 10 iterations must succeed for
+			 * SDR mode compliance
+			 */
+			zassert_equal(success_count, 10,
+				      "GETPID stress: %d/10 on DA=0x%02x %s",
+				      success_count, desc->dynamic_addr,
+				      i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/* Read endurance test on ALL targets at ALL modes */
+ZTEST(i3c_stress, test_read_endurance)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t data[4];
+			int success_count = 0;
+
+			for (int i = 0; i < 100; i++) {
+				int ret = i3c_reg_read(ctrl,
+						     desc->dynamic_addr,
+						     I3C_TEST_CHIP_ID_REG,
+						     data, 4);
+
+				if (ret == 0) {
+					success_count++;
+				}
+			}
+
+			/* All 100 iterations must succeed for
+			 * SDR mode compliance
+			 */
+			zassert_equal(success_count, 100,
+				      "Read endurance: %d/100 on DA=0x%02x %s",
+				      success_count, desc->dynamic_addr,
+				      i3c_test_mode_name(mode));
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/* Multi-message endurance test on ALL targets at ALL modes */
+ZTEST(i3c_stress, test_multi_msg_endurance)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t buf1[4], buf2[4];
+			int success_count = 0;
+
+			for (int i = 0; i < 20; i++) {
+				int ret1 = i3c_reg_read(ctrl,
+					desc->dynamic_addr,
+					I3C_TEST_CHIP_ID_REG,
+					buf1, 4);
+				int ret2 = i3c_reg_read(ctrl,
+					desc->dynamic_addr,
+					I3C_TEST_CHIP_ID_REG,
+					buf2, 4);
+
+				if (ret1 == 0 && ret2 == 0) {
+					success_count++;
+				}
+			}
+
+			/* All 20 multi-message iterations must succeed */
+			zassert_equal(success_count, 20,
+				      "Multi-msg endurance failed: %d/20 succeeded on DA=0x%02x",
+				      success_count, desc->dynamic_addr);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}
+
+/* CCC transfer interleave test on ALL targets at ALL modes */
+ZTEST(i3c_stress, test_ccc_transfer_interleave)
+{
+	I3C_TEST_FOR_EACH_MODE(ctrl, mode) {
+		I3C_TEST_FOR_EACH_TARGET(ctrl, desc) {
+			uint8_t pid_buf[6];
+			uint8_t dcr;
+			uint8_t buf[4];
+			int success_count = 0;
+
+			for (int i = 0; i < 20; i++) {
+				int ret1 = i3c_do_ccc_getpid(ctrl,
+					desc->dynamic_addr,
+					pid_buf, 6);
+				int ret2 = i3c_reg_read(ctrl,
+					desc->dynamic_addr,
+					I3C_TEST_CHIP_ID_REG,
+					buf, 2);
+				int ret3 = i3c_do_ccc_getpid(ctrl,
+					desc->dynamic_addr,
+					pid_buf, 6);
+				int ret4 = i3c_do_ccc_getdcr(ctrl,
+					desc->dynamic_addr,
+					&dcr);
+				int ret5 = i3c_reg_read(ctrl,
+					desc->dynamic_addr,
+					I3C_TEST_CHIP_ID_REG,
+					buf, 2);
+
+				/*
+				 * All 5 operations must succeed
+				 * for a successful iteration.
+				 */
+				if (ret1 == 6 && ret2 == 0 && ret3 == 6 &&
+				    ret4 == 0 && ret5 == 0) {
+					success_count++;
+				}
+			}
+
+			/* All 20 interleave iterations must succeed */
+			zassert_equal(success_count, 20,
+				      "CCC/transfer interleave failed: %d/20 succeeded on DA=0x%02x",
+				      success_count, desc->dynamic_addr);
+		} I3C_TEST_END_EACH_TARGET
+	} I3C_TEST_END_EACH_MODE
+}

--- a/tests/drivers/i3c/testcase.yaml
+++ b/tests/drivers/i3c/testcase.yaml
@@ -1,0 +1,84 @@
+common:
+  tags:
+    - drivers
+    - i3c
+  extra_conf_files:
+    - prj.conf
+  platform_allow:
+    - alif_e7_dk/ae722f80f55d5xx/rtss_he
+    - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+    - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+
+tests:
+  # =====================================================================
+  # All I3C tests combined
+  # =====================================================================
+  drivers.i3c.all:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_ALL_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  # =====================================================================
+  # Individual test suites
+  # =====================================================================
+  drivers.i3c.discovery:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_DISCOVERY_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  drivers.i3c.ccc:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_CCC_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  drivers.i3c.ibi:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_IBI_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  drivers.i3c.negative:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_NEGATIVE_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  drivers.i3c.stress:
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_STRESS_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+
+  drivers.i3c.sensor:
+    tags:
+      - drivers
+      - i3c
+      - sensor
+    depends_on:
+      - i3c
+      - sensor
+    extra_dtc_overlay_files:
+      - boards/i3c_test.overlay
+    extra_configs:
+      - CONFIG_I3C_SENSOR_TESTS=y
+    integration_platforms:
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+


### PR DESCRIPTION
Adds a multi-test-suite I3C driver validation framework supporting discovery, CCC commands, IBI, negative tests, stress tests, and sensor integration.

Test suites:
- Discovery: DAA, RSTDAA, PID retrieval, target enumeration
- CCC: GETPID, GETBCR, GETDCR, SETMWL, GETMWL, GETMRL, GETSTATUS, ENEC/DISEC event control, broadcast commands
- IBI: In-band interrupt capability detection and validation
- Negative: Error handling, invalid addresses, boundary conditions
- Stress: Repeated operations (10x GETPID), multi-target validation
- Sensor: Real device tests for BMI323 and ICM42670 sensors

Features:
- Multi-speed mode testing (SDR, I2C-FM+)
- RSTDAA+DAA reset sequence per test for clean state
- Device tree based target configuration via overlay
- Macro-based test iteration across modes and targets

Hardware requirements:
- I3C controller (i3c0)
- BMI323 sensor (default) or ICM42670 (optional)