### PR TITLE
manifest: update zephyr revision to include alif_e7/e8_dk apss xip

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 7557e780da8d273b47411e7509913a189406d6f8
+      revision: 62f6ad1f59b1880f480ab848ca45c09b90fa1d49
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pick up XIP support for alif_e7_dk/alif_e8_dk APSS board targets. zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/478 