### PR TITLE
manifest: update zephyr_alif revision for B1 ES1_OSC fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f12daf5c2812b8e93cf5ca4839f7b2f276d27b76
+      revision: 615af7df1c0fbc1ac52ec021951dcbb48bbb706f
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr_alif revision to include B1 ES1_OSC fix.

This depends on https://github.com/alifsemi/zephyr_alif/pull/467