### PR TITLE
manifest: update zephyr revision to pm support for USB

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 79f7dc778e43d918d90739ca2168e5bddad8b1b8
+      revision: 887d235d5e368999adb448a3b5974efa7fa49e9f
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated Zephyr revision to Power Management(PM)
support for USB device.
it depends on https://github.com/alifsemi/zephyr_alif/pull/457