### PR TITLE
Add Jpeg Encoder test support in video pipeline.

### DIFF
--- a/samples/drivers/video/README.rst
+++ b/samples/drivers/video/README.rst
@@ -1,7 +1,7 @@
 .. _video-sample:
 
 Video Sample
-#############################################
+############
 
 Overview
 ********
@@ -19,6 +19,10 @@ the memory. The sample also supports ISP in the video pipeline. The functional b
 * In case ISP is selected (serial_camera_arx3a0_selfie.overlay), Camera controller will pass the
   frame to ISP IP. The ISP then writes the processed frame to memory.
 
+* In case JPEG is selected (jpeg.overlay and jpeg.conf), the ISP's processed
+  output frame will be considerd for compression.Then the JPEG writes
+  the compressed frame to output memory.
+
 For E7 use serial_camera_arx3a0.overlay, while for E8 use serial_camera_arx3a0_standard.overlay,
 in case ISP is not needed and Standard camera is required. For selfie camera with ISP on E8, use
 serial_camera_arx3a0_selfie.overlay and isp.conf as OVERLAY_CONFIG. In case selfie camera without
@@ -32,6 +36,16 @@ The sample utilizes the CAM Controller IP from alif and a camera sensor. It may 
 MIPI-CSI2 IP from Synopsys if the serial camera sensor application is built from the command line.
 The camera sensors used in the parallel camera case is the MT9M114, while serial camera include
 ARX3A0 camera sensor.
+
+The JPEG encoder is supported only on the alif_e8 board and
+can be selected during the build process only for this target.
+
+  - The JPEG module consumes one buffer from the video buffer pool.
+    Since N_VID_BUFF requires a minimum of 2 buffers, the total buffer pool size
+    (CONFIG_VIDEO_BUFFER_POOL_NUM_MAX) must be at least 3.
+
+  - For a resolution of 480 × 480 with an NV12 input format,
+    the minimum required buffer size (CONFIG_VIDEO_BUFFER_POOL_SZ_MAX) is 346223 bytes.
 
 Supported Targets
 *****************
@@ -53,43 +67,148 @@ Tested Sensors
 Sample Output
 *************
 
+Video app with Jpeg encoder
+---------------------------
+
 .. code-block:: console
 
-  [00:00:00.000,000] <inf> csi2_dw: #rx_dphy_ids: 1
-  *** Booting Zephyr OS build 9951f106e882 ***
-  [00:00:00.662,000] <inf> video_app: - Device name: cam@49030000
-  [00:00:00.662,000] <inf> video_app: - Capabilities:
+   [00:00:00.000,000] <inf> csi2_dw: #rx_dphy_ids: 1
+   [00:00:00.664,000] <inf> jpeg_hantro_vc9000e: VeriSilicon Hantro VC9000E JPEG encoder initialized
+   [00:00:00.664,000] <inf> video_app: - Device name: isp@49046000
+   [00:00:00.664,000] <inf> video_app: Selected camera: Selfie
+   [00:00:00.664,000] <inf> video_app: - Capabilities:
 
-  [00:00:00.662,000] <inf> video_app:   Y10P width (min, max, step)[560; 560; 0] height (min, max, step)[560; 560; 0]
-  [00:00:01.202,000] <inf> dphy_dw: RX-DDR clock: 400000000
-  [00:00:01.203,000] <inf> video_app: - format: Y10P 560x560
-  [00:00:01.203,000] <inf> video_app: Width - 560, Pitch - 1120, Height - 560, Buff size - 627200
-  [00:00:01.203,000] <inf> video_app: - addr - 0x2000060, size - 627200, bytesused - 0
-  [00:00:01.231,000] <inf> video_app: capture buffer[0]: dump binary memory "/home/$USER/capture_0.bin" 0x02000060 0x0209925f -r
+   [00:00:00.664,000] <inf> video_app:   Y10P width (min, max, step)[560; 560; 0] height (min, max, step)[560; 560; 0]
+   [00:00:01.204,000] <inf> dphy_dw: RX-DDR clock: 400000000
+   [00:00:01.204,000] <inf> video_app: - format: NV12 480x480
+   [00:00:01.204,000] <inf> video_app: Width - 480, Pitch - 720, Height - 480, Buff size - 345600
+   [00:00:01.204,000] <inf> video_app: JPEG: device ready: jpeg@49044000
+   [00:00:01.204,000] <inf> video_app: JPEG: Encoder Capabilities:
+   [00:00:01.204,000] <inf> video_app:   Format: 0x3231564e, Size: 32x32 to 16384x16384
+   [00:00:01.204,000] <inf> video_app:   Format: 0x3132564e, Size: 32x32 to 16384x16384
+   [00:00:01.204,000] <inf> video_app: Jpeg: Outbuf allocated at 0x02000060 with 231023 bytes
 
-  [00:00:01.231,000] <inf> video_app: - addr - 0x2099268, size - 627200, bytesused - 0
-  [00:00:01.258,000] <inf> video_app: capture buffer[1]: dump binary memory "/home/$USER/capture_1.bin" 0x02099268 0x02132467 -r
+   [00:00:01.208,000] <inf> video_app: - addr - 0x20386d8, size - 345600, bytesused - 0, resolution - 480x480
+   [00:00:01.213,000] <inf> video_app: capture buffer[0]: dump binary memory "/home/$USER/capture_0.bin" 0x020386d8 0x0208ccd7 -r
 
-  [00:00:08.260,000] <inf> video_app: Capture started
-  [00:00:08.328,000] <inf> video_app: Got frame 0! size: 627200; timestamp 8328 ms
-  [00:00:08.328,000] <inf> video_app: FPS: 0.0
-  [00:00:08.528,000] <inf> video_app: Got frame 1! size: 627200; timestamp 8528 ms
-  [00:00:08.528,000] <inf> video_app: FPS: 5.000000
-  [00:00:08.728,000] <inf> video_app: Got frame 2! size: 627200; timestamp 8728 ms
-  [00:00:08.728,000] <inf> video_app: FPS: 5.000000
-  [00:00:08.928,000] <inf> video_app: Got frame 3! size: 627200; timestamp 8928 ms
-  [00:00:08.928,000] <inf> video_app: FPS: 5.000000
-  [00:00:09.128,000] <inf> video_app: Got frame 4! size: 627200; timestamp 9128 ms
-  [00:00:09.128,000] <inf> video_app: FPS: 5.000000
-  [00:00:09.328,000] <inf> video_app: Got frame 5! size: 627200; timestamp 9328 ms
-  [00:00:09.328,000] <inf> video_app: FPS: 5.000000
-  [00:00:09.528,000] <inf> video_app: Got frame 6! size: 627200; timestamp 9528 ms
-  [00:00:09.528,000] <inf> video_app: FPS: 5.000000
-  [00:00:09.728,000] <inf> video_app: Got frame 7! size: 627200; timestamp 9728 ms
-  [00:00:09.728,000] <inf> video_app: FPS: 5.000000
-  [00:00:09.928,000] <inf> video_app: Got frame 8! size: 627200; timestamp 9928 ms
-  [00:00:09.928,000] <inf> video_app: FPS: 5.000000
-  [00:00:10.128,000] <inf> video_app: Got frame 9! size: 627200; timestamp 10128 ms
-  [00:00:10.128,000] <inf> video_app: FPS: 5.000000
-  [00:00:10.128,000] <inf> video_app: Calling video flush.
-  [00:00:10.128,000] <inf> video_app: Calling video stream stop.
+   [00:00:01.213,000] <inf> video_app: - addr - 0x208cce0, size - 345600, bytesused - 0, resolution - 480x480
+   [00:00:01.219,000] <inf> video_app: capture buffer[1]: dump binary memory "/home/$USER/capture_1.bin" 0x0208cce0 0x020e12df -r
+
+   [00:00:08.220,000] <inf> video_app: Capture started
+   [00:00:08.288,000] <inf> video_app: Got frame 0! size: 345600; timestamp 8288 ms
+   [00:00:08.288,000] <inf> video_app: FPS: 0.0
+   [00:00:08.288,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:08.288,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:08.289,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:08.289,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_0.jpg" 0x02000060 0x02001db3
+
+   [00:00:08.488,000] <inf> video_app: Got frame 1! size: 345600; timestamp 8488 ms
+   [00:00:08.488,000] <inf> video_app: FPS: 5.000000
+   [00:00:08.488,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:08.488,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:08.489,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:08.489,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_1.jpg" 0x02000060 0x02005362
+
+   [00:00:08.688,000] <inf> video_app: Got frame 2! size: 345600; timestamp 8688 ms
+   [00:00:08.688,000] <inf> video_app: FPS: 5.000000
+   [00:00:08.688,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:08.688,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:08.689,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:08.689,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_2.jpg" 0x02000060 0x020054ce
+
+   [00:00:08.888,000] <inf> video_app: Got frame 3! size: 345600; timestamp 8888 ms
+   [00:00:08.888,000] <inf> video_app: FPS: 5.000000
+   [00:00:08.888,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:08.888,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:08.889,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:08.889,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_3.jpg" 0x02000060 0x02005575
+
+   [00:00:09.088,000] <inf> video_app: Got frame 4! size: 345600; timestamp 9088 ms
+   [00:00:09.088,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.088,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:09.088,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:09.089,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:09.089,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_4.jpg" 0x02000060 0x020054db
+
+   [00:00:09.288,000] <inf> video_app: Got frame 5! size: 345600; timestamp 9288 ms
+   [00:00:09.288,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.288,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:09.288,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:09.289,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:09.289,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_5.jpg" 0x02000060 0x02005450
+
+   [00:00:09.488,000] <inf> video_app: Got frame 6! size: 345600; timestamp 9488 ms
+   [00:00:09.488,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.488,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:09.488,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:09.489,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:09.489,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_6.jpg" 0x02000060 0x020053ee
+
+   [00:00:09.688,000] <inf> video_app: Got frame 7! size: 345600; timestamp 9688 ms
+   [00:00:09.688,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.688,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:09.688,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:09.689,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:09.689,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_7.jpg" 0x02000060 0x0200550b
+
+   [00:00:09.888,000] <inf> video_app: Got frame 8! size: 345600; timestamp 9888 ms
+   [00:00:09.888,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.888,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:09.888,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:09.889,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:09.889,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_8.jpg" 0x02000060 0x020055aa
+
+   [00:00:10.088,000] <inf> video_app: Got frame 9! size: 345600; timestamp 10088 ms
+   [00:00:10.088,000] <inf> video_app: FPS: 5.000000
+   [00:00:10.088,000] <inf> video_app: Starting JPEG encoding...
+   [00:00:10.088,000] <inf> video_app: Jpeg: Format set: 480x480, format: NV12
+   [00:00:10.089,000] <inf> video_app: === JPEG Encoding Success===
+   [00:00:10.089,000] <inf> video_app: Jpeg: Capture Image: dump memory "/home/$USER/capture_cp_9.jpg" 0x02000060 0x02005692
+
+   [00:00:10.089,000] <inf> video_app: Jpeg: Output Buffer released
+   [00:00:10.089,000] <inf> video_app: Calling video flush.
+   [00:00:10.089,000] <inf> video_app: Calling video stream stop.
+
+
+Video app without Jpeg encoder
+------------------------------
+
+.. code-block:: console
+
+   [00:00:00.000,000] <inf> csi2_dw: #rx_dphy_ids: 1
+   [00:00:00.662,000] <inf> video_app: - Device name: cam@49030000
+   [00:00:00.662,000] <inf> video_app: - Capabilities:
+
+   [00:00:00.662,000] <inf> video_app:   Y10P width (min, max, step)[560; 560; 0] height (min, max, step)[560; 560; 0]
+   [00:00:01.202,000] <inf> dphy_dw: RX-DDR clock: 400000000
+   [00:00:01.203,000] <inf> video_app: - format: Y10P 560x560
+   [00:00:01.203,000] <inf> video_app: Width - 560, Pitch - 1120, Height - 560, Buff size - 627200
+   [00:00:01.203,000] <inf> video_app: - addr - 0x2000060, size - 627200, bytesused - 0
+   [00:00:01.231,000] <inf> video_app: capture buffer[0]: dump binary memory "/home/$USER/capture_0.bin" 0x02000060 0x0209925f -r
+
+   [00:00:01.231,000] <inf> video_app: - addr - 0x2099268, size - 627200, bytesused - 0
+   [00:00:01.258,000] <inf> video_app: capture buffer[1]: dump binary memory "/home/$USER/capture_1.bin" 0x02099268 0x02132467 -r
+
+   [00:00:08.260,000] <inf> video_app: Capture started
+   [00:00:08.328,000] <inf> video_app: Got frame 0! size: 627200; timestamp 8328 ms
+   [00:00:08.328,000] <inf> video_app: FPS: 0.0
+   [00:00:08.528,000] <inf> video_app: Got frame 1! size: 627200; timestamp 8528 ms
+   [00:00:08.528,000] <inf> video_app: FPS: 5.000000
+   [00:00:08.728,000] <inf> video_app: Got frame 2! size: 627200; timestamp 8728 ms
+   [00:00:08.728,000] <inf> video_app: FPS: 5.000000
+   [00:00:08.928,000] <inf> video_app: Got frame 3! size: 627200; timestamp 8928 ms
+   [00:00:08.928,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.128,000] <inf> video_app: Got frame 4! size: 627200; timestamp 9128 ms
+   [00:00:09.128,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.328,000] <inf> video_app: Got frame 5! size: 627200; timestamp 9328 ms
+   [00:00:09.328,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.528,000] <inf> video_app: Got frame 6! size: 627200; timestamp 9528 ms
+   [00:00:09.528,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.728,000] <inf> video_app: Got frame 7! size: 627200; timestamp 9728 ms
+   [00:00:09.728,000] <inf> video_app: FPS: 5.000000
+   [00:00:09.928,000] <inf> video_app: Got frame 8! size: 627200; timestamp 9928 ms
+   [00:00:09.928,000] <inf> video_app: FPS: 5.000000
+   [00:00:10.128,000] <inf> video_app: Got frame 9! size: 627200; timestamp 10128 ms
+   [00:00:10.128,000] <inf> video_app: FPS: 5.000000
+   [00:00:10.128,000] <inf> video_app: Calling video flush.
+   [00:00:10.128,000] <inf> video_app: Calling video stream stop.

--- a/samples/drivers/video/boards/jpeg.conf
+++ b/samples/drivers/video/boards/jpeg.conf
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+# Video subsystem
+CONFIG_VIDEO_JPEG_HANTRO_VC9000E=y
+CONFIG_USE_ALIF_JPEG_SW_LIB=y
+CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=3
+CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=400000

--- a/samples/drivers/video/boards/jpeg.overlay
+++ b/samples/drivers/video/boards/jpeg.overlay
@@ -1,0 +1,15 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code are permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement.
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+&jpeg0 {
+	status = "okay";
+	quality-factor = <75>;
+	max-burst-length = <64>;
+};
+

--- a/samples/drivers/video/src/main.c
+++ b/samples/drivers/video/src/main.c
@@ -21,14 +21,22 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(video_app, LOG_LEVEL_INF);
 
+#define ISP_ENABLED DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(isp))
+#define JPEG_ENABLED (ISP_ENABLED && DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(jpeg0)))
+
 #ifdef CONFIG_DT_HAS_OVTI_OV5640_ENABLED
 #define N_FRAMES		1
 #else
 #define N_FRAMES		10
 #endif
+#if JPEG_ENABLED
+/* Jpeg output buffer needs one buffer. So allocate 1 less here */
+BUILD_ASSERT(CONFIG_VIDEO_BUFFER_POOL_NUM_MAX >= 3, "Insufficient Video buffer pool capacity");
+#define N_VID_BUFF              MIN((CONFIG_VIDEO_BUFFER_POOL_NUM_MAX - 1), N_FRAMES)
+#else
 #define N_VID_BUFF              MIN(CONFIG_VIDEO_BUFFER_POOL_NUM_MAX, N_FRAMES)
+#endif /* JPEG_ENABLED */
 
-#define ISP_ENABLED DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(isp))
 
 #ifdef CONFIG_DT_HAS_HIMAX_HM0360_ENABLED
 #define PIPELINE_FORMAT	VIDEO_PIX_FMT_BGGR8
@@ -39,7 +47,11 @@ LOG_MODULE_REGISTER(video_app, LOG_LEVEL_INF);
 #endif /* CONFIG_DT_HAS_HIMAX_HM0360_ENABLED */
 
 #if ISP_ENABLED
+#if JPEG_ENABLED
+#define OUTPUT_FORMAT	VIDEO_PIX_FMT_NV12
+#else
 #define OUTPUT_FORMAT	VIDEO_PIX_FMT_RGB888_PLANAR_PRIVATE
+#endif /* JPEG_ENABLED */
 #endif
 
 #if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
@@ -65,6 +77,16 @@ int log_level(void)
 	return LIB_LOG_LEVEL;
 }
 #endif
+
+#if JPEG_ENABLED
+#define JPEG_DEVICE_NODE DT_NODELABEL(jpeg0)
+#define JPEG_COMPRESS_QUALITY    50
+#define JPEG_HEADER_SIZE         CONFIG_VIDEO_JPEG_HANTRO_VC9000E_HEADER_SIZE
+/* Jpeg output buffer */
+static struct video_buffer *jpeg_op_buf;
+const struct device *jpeg_dev;
+static struct video_caps jpeg_fmt_caps;
+#endif /* JPEG_ENABLED */
 
 static int fourcc_to_pitch(uint32_t fourcc, uint32_t width)
 {
@@ -133,6 +155,104 @@ static void ae_status(const struct device *dev, uint8_t ae_stable, void *user_da
 	LOG_INF("AE Stabilization status: %d", ae_stable);
 }
 #endif /* ISP_ENABLED && defined(CONFIG_ISP_LIB_AE_MODULE) */
+
+#if JPEG_ENABLED
+/**
+ * @brief Test basic JPEG compression.
+ *
+ * Compress the full test image at the configured quality, store the
+ * compressed data in the provided output buffer, and print a host-side
+ * dump-memory command for retrieving the result.
+ *
+ * @param jpeg_dev      Pointer to the JPEG encoder device.
+ * @param fmt           Jpeg frame format.
+ * @param input_buf     Pointer to input buffer.
+ * @param input_buf_idx Input buffer index.
+ * @param output_buf    Pointer to output buffer for compressed jpeg data.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int jpeg_compress_img(const struct device *jpeg_dev,
+			struct video_format fmt,
+			struct video_buffer *input_buf,
+			uint8_t input_buf_idx,
+			struct video_buffer *output_buf)
+{
+	struct video_buffer *dequeued_buf = NULL;
+	int ret;
+
+	LOG_INF("Starting JPEG encoding...");
+
+	/* The pitch is 16-bytes aligned */
+	fmt.pitch = ROUND_UP(fmt.width, 16);
+
+	/* Set video format */
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to set format: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Jpeg: Format set: %ux%u, format: NV12", fmt.width, fmt.height);
+
+	/* Set JPEG quality */
+	uint8_t quality = JPEG_COMPRESS_QUALITY;
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &quality);
+	if (ret < 0) {
+		LOG_ERR("JPEG: Failed to set quality: %d", ret);
+		return ret;
+	}
+
+	/* Set input buffer address */
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, input_buf->buffer);
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to set input buffer: %d", ret);
+		return ret;
+	}
+
+	output_buf->bytesused = fmt.width * fmt.height;
+
+	/* Enqueue output buffer */
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, output_buf);
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to enqueue buffer: %d", ret);
+		return ret;
+	}
+
+
+	ret = video_stream_start(jpeg_dev);
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to start stream: %d", ret);
+		return ret;
+	}
+
+	/* Dequeue encoded buffer */
+	ret = video_dequeue(jpeg_dev, VIDEO_EP_OUT, &dequeued_buf, K_SECONDS(5));
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to dequeue buffer: %d", ret);
+		video_stream_stop(jpeg_dev);
+		return ret;
+	}
+
+	/* Stop streaming */
+	ret = video_stream_stop(jpeg_dev);
+	if (ret < 0) {
+		LOG_ERR("Jpeg: Failed to stop stream: %d", ret);
+		return ret;
+	}
+
+	/* Print results */
+	LOG_INF("=== JPEG Encoding Success===");
+	LOG_INF("Jpeg: Capture Image: dump memory "
+		"\"/home/$USER/capture_cp_%d.jpg\" 0x%08x 0x%08x\n",
+		input_buf_idx, (uint32_t)output_buf->buffer,
+		(uint32_t)output_buf->buffer + dequeued_buf->bytesused);
+
+	return 0;
+
+}
+#endif /* JPEG_ENABLED */
 
 int main(void)
 {
@@ -294,6 +414,46 @@ int main(void)
 		}
 #endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
 
+#if JPEG_ENABLED
+	/* Get JPEG device */
+	jpeg_dev = DEVICE_DT_GET(JPEG_DEVICE_NODE);
+	if (!device_is_ready(jpeg_dev)) {
+		LOG_ERR("JPEG: device not ready");
+		return -1;
+	}
+
+	LOG_INF("JPEG: device ready: %s", jpeg_dev->name);
+
+	/* Get capabilities */
+	ret = video_get_caps(jpeg_dev, VIDEO_EP_OUT, &jpeg_fmt_caps);
+	if (ret != 0) {
+		LOG_ERR("Jpeg: Failed to fetch Jpeg capabilities");
+		return -1;
+	}
+
+	LOG_INF("JPEG: Encoder Capabilities:");
+	for (int i = 0; jpeg_fmt_caps.format_caps[i].pixelformat != 0; i++) {
+		LOG_INF("  Format: 0x%08x, Size: %ux%u to %ux%u",
+			jpeg_fmt_caps.format_caps[i].pixelformat,
+			jpeg_fmt_caps.format_caps[i].width_min,
+			jpeg_fmt_caps.format_caps[i].height_min,
+			jpeg_fmt_caps.format_caps[i].width_max,
+			jpeg_fmt_caps.format_caps[i].height_max);
+	}
+
+	uint32_t jpeg_op_bsize = (fmt.width * fmt.height) + JPEG_HEADER_SIZE;
+
+	/* Allocate output buffer from video buffer pool */
+	jpeg_op_buf = video_buffer_alloc(jpeg_op_bsize, K_NO_WAIT);
+	if (jpeg_op_buf == NULL) {
+		LOG_ERR("Jpeg: Failed to allocate Jpeg output buffer");
+		return -1;
+	}
+	LOG_INF("Jpeg: Outbuf allocated at 0x%08x with %u bytes\n",
+			(uint32_t)jpeg_op_buf->buffer, jpeg_op_bsize);
+	memset(jpeg_op_buf->buffer, 0, jpeg_op_bsize);
+#endif /* JPEG_ENABLED */
+
 	/* Alloc video buffers and enqueue for capture */
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
 		buffers[i] = video_buffer_alloc(bsize, K_NO_WAIT);
@@ -363,6 +523,14 @@ int main(void)
 			LOG_INF("FPS: %f", 1000.0/frame_time);
 		}
 
+#if JPEG_ENABLED
+		ret = jpeg_compress_img(jpeg_dev, fmt, vbuf, i, jpeg_op_buf);
+		if (ret != 0) {
+			LOG_ERR("Jpeg compression failed");
+			goto release_jpeg_op_buf;
+		}
+#endif /* JPEG_ENABLED */
+
 		if (i < N_FRAMES - N_VID_BUFF) {
 			ret = video_enqueue(video, VIDEO_EP_OUT, vbuf);
 			if (ret) {
@@ -378,6 +546,14 @@ int main(void)
 			}
 		}
 	}
+
+#if JPEG_ENABLED
+release_jpeg_op_buf:
+	/* Free allocated buffers */
+	video_buffer_release(jpeg_op_buf);
+
+	LOG_INF("Jpeg: Output Buffer released");
+#endif /* JPEG_ENABLED */
 
 	LOG_INF("Calling video flush.");
 	video_flush(video, VIDEO_EP_OUT, false);


### PR DESCRIPTION
-- Add JPEG hardware encoding path to the video sample application. 
-- When jpeg0 node is enabled, switches ISP output to NV12 format,
   allocates a JPEG output buffer, configures the encoder quality
   and input buffer CID, and encodes each captured frame. Includes
   corresponding README documentation updates.
-- Add config and overlay files for Jpeg support