### PR TITLE
powermgr: add BLE and pinmux autostart Kconfig option

### DIFF
--- a/applications/testapp/readme.rst
+++ b/applications/testapp/readme.rst
@@ -73,3 +73,34 @@ To build the sample with OpenThread Sleepy end device support with automatic sta
 .. code-block:: console
 
    west build -- -DCONFIG_OPENTHREAD_MANUAL_START=n -DEXTRA_CONF_FILE=overlay-sed.conf
+
+BLE radio and pinmux autostart
+*******************
+
+Automatically initialize the ES0 BLE radio on boot without manual shell commands.
+This is useful for automated testing scenarios.
+
+To enable autostart in prj.conf:
+
+.. code-block:: ini
+
+   CONFIG_ALIF_PWR_AUTOSTART=y
+   # Optional: use pinmux_b instead of default pinmux_a
+   CONFIG_ALIF_PWR_AUTOSTART_HCI_PINMUX_B=y
+
+Or enable via build command:
+
+.. code-block:: console
+
+   west build alif/applications/testapp -- \
+     -DCONFIG_ALIF_PWR_AUTOSTART=y \
+     -DCONFIG_ALIF_PWR_AUTOSTART_HCI_PINMUX_B=y
+
+This automatically executes the equivalent of:
+
+.. code-block:: console
+
+   pwr start --hpa
+   pwr hci [--pinmux_b]
+
+The feature is disabled by default (CONFIG_ALIF_PWR_AUTOSTART=n).

--- a/subsys/powermgr/Kconfig
+++ b/subsys/powermgr/Kconfig
@@ -13,3 +13,20 @@ config ALIF_POWER_MGR_SHELL
 	depends on HAS_ALIF_POWER_MANAGER
 	help
 	  Enable Alif Power manager commands
+
+config ALIF_PWR_AUTOSTART
+	bool "Automatically start ES0 BLE radio on boot"
+	default n
+	depends on ALIF_POWER_MGR_SHELL
+	help
+	  When enabled, automatically initializes the ES0 BLE radio
+	  with HPA mode on boot. Equivalent to running the shell
+	  commands 'pwr start --hpa' and 'pwr hci' at startup.
+
+config ALIF_PWR_AUTOSTART_HCI_PINMUX_B
+	bool "Use pinmux_b for HCI UART on autostart"
+	default n
+	depends on ALIF_PWR_AUTOSTART
+	help
+	  When enabled, the autostart HCI configuration uses pinmux_b.
+	  Equivalent to running 'pwr hci --pinmux_b'.

--- a/subsys/powermgr/shell/src/power_mgr_shell.c
+++ b/subsys/powermgr/shell/src/power_mgr_shell.c
@@ -177,12 +177,16 @@ static int cmd_start(const struct shell *shell, size_t argc, char **argv)
 	alif_eui48_read(bd_address);
 
 	if (param_get_flag(argc, argv, "--hpa")) {
-		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Enable HPA\n");
+		if (shell) {
+			shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Enable HPA\n");
+		}
 		hpa_setup = 1;
 	}
 
 	if (param_get_flag(argc, argv, "--lpa")) {
-		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Enable LPA\n");
+		if (shell) {
+			shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Enable LPA\n");
+		}
 		hpa_setup = 0;
 	}
 
@@ -283,7 +287,9 @@ static int cmd_start(const struct shell *shell, size_t argc, char **argv)
 	int8_t ret = take_es0_into_use_with_params(ll_boot_params_buffer, total_length,
 						   es0_clock_select, hpa_setup);
 
-	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Start ES0 ret:%d\n", ret);
+	if (shell) {
+		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "Start ES0 ret:%d\n", ret);
+	}
 	return 0;
 }
 
@@ -378,8 +384,10 @@ static int cmd_hci(const struct shell *shell, size_t argc, char **argv)
 		pinctrl_configure_pins(pinctrl_hci_a_ext, ARRAY_SIZE(pinctrl_hci_a_ext),
 				       PINCTRL_REG_NONE);
 	}
-	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT,
-		      "configuring external UART trace select:0x%x\n", trace_select);
+	if (shell) {
+		shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT,
+			      "configuring external UART trace select:0x%x\n", trace_select);
+	}
 
 	sys_write32(trace_select, 0x1a605008);
 	return 0;
@@ -393,3 +401,25 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pwr, &sub_cmds, "Power management test commands", NULL);
+
+#if IS_ENABLED(CONFIG_ALIF_PWR_AUTOSTART)
+static int pwr_autostart_init(void)
+{
+	static const char * const start_argv[] = {"start", "--hpa"};
+
+	cmd_start(NULL, 2, (char **)start_argv);
+
+#if IS_ENABLED(CONFIG_ALIF_PWR_AUTOSTART_HCI_PINMUX_B)
+	static const char * const hci_argv[] = {"hci", "--pinmux_b"};
+
+	cmd_hci(NULL, 2, (char **)hci_argv);
+#else
+	static const char * const hci_argv[] = {"hci"};
+
+	cmd_hci(NULL, 1, (char **)hci_argv);
+#endif
+
+	return 0;
+}
+SYS_INIT(pwr_autostart_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif /* CONFIG_ALIF_PWR_AUTOSTART */


### PR DESCRIPTION
Add CONFIG_ALIF_PWR_AUTOSTART and CONFIG_ALIF_PWR_AUTOSTART_HCI_PINMUX_B to automatically initialize the ES0 BLE radio and external HCI pinmux on boot without manual shell commands. Useful for automated testing scenarios.

When enabled, the feature executes the equivalent of:
- pwr start --hpa
- pwr hci [--pinmux_b]

Note: Gitlint didn't like the commit title starting with "subsys:" so it was removed. 