### PR TITLE
manifest: zephyr: dma_pl330: clock and pm support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: de4da65b024990ca5e49c23849424070d4ba463c
+      revision: pull/469/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the zephyr repo to include the clock and pm support for dma

Depends: https://github.com/alifsemi/zephyr_alif/pull/469