### PR TITLE
app: video: Add call back for AE isStable flag

### DIFF
--- a/samples/drivers/video/src/main.c
+++ b/samples/drivers/video/src/main.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/gpio.h>
 
 #include <zephyr/drivers/video/video_alif.h>
+#include <zephyr/drivers/video/isp-vsi.h>
 
 #ifdef CONFIG_DT_HAS_HIMAX_HM0360_ENABLED
 #include <zephyr/drivers/video/hm0360-video-controls.h>
@@ -124,6 +125,15 @@ static int fourcc_to_pitch(uint32_t fourcc, uint32_t width)
 	return pitch;
 }
 
+#if ISP_ENABLED && defined(CONFIG_ISP_LIB_AE_MODULE)
+static void ae_status(const struct device *dev, uint8_t ae_stable, void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	LOG_INF("AE Stabilization status: %d", ae_stable);
+}
+#endif /* ISP_ENABLED && defined(CONFIG_ISP_LIB_AE_MODULE) */
+
 int main(void)
 {
 	struct video_buffer *buffers[N_VID_BUFF], *vbuf;
@@ -159,6 +169,14 @@ int main(void)
 		return -1;
 	}
 	LOG_INF("- Device name: %s", video->name);
+
+#if ISP_ENABLED && defined(CONFIG_ISP_LIB_AE_MODULE)
+	ret = isp_vsi_register_ae_status_callback(video, ae_status, NULL);
+	if (ret) {
+		LOG_ERR("Failed to register AE callback!");
+		return ret;
+	}
+#endif /* ISP_ENABLED && defined(CONFIG_ISP_LIB_AE_MODULE) */
 
 	for (loop_ctr = NUM_CAMS - 1; loop_ctr >= 0; loop_ctr--) {
 #if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 8ab077cca57f869e70e7f40603f75693bcc592aa
+      revision: 69b1bf7809bce81da4ce16d8f68e47d49ba5fe50
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Add a callback for AE isStable flag. This callback will be called when ISP and AE both are enabled. It will be called from the bottom half of the ISP when frame has been dumped.

This PR depends on: alifsemi/zephyr_alif/pull/476
This PR depends on: alifsemi/hal_alif/pull/121