### PR TITLE
manifest: Update zephyr_alif revision to ISP change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: d3009405923d4d6c575ed97e6169920ac326d00f
+      revision: de98f00eaf8d659a45ba9c5d1e067a0fdfb7d04a
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the zephyr_alif revision to set/get APIs of the ISP configuration parameters.

This PR depends on: alifsemi/zephyr_alif/pull/472
This PR depends on: alifsemi/hal_alif/pull/118