### PR TITLE
pm_system_off: Use dts aipm profiles

### DIFF
--- a/doc/appnotes/source/index.rst
+++ b/doc/appnotes/source/index.rst
@@ -42,6 +42,7 @@ Application Notes for the Zephyr Alif SDK
    pdm.rst
    ensemble_pins.rst
    power_management.rst
+   se_aipm_profiles.rst
    psram.rst
    pwm.rst
    qdec.rst

--- a/doc/appnotes/source/se_aipm_profiles.rst
+++ b/doc/appnotes/source/se_aipm_profiles.rst
@@ -1,0 +1,281 @@
+.. _appnote-se-aipm-profiles:
+
+==================================
+SE aiPM Run and Off Profile (DTS)
+==================================
+
+Introduction
+============
+
+Alif SoCs use Secure Enclave (SE) to manage global power and clock settings
+through the aiPM (Autonomous Intelligent Power Management) framework. Two
+profiles control this:
+
+* **Run profile** — applied at cold boot and on each PM resume. Sets the CPU
+  clock, DCDC mode, power domains, and other active-state parameters.
+
+* **Off profile** — applied on PM state entry (``SUSPEND_TO_RAM``,
+  ``SOFT_OFF``). Sets memory retention, wakeup sources, EWIC configuration,
+  and standby clocks before the CPU is power-gated.
+
+Both profiles are configured via Devicetree nodes (``aipm_run``,
+``aipm_off``) defined in the SoC DTSI. The run profile is active by default
+(``status = "okay"``); board overlays override only the properties that
+differ from the SoC defaults. The off profile is ``status = "disabled"`` by
+default and must be explicitly enabled in a board overlay. No application
+code changes are required — the SE service driver applies the profiles
+automatically.
+
+Run Profile
+===========
+
+Overview
+--------
+
+The ``aipm_run`` node (compatible ``alif,aipm-run``) holds one child node
+per PM state/substate. A child without ``pm-state`` acts as the cold-boot
+default and universal fallback.
+
+The profile is applied:
+
+* At PRE_KERNEL_1 priority 45 (``se_service_mhuv2_nodes_init``), just after
+  the SE communication channel is ready.
+* In the ``pre_device_resume`` PM notifier before devices are resumed,
+  ensuring the correct power domains are active before driver callbacks run.
+
+.. note::
+   Any driver or ``SYS_INIT`` callback that needs a power domain enabled
+   (e.g. SYSTOP for peripheral register access) must run at PRE_KERNEL_1
+   priority **greater than 45** so the run profile — and its power domains —
+   is already active.
+
+Key Properties (per child node)
+---------------------------------
+
+.. list-table::
+   :widths: 25 10 65
+   :header-rows: 1
+
+   * - Property
+     - Required
+     - Description
+   * - ``pm-state``
+     - No
+     - PM state this child targets on resume. Omit for cold-boot default.
+   * - ``pm-substate``
+     - No
+     - Substate index. Default 0.
+   * - ``aipm-power-domains``
+     - No
+     - Power domain bitmask (``ALIF_PD_*_MASK``). Domains kept powered.
+   * - ``cpu-clk-freq``
+     - **Yes**
+     - CPU clock frequency. Use ``ALIF_CLOCK_FREQ_*`` constants.
+   * - ``clk-src``
+     - No
+     - HF run clock source: ``"hfrc"``, ``"hfxo"``, ``"pll"``.
+   * - ``dcdc-mode``
+     - No
+     - DCDC mode: ``"off"``, ``"pfm-auto"``, ``"pfm-forced"``, ``"pwm"``.
+   * - ``dcdc-voltage``
+     - No
+     - DCDC voltage in mV: 800, 825, or 850.
+   * - ``aon-clk-src``
+     - No
+     - Always-on LF clock: ``"lfrc"`` or ``"lfxo"``.
+   * - ``memory-blocks``
+     - No
+     - Memory retention bitmask. See `Memory Block Reference`_.
+   * - ``vdd-ioflex``
+     - No
+     - GPIO voltage: ``ALIF_IOFLEX_LEVEL_1V8`` (default) or ``ALIF_IOFLEX_LEVEL_3V3``.
+
+Example — Enabling and Customising the Run Profile
+----------------------------------------------------
+
+The SoC DTSI defines the ``aipm_run`` node with ``status = "okay"`` and a
+default child. A board overlay overrides only the child properties that
+differ from the SoC defaults:
+
+.. code-block:: dts
+
+   /* Override the default cold-boot profile */
+   &run_profile_default {
+       status = "okay";
+       aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK |
+                              ALIF_PD_VBAT_AON_MASK   |
+                              ALIF_PD_SYST_AON_MASK   |
+                              ALIF_PD_SYST_MEM_MASK   |
+                              ALIF_PD_SYST_FULL_MASK)>;
+       cpu-clk-freq  = <ALIF_CLOCK_FREQ_400_MHZ>;
+       clk-src       = "pll";
+       dcdc-mode     = "pwm";
+       dcdc-voltage  = <850>;
+       aon-clk-src   = "lfxo";
+   };
+
+Off Profile
+===========
+
+Overview
+--------
+
+The ``aipm_off`` node (compatible ``alif,aipm-off``) holds one child node
+per PM state/substate for which an off profile is needed. The SE service
+matches by ``(pm-state, pm-substate)`` in the ``state_entry`` PM notifier —
+**before** the SE communication channel is closed.
+
+The parent node carries ``vtor-address``: the vector table base address the
+SE uses to resume CPU execution after wakeup.
+
+.. list-table:: Default ``vtor-address`` values by core
+   :widths: 40 30 30
+   :header-rows: 1
+
+   * - Core / SoC
+     - Default (MRAM boot)
+     - TCM boot override
+   * - RTSS_HE (Ensemble, E1C, B1)
+     - ``0x80000000``
+     - ``0x00000000``
+   * - RTSS_HP (Ensemble)
+     - ``0x80200000``
+     - N/A (HP has no TCM Retention mode)
+
+Key Properties (parent node)
+------------------------------
+
+.. list-table::
+   :widths: 25 10 65
+   :header-rows: 1
+
+   * - Property
+     - Required
+     - Description
+   * - ``vtor-address``
+     - **Yes**
+     - Vector table base address. Set in SoC DTSI; override in board overlay
+       for TCM or SRAM-relocation boot.
+
+Key Properties (per child node)
+---------------------------------
+
+.. list-table::
+   :widths: 25 10 65
+   :header-rows: 1
+
+   * - Property
+     - Required
+     - Description
+   * - ``pm-state``
+     - **Yes**
+     - PM state this child applies to. ``4`` = SUSPEND_TO_RAM,
+       ``6`` = SOFT_OFF.
+   * - ``pm-substate``
+     - No
+     - Substate index. Default 0.
+   * - ``aipm-power-domains``
+     - No
+     - Power domains kept powered during sleep.
+   * - ``memory-blocks``
+     - No
+     - Memory retention bitmask. Default 0 (no retention).
+       See `Memory Block Reference`_.
+   * - ``wakeup-events``
+     - No
+     - Wakeup source bitmask (``ALIF_WE_*``). Default 0 — **must** be set
+       in board overlay to enable wakeup.
+   * - ``ewic-cfg``
+     - No
+     - EWIC configuration bitmask (``ALIF_EWIC_*``). Default 0 — **must**
+       be set in board overlay to enable EWIC wakeup.
+   * - ``dcdc-mode``
+     - No
+     - DCDC mode during sleep. Typically ``"off"``.
+   * - ``aon-clk-src``
+     - No
+     - Always-on LF clock: ``"lfrc"`` or ``"lfxo"`` (default).
+   * - ``stby-clk-src``
+     - No
+     - Standby HF clock: ``"hfrc"`` (default), ``"hfxo"``, or ``"pll"``.
+   * - ``stby-clk-freq``
+     - No
+     - Scaled standby clock frequency. Use ``ALIF_SCALED_FREQ_RC_STDBY_*``.
+   * - ``vdd-ioflex``
+     - No
+     - GPIO voltage level. Default ``ALIF_IOFLEX_LEVEL_1V8``.
+
+Example — Enabling the Off Profile in a Board Overlay
+------------------------------------------------------
+
+.. code-block:: dts
+
+   /* Override vtor-address for TCM boot */
+   &aipm_off {
+       vtor-address = <0x00000000>;
+       status = "okay";
+   };
+
+   /* SUSPEND_TO_RAM substate 0 (STANDBY) */
+   &off_profile_standby {
+       status = "okay";
+       wakeup-events = <ALIF_WE_LPRTC>;
+       ewic-cfg      = <ALIF_EWIC_RTC_A>;
+       memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+                         ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+                         ALIF_SERAM_MASK   | ALIF_MRAM_MASK)>;
+   };
+
+   /* SUSPEND_TO_RAM substate 1 (STOP) */
+   &off_profile_stop {
+       status = "okay";
+       wakeup-events = <ALIF_WE_LPRTC>;
+       ewic-cfg      = <ALIF_EWIC_RTC_A>;
+       memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+                         ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+                         ALIF_SERAM_MASK   | ALIF_MRAM_MASK)>;
+   };
+
+.. note::
+   ``wakeup-events`` and ``ewic-cfg`` default to ``0`` in the SoC DTSI
+   (safe default — no spurious wakeups). Always set them explicitly in the
+   board overlay for the desired wakeup source.
+
+Memory Block Reference
+======================
+
+The ``memory-blocks`` bitmask selects which memories the SE keeps powered
+and retained during sleep. Use constants from the per-SoC header included in
+the SoC DTSI.
+
+.. list-table:: HE Core Memory Blocks by SoC Family
+   :widths: 30 35 35
+   :header-rows: 1
+
+   * - Block
+     - Ensemble / Gen2 (E3–E8)
+     - E1C / B1
+   * - ITCM (SRAM4)
+     - ``ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK``
+     - ``ALIF_SRAM4_1_MASK`` … ``ALIF_SRAM4_4_MASK``
+   * - DTCM (SRAM5)
+     - ``ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK``
+     - ``ALIF_SRAM5_1_MASK`` … ``ALIF_SRAM5_5_MASK``
+   * - SERAM
+     - ``ALIF_SERAM_MASK`` (1 bit / 2 bits)
+     - ``ALIF_SERAM_MASK`` (4 bits)
+   * - MRAM
+     - ``ALIF_MRAM_MASK``
+     - ``ALIF_MRAM_MASK``
+
+.. note::
+   ``ALIF_SERAM_MASK`` resolves to the correct width automatically via the
+   per-SoC header pulled in by the SoC DTSI. No manual bit-width selection
+   is needed.
+
+PM System Off Snippet
+======================
+
+The ``pm-system-off-he`` snippet provides ready-to-use overlay files for the
+HE core. See the ``alif-pm-states-sample`` sample for build instructions
+and per-SoC overlay selection details.

--- a/doc/release_notes/source/release_note.rst
+++ b/doc/release_notes/source/release_note.rst
@@ -215,6 +215,11 @@ System Resources
      - Pin multiplexer controlling GPIO pin function selection and routing of peripheral signals to physical pins, enabling flexible I/O configuration.
    * - System Power Management (suspend to ram)
      - Power management framework supporting deep sleep states including Suspend-to-RAM (S2RAM), where SRAM is retained, enabling fast resume and ultra-low power idle operation.
+   * - SE Run/Off Profile (DTS-driven)
+     - Devicetree-configurable Secure Enclave power profiles applied
+       automatically at boot/resume (run profile) and on PM state entry
+       (off profile). Board overlays select per-state settings for wakeup
+       events, memory retention, clock sources, and power domains.
    * -  LP-GPIO
      - Low-power GPIO controller that maintains state and wake-up capability during system sleep modes, allowing external events to trigger resume from low-power states.
    * - DMA

--- a/samples/drivers/pm/system_off/src/main.c
+++ b/samples/drivers/pm/system_off/src/main.c
@@ -25,6 +25,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pm_system_off, LOG_LEVEL_INF);
 
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 /**
  * As per the application requirements, it can remove the memory blocks which are not in use.
  */
@@ -37,18 +38,26 @@ LOG_MODULE_REGISTER(pm_system_off, LOG_LEVEL_INF);
 	#define APP_RET_MEM_BLOCKS SRAM4_1_MASK | SRAM4_2_MASK | SRAM5_1_MASK | SRAM5_2_MASK
 	#define SERAM_MEMORY_BLOCKS_IN_USE SERAM_MASK
 #endif
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE || CONFIG_ALIF_SE_DTS_OFF_PROFILE */
 
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
-	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
 	#define SE_OFFP_EWIC_CFG EWIC_RTC_A
 	#define SE_OFFP_WAKEUP_EVENTS WE_LPRTC
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
-	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
 	#define SE_OFFP_EWIC_CFG EWIC_VBAT_TIMER
 	#define SE_OFFP_WAKEUP_EVENTS WE_LPTIMER0
+#endif
+#endif /* CONFIG_ALIF_SE_DTS_OFF_PROFILE */
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
 #else
 #error "Wakeup Device not enabled in the dts"
 #endif
+
 
 /* Sleep duration for PM_STATE_RUNTIME_IDLE */
 #define RUNTIME_IDLE_SLEEP_USEC (18 * 1000 * 1000)
@@ -108,6 +117,7 @@ BUILD_ASSERT((SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC),
 	"SOFT_OFF sleep duration should be greater than STOP sleep duration");
 #endif
 
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
 /**
  * Set the RUN profile parameters for this application.
  */
@@ -149,7 +159,9 @@ static int app_set_run_params(void)
  * On SOFT_OFF wakeup: SYSTOP is OFF, must restore BEFORE peripherals access registers.
  */
 SYS_INIT(app_set_run_params, PRE_KERNEL_1, 46);
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE */
 
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 static int app_set_off_params(enum pm_state state, uint8_t substate_id)
 {
 	int ret;
@@ -235,7 +247,9 @@ static void pm_notify_state_entry(enum pm_state state)
 		break;
 	}
 }
+#endif /* CONFIG_ALIF_SE_DTS_OFF_PROFILE */
 
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
 /**
  * PM Notifier callback called BEFORE devices are resumed
  *
@@ -263,14 +277,21 @@ static void pm_notify_pre_device_resume(enum pm_state state)
 		break;
 	}
 }
+#endif
 
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 /**
  * PM Notifier structure
  */
 static struct pm_notifier app_pm_notifier = {
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 	.state_entry = pm_notify_state_entry,
+#endif
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
 	.pre_device_resume = pm_notify_pre_device_resume,
+#endif
 };
+#endif
 
 /**
  * Helper function to lock/unlock deeper power states
@@ -346,8 +367,10 @@ static int app_pre_kernel_init(void)
 	/* Lock deeper power states to allow only RUNTIME_IDLE */
 	app_pm_lock_deeper_states(true);
 
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 	/* Register PM notifier callbacks */
 	pm_notifier_register(&app_pm_notifier);
+#endif
 
 	return 0;
 }
@@ -526,7 +549,9 @@ int main(void)
 	}
 
 	/* Configure OFF profile for wakeup capability */
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
 	app_set_off_params(PM_STATE_SOFT_OFF, 0);
+#endif
 
 	LOG_INF("Calling sys_poweroff() - system will power off permanently");
 	sys_poweroff();

--- a/snippets/pm-system-off-he/pm_off_common.overlay
+++ b/snippets/pm-system-off-he/pm_off_common.overlay
@@ -44,6 +44,23 @@
 	status = "okay";
 };
 
+&aipm_off {
+	vtor-address = <0x00000000>;
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
 / {
 	chosen {
 		zephyr,cortex-m-idle-timer = &rtc0;

--- a/snippets/pm-system-off-he/pm_off_e1c_b1.overlay
+++ b/snippets/pm-system-off-he/pm_off_e1c_b1.overlay
@@ -1,0 +1,33 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble E1C and Balletto B1 SoCs.
+ */
+
+#include "pm_off_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/snippets/pm-system-off-he/pm_off_ensemble.overlay
+++ b/snippets/pm-system-off-he/pm_off_ensemble.overlay
@@ -1,0 +1,28 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble (E1/E3/E5/E7) and Ensemble Gen2
+ * (E4/E6/E8) SoCs.
+ */
+
+#include "pm_off_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/snippets/pm-system-off-he/snippet.yml
+++ b/snippets/pm-system-off-he/snippet.yml
@@ -1,4 +1,13 @@
 name: pm-system-off-he
 append:
-  EXTRA_DTC_OVERLAY_FILE: snippet.overlay
   EXTRA_CONF_FILE: prj.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: pm_off_e1c_b1.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: pm_off_e1c_b1.overlay
+  /alif_(e3|e4|e5|e6|e7|e8).*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: pm_off_ensemble.overlay

--- a/snippets/pm-system-off-hp/snippet.overlay
+++ b/snippets/pm-system-off-hp/snippet.overlay
@@ -33,6 +33,17 @@
 	status = "okay";
 };
 
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	status = "okay";
+	memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+	wakeup-events      = <ALIF_WE_LPTIMER0>;
+	ewic-cfg           = <ALIF_EWIC_VBAT_TIMER>;
+};
+
 / {
 	chosen {
 		zephyr,console = &uart2;

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 887d235d5e368999adb448a3b5974efa7fa49e9f
+      revision: 4af941a6a1bb1bccb4a305939f65001faa9e0b20
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Use DT based configuration to set the RUN and OFF profiles.
The Application Note and Release Notes are updated.

Depends: https://github.com/alifsemi/zephyr_alif/pull/468