### PR TITLE
tests: drivers: spi: add SPI driver validation test suite

### DIFF
--- a/tests/drivers/spi/CMakeLists.txt
+++ b/tests/drivers/spi/CMakeLists.txt
@@ -1,0 +1,137 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+# ==================== BOARD AUTO-DETECTION ==================
+# Set ALIF_BOARD macro for overlay preprocessor so every overlay
+# automatically picks the right pins / interrupts / console.
+# Override on the command line:  west build -b <board> -- -DALIF_BOARD=ALIF_BOARD_E7_HP
+if(NOT DEFINED ALIF_BOARD)
+  if(BOARD MATCHES "e7.*rtss_he")
+    set(ALIF_BOARD "ALIF_BOARD_E7_HE")
+  elseif(BOARD MATCHES "e7.*rtss_hp")
+    set(ALIF_BOARD "ALIF_BOARD_E7_HP")
+  elseif(BOARD MATCHES "e8.*rtss_he")
+    set(ALIF_BOARD "ALIF_BOARD_E8_HE")
+  elseif(BOARD MATCHES "e8.*rtss_hp")
+    set(ALIF_BOARD "ALIF_BOARD_E8_HP")
+  elseif(BOARD MATCHES "a5")
+    set(ALIF_BOARD "ALIF_BOARD_A5")
+  elseif(BOARD MATCHES "e1c.*rtss_he")
+    set(ALIF_BOARD "ALIF_BOARD_E1C")
+  elseif(BOARD MATCHES "b1.*rtss_he")
+    set(ALIF_BOARD "ALIF_BOARD_B1")
+  else()
+    set(ALIF_BOARD "ALIF_BOARD_E8_HP")
+    message(WARNING "Unknown board '${BOARD}' — defaulting to E8 HP pin mapping.
+            Set -DALIF_BOARD=... to override.")
+  endif()
+endif()
+
+# Pass to the devicetree preprocessor so overlays resolve the macros.
+# C code does not need ALIF_BOARD, but the C preprocessor that runs on .overlay
+# files uses DTS_EXTRA_CPPFLAGS.
+list(APPEND DTS_EXTRA_CPPFLAGS "-DALIF_BOARD=${ALIF_BOARD}")
+message(STATUS "SPI test overlay board: ${ALIF_BOARD}")
+
+# Default overlay for plain west builds; Twister/CLI overlays take precedence.
+if(NOT DTC_OVERLAY_FILE)
+  set(DTC_OVERLAY_FILE
+      ${CMAKE_CURRENT_SOURCE_DIR}/boards/spi.overlay
+      CACHE STRING "Default SPI test overlay" FORCE)
+endif()
+
+# ==================== ZEPHYR PROJECT SETUP ==================
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(alif_spi)
+
+
+
+# ==================== STACK SIZES ==========================
+# Stack sizes are defined in prj.conf (20KB default for all tests)
+
+target_include_directories(app PRIVATE src)
+
+# ==================== SOURCE FILE DEFINITIONS ================
+set(SPI_CORE_SOURCES
+  src/test_spi_common.c
+  src/test_spi_threads.c
+)
+
+set(SPI_LOOPBACK_SOURCES
+  src/test_spi_loopback.c
+)
+
+set(SPI_NEGATIVE_SOURCES
+  src/test_spi_negative.c
+)
+
+set(SPI_BOUNDARY_SOURCES
+  src/test_spi_boundary.c
+)
+
+set(SPI_STRESS_SOURCES
+  src/test_spi_stress.c
+)
+
+set(SPI_PERF_SOURCES
+  src/test_spi_perf.c
+)
+
+# ==================== CORE TEST BUILD ========================
+set(SPI_TEST_SOURCES ${SPI_CORE_SOURCES})
+
+# ==================== CONDITIONAL TEST SUITES ==============
+# Include test sources based on Kconfig selections
+if(CONFIG_TEST_SPI_LOOPBACK)
+  list(APPEND SPI_TEST_SOURCES ${SPI_LOOPBACK_SOURCES})
+endif()
+
+if(CONFIG_TEST_SPI_NEGATIVE)
+  list(APPEND SPI_TEST_SOURCES ${SPI_NEGATIVE_SOURCES})
+endif()
+
+if(CONFIG_TEST_SPI_BOUNDARY)
+  list(APPEND SPI_TEST_SOURCES ${SPI_BOUNDARY_SOURCES})
+endif()
+
+if(CONFIG_TEST_SPI_STRESS)
+  list(APPEND SPI_TEST_SOURCES ${SPI_STRESS_SOURCES})
+endif()
+
+if(CONFIG_TEST_SPI_PERFORMANCE)
+  list(APPEND SPI_TEST_SOURCES ${SPI_PERF_SOURCES})
+endif()
+
+target_sources(app PRIVATE ${SPI_TEST_SOURCES})
+
+# ==================== COMPILATION FLAGS ======================
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_compile_options(app PRIVATE -Wall -Wextra -Werror)
+endif()
+
+# ==================== VALIDATION MESSAGES ====================
+message(STATUS "  Test Type: SPI Driver Validation")
+message(STATUS "  Hardware Overlay: ${DTC_OVERLAY_FILE}")
+
+if(CONFIG_TEST_SPI_LOOPBACK)
+  message(STATUS "  Enabled: Loopback Tests")
+endif()
+
+if(CONFIG_TEST_SPI_NEGATIVE)
+  message(STATUS "  Enabled: Negative Tests")
+endif()
+
+if(CONFIG_TEST_SPI_BOUNDARY)
+  message(STATUS "  Enabled: Boundary Tests")
+endif()
+
+if(CONFIG_TEST_SPI_STRESS)
+  message(STATUS "  Enabled: Stress Tests")
+endif()
+
+if(CONFIG_TEST_SPI_PERFORMANCE)
+  message(STATUS "  Enabled: Performance Tests")
+endif()
+
+if(CONFIG_TEST_SPI_USE_DMA)
+  message(STATUS "  Enabled: DMA path")
+endif()

--- a/tests/drivers/spi/Kconfig
+++ b/tests/drivers/spi/Kconfig
@@ -1,0 +1,94 @@
+source "Kconfig.zephyr"
+
+# ---------------------------------------------------------------------------
+# Test selection - enable the test you want to run
+# ---------------------------------------------------------------------------
+
+config TEST_SPI_LOOPBACK
+	bool "Loopback tests"
+	help
+	  Enable the SPI loopback test suite.  This suite exercises
+	  the controller by wiring MOSI to MISO either internally or
+	  externally and validates data integrity across 8, 16 and
+	  32-bit word sizes at configurable frequencies.
+
+config TEST_SPI_NEGATIVE
+	bool "Negative tests"
+	help
+	  Enable the SPI negative test suite.  These tests deliberately
+	  pass invalid configurations, unsupported SPI modes, and null
+	  pointers to the driver to verify that proper error codes are
+	  returned and the driver does not crash or corrupt state.
+
+config TEST_SPI_BOUNDARY
+	bool "Boundary tests"
+	help
+	  Enable the SPI boundary test suite.  These tests probe driver
+	  behaviour at FIFO depth limits, minimum and maximum transfer
+	  sizes, unaligned buffer addresses, and extreme word widths
+	  to ensure robust handling of edge cases.
+
+config TEST_SPI_STRESS
+	bool "Stress tests"
+	help
+	  SPI stress tests that exercise repeated back-to-back
+	  full-duplex transfers between two controllers (SPI1 <-> SPI0)
+	  with rotating data patterns. Detects FIFO leakage and
+	  state retention issues across iterations.
+
+config TEST_SPI_PERFORMANCE
+	bool "Performance tests"
+	help
+	  Enable the SPI performance test suite.  It runs back-to-back
+	  MOSI, MISO and full-duplex transceive tests across 8, 16 and
+	  32-bit word sizes while sweeping frequencies from 1x to 25x
+	  the base rate, reporting cycle counts and elapsed time.
+
+# ---------------------------------------------------------------------------
+# Test options
+# ---------------------------------------------------------------------------
+
+config TEST_SPI_INTERNAL_LOOPBACK
+	bool "Use controller internal loopback for loopback and boundary tests"
+	depends on TEST_SPI_LOOPBACK || TEST_SPI_BOUNDARY
+	default y
+	help
+	  When enabled, loopback and boundary tests run on a single
+	  controller using the SPI_MODE_LOOP flag (no external wiring
+	  needed). When disabled, the same tests run across two
+	  controllers (SPI1 as controller, SPI0 as target wired
+	  together) and validate both MOSI and MISO directions
+	  with two independent transceives.
+
+config TEST_SPI_WORD_SIZE
+	int "SPI word size for all tests"
+	range 4 32
+	default 8
+	help
+	  Fixed word size (4..32 bits) used by all test suites.
+
+config TEST_SPI_FREQUENCY
+	int "SPI test base frequency (Hz)"
+	default 1000000
+	help
+	  Base operating frequency used by all SPI test scenarios.
+	  Frequency sweep multipliers (1x, 5x, 12x, 25x) and the
+	  performance sweep are relative to this value.  Default is
+	  1 MHz (1000000 Hz).
+
+# ---------------------------------------------------------------------------
+# DMA support
+# ---------------------------------------------------------------------------
+config TEST_SPI_USE_DMA
+	bool "Enable DMA for SPI transfers"
+	depends on $(dt_nodelabel_enabled,dma0) || $(dt_nodelabel_enabled,dma1) || $(dt_nodelabel_enabled,dma2)
+	select SPI_DW_USE_DMA
+	select DMA
+	select DMA_PL330
+	help
+	  Enable DMA-based SPI transfers for all selected test suites.
+	  When enabled, the driver routes large transfers through the
+	  PL330 DMA controller instead of the PIO path.  This option is
+	  only selectable when a DMA controller node is present in the
+	  active devicetree overlay (e.g. spi_DMA.overlay).
+

--- a/tests/drivers/spi/README.rst
+++ b/tests/drivers/spi/README.rst
@@ -1,0 +1,258 @@
+SPI Driver Tests
+#####################
+
+Overview
+********
+
+This test suite validates the SPI/LPSPI controller and Zephyr integration,
+focusing on real bug detection rather than API compliance.
+
+Test suites:
+
+- **Loopback** -- internal/external loopback functional tests
+- **Performance** -- frequency sweep and throughput measurement
+- **Negative** -- driver error path validation
+- **Boundary** -- FIFO limits, scatter-gather, edge cases
+- **Stress** -- repeated transfer stress with repeated iterations
+
+Building and Running
+********************
+
+All commands are run from the ``zephyr/`` directory (the repo's Zephyr base),
+so the test path is ``tests/drivers/spi``.
+
+Twister (recommended)
+=====================
+
+``ALIF_BOARD`` is auto-detected from the board name by ``CMakeLists.txt``,
+so no extra flag is required for twister.  To override it manually:
+
+.. code-block:: console
+
+   west twister -T tests/drivers/spi --platform <board> \
+               -- -DALIF_BOARD=ALIF_BOARD_E7_HP
+
+Test scenarios (``-s`` filter):
+
+- ``drivers.spi.alif.loopback``
+- ``drivers.spi.alif.loopback.explicit``
+- ``drivers.spi.alif.loopback.ext``
+- ``drivers.spi.alif.perf``
+- ``drivers.spi.alif.perf.dma``
+- ``drivers.spi.alif.perf.dma.evtrtr``
+- ``drivers.spi.alif.negative``
+- ``drivers.spi.alif.boundary``
+- ``drivers.spi.alif.boundary.ext``
+- ``drivers.spi.alif.stress``
+- ``drivers.spi.alif.stress.dma``
+- ``drivers.spi.alif.stress.dma.evtrtr``
+- ``drivers.spi.alif.lpspi.loopback``
+- ``drivers.spi.alif.lpspi.perf``
+- ``drivers.spi.alif.lpspi.perf.dma``
+- ``drivers.spi.alif.lpspi.perf.dma.evtrtr``
+- ``drivers.spi.alif.lpspi.stress``
+- ``drivers.spi.alif.lpspi.stress.dma``
+- ``drivers.spi.alif.lpspi.stress.dma.evtrtr``
+
+Manual west build
+=================
+
+The default overlay (``boards/spi.overlay``) enables SPI1/SPI0 loopback tests.
+Other topologies and options are selected with ``-DDTC_OVERLAY_FILE`` and
+``-DCONFIG_*`` flags.
+
+Loopback tests (SPI1/SPI0)
+--------------------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_LOOPBACK=y
+
+.. code-block:: console
+
+   west build -p always -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_LOOPBACK=y
+
+Performance tests
+-----------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_PERFORMANCE=y
+
+Performance with DMA
+--------------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- "-DDTC_OVERLAY_FILE=boards/spi.overlay;boards/spi_DMA.overlay" \
+                 -DCONFIG_TEST_SPI_PERFORMANCE=y \
+                 -DCONFIG_TEST_SPI_USE_DMA=y
+
+Negative tests
+--------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_NEGATIVE=y
+
+Boundary tests
+--------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_BOUNDARY=y
+
+Stress tests
+------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/spi.overlay \
+                 -DCONFIG_TEST_SPI_STRESS=y
+
+LPSPI tests
+-----------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
+              tests/drivers/spi \
+              -- -DDTC_OVERLAY_FILE=boards/lpspi.overlay
+
+LPSPI with DMA
+--------------
+
+.. code-block:: console
+
+   west build -p always -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
+              tests/drivers/spi \
+              -- "-DDTC_OVERLAY_FILE=boards/lpspi.overlay;boards/lpspi_DMA.overlay" \
+                 -DCONFIG_TEST_SPI_PERFORMANCE=y \
+                 -DCONFIG_TEST_SPI_USE_DMA=y
+
+Console Output
+==============
+
+After flashing, open the console to view test progress:
+
+.. code-block:: console
+
+   west flash
+
+Kconfig Options
+***************
+
+Top-level suite selection:
+
+- ``CONFIG_TEST_SPI_LOOPBACK``       Loopback functional tests
+- ``CONFIG_TEST_SPI_NEGATIVE``       Driver error path tests
+- ``CONFIG_TEST_SPI_BOUNDARY``       Boundary condition tests
+- ``CONFIG_TEST_SPI_STRESS``         Stress tests
+- ``CONFIG_TEST_SPI_PERFORMANCE``    Performance tests
+- ``CONFIG_TEST_SPI_USE_DMA``        Enable DMA for SPI transfers
+
+Test tuning:
+
+- ``CONFIG_TEST_SPI_FREQUENCY``      Base SPI frequency in Hz (default 1 MHz)
+- ``CONFIG_TEST_SPI_WORD_SIZE``      Pinned word size for all suites (0 = sweep 8/16/32)
+- ``CONFIG_TEST_SPI_INTERNAL_LOOPBACK`` Use internal loopback mode
+
+Setting Kconfig options
+=====================
+
+**Via ``prj.conf`` (project default):**
+
+.. code-block:: kconfig
+
+   CONFIG_TEST_SPI_FREQUENCY=2500000
+   CONFIG_TEST_SPI_WORD_SIZE=16
+
+**Via west build command line (one-shot):**
+
+.. code-block:: console
+
+   west build -- -DCONFIG_TEST_SPI_FREQUENCY=2500000 -DCONFIG_TEST_SPI_WORD_SIZE=16
+
+**Via Twister ``extra_configs`` in ``testcase.yaml``:**
+
+.. code-block:: yaml
+
+   extra_configs:
+     - CONFIG_TEST_SPI_FREQUENCY=2500000
+     - CONFIG_TEST_SPI_WORD_SIZE=16
+
+The frequency value is the raw Hz value (e.g. ``1000000`` = 1 MHz).
+Word size values: ``8`` (default), ``16``, or ``32`` pins to that width.
+Valid range is 4..32.
+
+Devicetree Overlays
+*******************
+
+- ``boards/spi.overlay``              SPI1 master / SPI0 slave
+- ``boards/spi2.overlay``             SPI1 controller / SPI2 target (manual only)
+- ``boards/spi3.overlay``             SPI1 controller / SPI3 target (manual only)
+- ``boards/lpspi.overlay``            LPSPI controller / SPI target (board-dependent)
+- ``boards/spi_ss_sw.overlay``        Software chip-select (SPI)
+- ``boards/lpspi_ss_sw.overlay``      Software chip-select (LPSPI)
+- ``boards/spi_DMA.overlay``          DMA option (SPI)
+- ``boards/spi_DMA_evtrtr.overlay``   DMA with event router (SPI)
+- ``boards/lpspi_DMA.overlay``        DMA option (LPSPI)
+- ``boards/lpspi_DMA_evtrtr.overlay``   DMA with event router (LPSPI)
+
+Best practice: stack a base overlay with DMA/GPIO overlays via
+``-DDTC_OVERLAY_FILE``.
+
+Hardware Requirements
+*********************
+
+Supported boards
+================
+
+- ``alif_e7_dk/ae722f80f55d5xx/rtss_hp``
+- ``alif_e7_dk/ae722f80f55d5xx/rtss_he``
+- ``alif_e8_dk/ae822fa0e5597xx0/rtss_hp``
+- ``alif_e8_dk/ae822fa0e5597xx0/rtss_he``
+- ``alif_e1c_dk/ae1c1f4051920hh/rtss_he``
+- ``alif_b1_dk/ab1c1f4m51820hh0/rtss_he``
+
+Loopback / Boundary tests
+=========================
+
+These suites support two modes, selectable via Kconfig.
+
+Internal loopback (default):
+
+- ``CONFIG_TEST_SPI_INTERNAL_LOOPBACK=y``
+- Single controller, ``SPI_MODE_LOOP`` enabled inside the IP.
+- No external wiring required.
+
+External loopback:
+
+- ``CONFIG_TEST_SPI_INTERNAL_LOOPBACK=n``
+- Two controllers (SPI1 as controller, SPI0 as target) wired together.
+- Same scenarios run without ``SPI_MODE_LOOP``, validating both MOSI
+  and MISO directions across two independent transceives.
+
+Pinned word size:
+
+- ``CONFIG_TEST_SPI_WORD_SIZE=N`` (range 4..32, default 8) pins the loopback /
+  boundary scenarios to a single data width for targeted debugging.

--- a/tests/drivers/spi/boards/board_common.overlay
+++ b/tests/drivers/spi/boards/board_common.overlay
@@ -1,0 +1,188 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * -----------------------------------------------------------------------
+ * Alif SPI test board-common macros.
+ *
+ * Include this from every instance/feature overlay:
+ *   #include "board_common.overlay"
+ *
+ * It defines board-specific pinmux, interrupt numbers, GPIO/SS mappings,
+ * console choice and DMA controller — everything that varies by board.
+ *
+ * Instance overlays then only need to:
+ *   - pick controller-spi / target-spi aliases
+ *   - &node { status = "okay"; interrupts = <ALIF_SPIx_IRQ 0>; };
+ *   - apply &pinctrl using the ALIF_SPIx_* macros from this file.
+ * -----------------------------------------------------------------------
+ */
+
+#ifndef ALIF_BOARD_COMMON_OVERLAY
+#define ALIF_BOARD_COMMON_OVERLAY
+
+/* --- Board enum ------------------------------------------------------- */
+#define ALIF_BOARD_E7_HP 1
+#define ALIF_BOARD_E8_HP 2
+#define ALIF_BOARD_A5    3
+#define ALIF_BOARD_E7_HE 4
+#define ALIF_BOARD_E8_HE 5
+#define ALIF_BOARD_E1C   6
+#define ALIF_BOARD_B1    7
+
+/* Manual override: -DALIF_BOARD=ALIF_BOARD_E7_HP on west command line  */
+#ifndef ALIF_BOARD
+#define ALIF_BOARD ALIF_BOARD_E8_HP
+#endif
+
+/* --- Console (UART) --------------------------------------------------- */
+#if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E8_HP
+  #define CONSOLE          uart4
+  #define UART_DISABLED    uart2
+#else
+  #define CONSOLE          uart2
+  #define UART_DISABLED    uart4
+#endif
+
+/* --- SPI0 pinmux ------------------------------------------------------ */
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define SPI0_MISO   PIN_P5_0__SPI0_MISO_B
+  #define SPI0_MOSI   PIN_P5_1__SPI0_MOSI_B
+  #define SPI0_SCLK   PIN_P5_2__SPI0_SCLK_B
+  #define SPI0_SS0    PIN_P5_3__SPI0_SS0_B
+#elif ALIF_BOARD == ALIF_BOARD_E7_HP
+  #define SPI0_MISO   PIN_P5_0__SPI0_MISO_B
+  #define SPI0_MOSI   PIN_P5_1__SPI0_MOSI_B
+  #define SPI0_SCLK   PIN_P5_3__SPI0_SCLK_B
+  #define SPI0_SS0    PIN_P5_2__SPI0_SS0_B
+#else
+  #define SPI0_MISO   PIN_P1_0__SPI0_MISO_A
+  #define SPI0_MOSI   PIN_P1_1__SPI0_MOSI_A
+  #define SPI0_SCLK   PIN_P1_2__SPI0_SCLK_A
+  #define SPI0_SS0    PIN_P1_3__SPI0_SS0_A
+#endif
+
+/* --- SPI1 pinmux ------------------------------------------------------ */
+#if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E7_HE
+  #define SPI1_MISO   PIN_P8_3__SPI1_MISO_B
+  #define SPI1_MOSI   PIN_P8_4__SPI1_MOSI_B
+  #define SPI1_SCLK   PIN_P8_5__SPI1_SCLK_B
+  #define SPI1_SS0    PIN_P6_4__SPI1_SS0_B
+#elif ALIF_BOARD == ALIF_BOARD_E8_HP || ALIF_BOARD == ALIF_BOARD_E8_HE
+  #define SPI1_MISO   PIN_P14_4__SPI1_MISO_C
+  #define SPI1_MOSI   PIN_P14_5__SPI1_MOSI_C
+  #define SPI1_SCLK   PIN_P14_6__SPI1_SCLK_C
+  #define SPI1_SS0    PIN_P14_7__SPI1_SS0_C
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define SPI1_MISO   PIN_P8_4__SPI1_MISO_C
+  #define SPI1_MOSI   PIN_P8_5__SPI1_MOSI_C
+  #define SPI1_SCLK   PIN_P8_6__SPI1_SCLK_C
+  #define SPI1_SS0    PIN_P8_7__SPI1_SS0_C
+#endif
+
+/* --- SPI2 pinmux ------------------------------------------------------ */
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define SPI2_MISO   PIN_P7_0__SPI2_MISO_B
+  #define SPI2_MOSI   PIN_P7_1__SPI2_MOSI_B
+  #define SPI2_SCLK   PIN_P7_2__SPI2_SCLK_B
+  #define SPI2_SS0    PIN_P7_3__SPI2_SS0_B
+#else
+  #define SPI2_MISO   PIN_P4_2__SPI2_MISO_A
+  #define SPI2_MOSI   PIN_P4_3__SPI2_MOSI_A
+  #define SPI2_SCLK   PIN_P4_4__SPI2_SCLK_A
+  #define SPI2_SS0    PIN_P4_5__SPI2_SS0_A
+#endif
+
+/* --- SPI3 pinmux ------------------------------------------------------ */
+#if ALIF_BOARD == ALIF_BOARD_E7_HP || \
+	ALIF_BOARD == ALIF_BOARD_E7_HE
+  #define SPI3_MISO   PIN_P10_5__SPI3_MISO_B
+  #define SPI3_MOSI   PIN_P12_5__SPI3_MOSI_A
+  #define SPI3_SCLK   PIN_P12_6__SPI3_SCLK_B
+  #define SPI3_SS0    PIN_P12_7__SPI3_SS0_B
+#elif ALIF_BOARD == ALIF_BOARD_E8_HP || \
+	ALIF_BOARD == ALIF_BOARD_E8_HE
+  #define SPI3_MISO   PIN_P12_4__SPI3_MISO_A
+  #define SPI3_MOSI   PIN_P12_5__SPI3_MOSI_A
+  #define SPI3_SCLK   PIN_P12_6__SPI3_SCLK_A
+  #define SPI3_SS0    PIN_P12_7__SPI3_SS0_A
+#endif
+
+/* --- SPI4 / LPSPI0 pinmux (HE boards + A5) -------------------------- */
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+  #define SPI4_MISO   PIN_P7_4__LPSPI_MISO_A
+  #define SPI4_MOSI   PIN_P7_5__LPSPI_MOSI_A
+  #define SPI4_SCLK   PIN_P7_6__LPSPI_SCLK_A
+  #define SPI4_SS0    PIN_P7_7__LPSPI_SS0_A
+#elif ALIF_BOARD == ALIF_BOARD_E8_HE
+  #define SPI4_MISO   PIN_P11_4__LPSPI_MISO_B
+  #define SPI4_MOSI   PIN_P11_5__LPSPI_MOSI_B
+  #define SPI4_SCLK   PIN_P11_6__LPSPI_SCLK_B
+  #define SPI4_SS0    PIN_P11_7__LPSPI_SS0_B
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define LPSPI0_MISO PIN_P1_3__LPSPI_MISO_A
+  #define LPSPI0_MOSI PIN_P1_4__LPSPI_MOSI_A
+  #define LPSPI0_SCLK PIN_P1_5__LPSPI_SCLK_A
+  #define LPSPI0_SS0  PIN_P2_0__LPSPI_SS0_A
+#endif
+
+/* --- Interrupt numbers (instance-based, same across boards) ---------- */
+#define SPI0_IRQ    137
+#define SPI1_IRQ    138
+#define SPI2_IRQ    139
+#define SPI3_IRQ    140
+#define SPI4_IRQ    46   /* LPSPI0 uses same number on A5 */
+
+/* --- Software-CS GPIO pins (SPI1-based overlays) --------------------- */
+#if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E7_HE
+  #define SPI_SS_GPIO_PIN   PIN_P6_4__GPIO
+  #define SPI_SS_GPIO_BANK  gpio6
+  #define SPI_SS_GPIO_NUM   4
+#elif ALIF_BOARD == ALIF_BOARD_E8_HP || ALIF_BOARD == ALIF_BOARD_E8_HE
+  #define SPI_SS_GPIO_PIN   PIN_P14_7__GPIO
+  #define SPI_SS_GPIO_BANK  gpio14
+  #define SPI_SS_GPIO_NUM   7
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define SPI_SS_GPIO_PIN   PIN_P8_7__GPIO
+  #define SPI_SS_GPIO_BANK  gpio8
+  #define SPI_SS_GPIO_NUM   7
+#endif
+
+/* --- Software-CS GPIO pins (LPSPI-based overlays) --------------------- */
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+  #define LPSPI_SS_GPIO_PIN   PIN_P7_7__GPIO
+  #define LPSPI_SS_GPIO_BANK  gpio7
+  #define LPSPI_SS_GPIO_NUM   7
+#elif ALIF_BOARD == ALIF_BOARD_E8_HE
+  #define LPSPI_SS_GPIO_PIN   PIN_P11_7__GPIO
+  #define LPSPI_SS_GPIO_BANK  gpio11
+  #define LPSPI_SS_GPIO_NUM   7
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define LPSPI_SS_GPIO_PIN   PIN_P2_0__GPIO
+  #define LPSPI_SS_GPIO_BANK  gpio2
+  #define LPSPI_SS_GPIO_NUM   0
+#endif
+
+/* --- DMA controller per board ----------------------------------------- */
+#if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E8_HP
+  #define DMA_CTRL    dma1
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+  #define DMA_CTRL    dma2
+#else  /* E7_HE, E8_HE */
+  #define DMA_CTRL    dma2
+#endif
+
+#endif /* ALIF_BOARD_COMMON_OVERLAY */

--- a/tests/drivers/spi/boards/lpspi.overlay
+++ b/tests/drivers/spi/boards/lpspi.overlay
@@ -1,0 +1,120 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* LPSPI / SPI test overlay.
+ * HE: SPI4 controller <-> SPI0/SPI1 target (board-dependent)
+ * A5: LPSPI0 controller <-> SPI1 target
+ */
+#include "board_common.overlay"
+
+/ {
+	aliases {
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+		controller-spi = &spi4;
+		target-spi     = &spi0;
+#elif ALIF_BOARD == ALIF_BOARD_E8_HE
+		controller-spi = &spi4;
+		target-spi     = &spi1;
+#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+		controller-spi = &lpspi0;
+		target-spi     = &spi1;
+#else
+		/* Default to SPI4/SPI0 for unknown HE boards */
+		controller-spi = &spi4;
+		target-spi     = &spi0;
+#endif
+	};
+
+	chosen {
+		zephyr,console = &CONSOLE;
+	};
+};
+
+&CONSOLE {
+	status = "okay";
+};
+
+&UART_DISABLED {
+	status = "disabled";
+};
+
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+&lpspi0 {
+	status = "okay";
+	interrupts = <SPI4_IRQ 0>;
+};
+#else
+&spi4 {
+	status = "okay";
+	interrupts = <SPI4_IRQ 0>;
+};
+#endif
+
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+&spi0 {
+	status = "okay";
+	serial-target;
+	interrupts = <SPI0_IRQ 1>;
+};
+#else
+&spi1 {
+	status = "okay";
+	serial-target;
+	interrupts = <SPI1_IRQ 1>;
+};
+#endif
+
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+&pinctrl_spi0 {
+	group0 {
+		pinmux = < SPI0_MISO >,
+			 < SPI0_MOSI >,
+			 < SPI0_SCLK >,
+			 < SPI0_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+#endif
+
+#if ALIF_BOARD != ALIF_BOARD_E7_HE
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < SPI1_MISO >,
+			 < SPI1_MOSI >,
+			 < SPI1_SCLK >,
+			 < SPI1_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+#endif
+
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+&pinctrl_lpspi0 {
+	group0 {
+		pinmux = < LPSPI0_MISO >,
+			 < LPSPI0_MOSI >,
+			 < LPSPI0_SCLK >,
+			 < LPSPI0_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+#else
+&pinctrl_lpspi {
+	group0 {
+		pinmux = < SPI4_MISO >,
+			 < SPI4_MOSI >,
+			 < SPI4_SCLK >,
+			 < SPI4_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+#endif

--- a/tests/drivers/spi/boards/lpspi_DMA.overlay
+++ b/tests/drivers/spi/boards/lpspi_DMA.overlay
@@ -1,0 +1,42 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* DMA overlay for LPSPI test instances.  Stack with boards/lpspi.overlay.
+ * HP boards use dma1; HE / A5 / E1C / B1 use dma2.
+ */
+#include "board_common.overlay"
+
+&DMA_CTRL {
+	status = "okay";
+};
+
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+&lpspi0 {
+	dmas = <&DMA_CTRL 0 13>, <&DMA_CTRL 1 12>;
+	dma-names = "txdma", "rxdma";
+};
+#else
+&spi4 {
+	dmas = <&DMA_CTRL 0 13>, <&DMA_CTRL 1 12>;
+	dma-names = "txdma", "rxdma";
+};
+#endif
+
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+&spi0 {
+	dmas = <&DMA_CTRL 2 20>, <&DMA_CTRL 3 16>;
+	dma-names = "txdma", "rxdma";
+};
+#else
+&spi1 {
+	dmas = <&DMA_CTRL 2 21>, <&DMA_CTRL 3 17>;
+	dma-names = "txdma", "rxdma";
+};
+#endif

--- a/tests/drivers/spi/boards/lpspi_DMA_evtrtr.overlay
+++ b/tests/drivers/spi/boards/lpspi_DMA_evtrtr.overlay
@@ -1,0 +1,51 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Event-router DMA overlay for LPSPI instances.
+ * Stack with boards/lpspi.overlay.
+ */
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+#include "board_common.overlay"
+
+&DMA_CTRL {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+&lpspi0 {
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 2, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 2, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+#else
+&spi4 {
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 2, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 2, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+#endif
+
+#if ALIF_BOARD == ALIF_BOARD_E7_HE
+&spi0 {
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};
+#else
+&spi1 {
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};
+#endif

--- a/tests/drivers/spi/boards/lpspi_ss_sw.overlay
+++ b/tests/drivers/spi/boards/lpspi_ss_sw.overlay
@@ -1,0 +1,52 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Software-CS overlay for LPSPI controller.
+ * Stack with boards/lpspi.overlay.
+ */
+#include "board_common.overlay"
+
+#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
+	ALIF_BOARD == ALIF_BOARD_B1
+&lpspi0 {
+	status = "okay";
+	cs-gpios = <&LPSPI_SS_GPIO_BANK LPSPI_SS_GPIO_NUM GPIO_ACTIVE_LOW>;
+	interrupts = <SPI4_IRQ 0>;
+};
+
+&pinctrl_lpspi0 {
+	group0 {
+		pinmux = < LPSPI0_MISO >,
+			 < LPSPI0_MOSI >,
+			 < LPSPI0_SCLK >,
+			 < LPSPI_SS_GPIO_PIN >;
+		read-enable = < 0x1 >;
+	};
+};
+#else
+&spi4 {
+	status = "okay";
+	cs-gpios = <&LPSPI_SS_GPIO_BANK LPSPI_SS_GPIO_NUM GPIO_ACTIVE_LOW>;
+	interrupts = <SPI4_IRQ 0>;
+};
+
+&pinctrl_lpspi {
+	group0 {
+		pinmux = < SPI4_MISO >,
+			 < SPI4_MOSI >,
+			 < SPI4_SCLK >,
+			 < LPSPI_SS_GPIO_PIN >;
+		read-enable = < 0x1 >;
+	};
+};
+#endif
+
+&LPSPI_SS_GPIO_BANK {
+	status = "okay";
+};

--- a/tests/drivers/spi/boards/spi.overlay
+++ b/tests/drivers/spi/boards/spi.overlay
@@ -1,0 +1,65 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* SPI0/SPI1 test overlay.  Include board-common macros then wire SPI1
+ * controller <-> SPI0 target.  Board is auto-detected from the BOARD
+ * CMake variable (set in CMakeLists.txt) or can be overridden on the
+ * west command line with -DALIF_BOARD=ALIF_BOARD_E7_HP.
+ */
+#include "board_common.overlay"
+
+/ {
+	aliases {
+		controller-spi = &spi1;
+		target-spi     = &spi0;
+	};
+
+	chosen {
+		zephyr,console = &CONSOLE;
+	};
+};
+
+&CONSOLE {
+	status = "okay";
+};
+
+&UART_DISABLED {
+	status = "disabled";
+};
+
+&spi1 {
+	status = "okay";
+	interrupts = <SPI1_IRQ 0>;
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	interrupts = <SPI0_IRQ 1>;
+};
+
+&pinctrl_spi0 {
+	group0 {
+		pinmux = < SPI0_MISO >,
+			 < SPI0_MOSI >,
+			 < SPI0_SCLK >,
+			 < SPI0_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < SPI1_MISO >,
+			 < SPI1_MOSI >,
+			 < SPI1_SCLK >,
+			 < SPI1_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};

--- a/tests/drivers/spi/boards/spi2.overlay
+++ b/tests/drivers/spi/boards/spi2.overlay
@@ -1,0 +1,61 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* SPI1/SPI2 test overlay. */
+#include "board_common.overlay"
+
+/ {
+	aliases {
+		controller-spi = &spi1;
+		target-spi     = &spi2;
+	};
+
+	chosen {
+		zephyr,console = &CONSOLE;
+	};
+};
+
+&CONSOLE {
+	status = "okay";
+};
+
+&UART_DISABLED {
+	status = "disabled";
+};
+
+&spi1 {
+	status = "okay";
+	interrupts = <SPI1_IRQ 0>;
+};
+
+&spi2 {
+	status = "okay";
+	serial-target;
+	interrupts = <SPI2_IRQ 1>;
+};
+
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < SPI1_MISO >,
+			 < SPI1_MOSI >,
+			 < SPI1_SCLK >,
+			 < SPI1_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+
+&pinctrl_spi2 {
+	group0 {
+		pinmux = < SPI2_MISO >,
+			 < SPI2_MOSI >,
+			 < SPI2_SCLK >,
+			 < SPI2_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};

--- a/tests/drivers/spi/boards/spi3.overlay
+++ b/tests/drivers/spi/boards/spi3.overlay
@@ -1,0 +1,61 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* SPI1/SPI3 test overlay. */
+#include "board_common.overlay"
+
+/ {
+	aliases {
+		controller-spi = &spi1;
+		target-spi     = &spi3;
+	};
+
+	chosen {
+		zephyr,console = &CONSOLE;
+	};
+};
+
+&CONSOLE {
+	status = "okay";
+};
+
+&UART_DISABLED {
+	status = "disabled";
+};
+
+&spi1 {
+	status = "okay";
+	interrupts = <SPI1_IRQ 0>;
+};
+
+&spi3 {
+	status = "okay";
+	serial-target;
+	interrupts = <SPI3_IRQ 1>;
+};
+
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < SPI1_MISO >,
+			 < SPI1_MOSI >,
+			 < SPI1_SCLK >,
+			 < SPI1_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};
+
+&pinctrl_spi3 {
+	group0 {
+		pinmux = < SPI3_MISO >,
+			 < SPI3_MOSI >,
+			 < SPI3_SCLK >,
+			 < SPI3_SS0 >;
+		read-enable = < 0x1 >;
+	};
+};

--- a/tests/drivers/spi/boards/spi_DMA.overlay
+++ b/tests/drivers/spi/boards/spi_DMA.overlay
@@ -1,0 +1,27 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* DMA overlay for SPI1/SPI0.  Stack with boards/spi.overlay.
+ * HP boards use dma1; HE / A5 / E1C / B1 use dma2.
+ */
+#include "board_common.overlay"
+
+&DMA_CTRL {
+	status = "okay";
+};
+
+&spi1 {
+	dmas = <&DMA_CTRL 0 21>, <&DMA_CTRL 1 17>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	dmas = <&DMA_CTRL 2 20>, <&DMA_CTRL 3 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/tests/drivers/spi/boards/spi_DMA_evtrtr.overlay
+++ b/tests/drivers/spi/boards/spi_DMA_evtrtr.overlay
@@ -1,0 +1,34 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Event-router DMA overlay for SPI1/SPI0.
+ * Stack with boards/spi.overlay.
+ */
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+#include "board_common.overlay"
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi1 {
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(0, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(1, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/tests/drivers/spi/boards/spi_ss_sw.overlay
+++ b/tests/drivers/spi/boards/spi_ss_sw.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* Software-controlled GPIO chip-select overlay for SPI1 controller.
+ * Stack with boards/spi.overlay (base pinmux already applied).
+ * This overlay only overrides the SS pin to GPIO and adds cs-gpios.
+ */
+#include "board_common.overlay"
+
+&spi1 {
+	cs-gpios = <&SPI_SS_GPIO_BANK SPI_SS_GPIO_NUM GPIO_ACTIVE_LOW>;
+};
+
+&pinctrl_spi1 {
+	group0 {
+		pinmux = < SPI1_MISO >,
+			 < SPI1_MOSI >,
+			 < SPI1_SCLK >,
+			 < SPI_SS_GPIO_PIN >;
+		read-enable = <0x1>;
+	};
+};
+
+&SPI_SS_GPIO_BANK {
+	status = "okay";
+};

--- a/tests/drivers/spi/prj.conf
+++ b/tests/drivers/spi/prj.conf
@@ -1,0 +1,24 @@
+# Note: SPI slave mode (target role) enabled
+# Base SPI driver
+CONFIG_SPI=y
+CONFIG_SPI_DW=y
+CONFIG_SPI_SLAVE=y
+
+# Zephyr test framework
+CONFIG_ZTEST=y
+
+# Logging - Fix console output issues
+CONFIG_LOG=y
+
+# Kernel features
+CONFIG_EVENTS=y
+CONFIG_STDOUT_CONSOLE=y
+
+# Async SPI path coverage (sync path uses spi_transceive, async uses
+# spi_transceive_signal which needs both of these)
+CONFIG_SPI_ASYNC=y
+CONFIG_POLL=y
+
+# Stack sizes - stress tests need larger stacks
+CONFIG_MAIN_STACK_SIZE=20480
+CONFIG_ZTEST_STACK_SIZE=20480

--- a/tests/drivers/spi/src/test_spi_boundary.c
+++ b/tests/drivers/spi/src/test_spi_boundary.c
@@ -1,0 +1,397 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * Alif SPI boundary / edge-case validation suite.
+ *
+ * Two ZTESTs only:
+ *   - test_boundary_sync  : runs the boundary scenarios using
+ *                           synchronous spi_transceive
+ *   - test_boundary_async : same scenarios driven via
+ *                           spi_transceive_signal + k_poll
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+#if IS_ENABLED(CONFIG_TEST_SPI_BOUNDARY)
+
+#include "test_spi_common.h"
+
+LOG_MODULE_REGISTER(alif_spi_bnd, LOG_LEVEL_INF);
+
+#define BND_MAX_BUF           1024
+#define BND_DEFAULT_FREQ      SPI_FREQ_MHZ
+#define BND_ASYNC_TIMEOUT_MS  500
+
+static const struct device *const controller_dev =
+	DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+static struct k_poll_signal bnd_async_sig;
+static struct k_poll_event  bnd_async_evt;
+
+static int bnd_xfer(const struct spi_config *cfg,
+		    const struct spi_buf_set *tx,
+		    const struct spi_buf_set *rx,
+		    bool async)
+{
+	int ret;
+
+	if (!async) {
+		return spi_transceive(controller_dev, cfg, tx, rx);
+	}
+
+	k_poll_signal_reset(&bnd_async_sig);
+	bnd_async_evt.signal->signaled = 0U;
+	bnd_async_evt.state = K_POLL_STATE_NOT_READY;
+
+	ret = spi_transceive_signal(controller_dev, cfg, tx, rx, &bnd_async_sig);
+	if (ret != 0) {
+		return ret;
+	}
+	ret = k_poll(&bnd_async_evt, 1, K_MSEC(BND_ASYNC_TIMEOUT_MS));
+	if (ret != 0) {
+		LOG_ERR("boundary async poll timeout");
+		return -ETIMEDOUT;
+	}
+	return bnd_async_sig.result;
+}
+
+static int bnd_xfer_compare(const struct spi_config *cfg,
+			    void *tx, void *rx, size_t len, bool async)
+{
+	struct spi_buf tb = { .buf = tx, .len = len };
+	struct spi_buf rb = { .buf = rx, .len = len };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
+	int ret;
+
+	memset(rx, 0, len);
+	ret = bnd_xfer(cfg, &ts, &rs, async);
+	if (ret < 0) {
+		return ret;
+	}
+	return memcmp(tx, rx, len) == 0 ? 0 : -EIO;
+}
+
+static struct spi_config bnd_cfg(uint32_t word, uint32_t freq_hz)
+{
+	uint32_t operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(word);
+
+	if (IS_ENABLED(CONFIG_TEST_SPI_INTERNAL_LOOPBACK)) {
+		operation |= SPI_MODE_LOOP;
+	}
+	return spi_test_config(operation, freq_hz);
+}
+
+static int sc_single_byte(bool async)
+{
+	static const uint8_t patterns[] = {
+		0x00, 0xFF, 0xA5, 0x5A, 0x01, 0xFE, 0x55, 0xAA
+	};
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	int fail = 0;
+
+	for (size_t p = 0; p < ARRAY_SIZE(patterns); p++) {
+		uint8_t tx = patterns[p];
+		uint8_t rx = 0U;
+		int ret = bnd_xfer_compare(&cfg, &tx, &rx, 1U, async);
+
+		if (ret != 0) {
+			LOG_ERR("single_byte 0x%02X ret=%d", patterns[p], ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_fifo_sizes(uint32_t word, const size_t *sizes,
+			 size_t n_sizes, bool async)
+{
+	static uint32_t tx[64];
+	static uint32_t rx[64];
+	struct spi_config cfg = bnd_cfg(word, BND_DEFAULT_FREQ);
+	int fail = 0;
+	size_t bytes_per_frame = word / 8U;
+
+	for (size_t s = 0; s < n_sizes; s++) {
+		size_t frames = sizes[s];
+		size_t len = frames * bytes_per_frame;
+
+		for (size_t i = 0; i < ARRAY_SIZE(tx); i++) {
+			tx[i] = 0xA5000000U | (uint32_t)(i + frames);
+		}
+		int ret = bnd_xfer_compare(&cfg, tx, rx, len, async);
+
+		if (ret != 0) {
+			LOG_ERR("fifo_%u_bit frames=%zu ret=%d", word,
+				frames, ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_fifo_8bit(bool async)
+{
+	static const size_t sizes[] = {15, 16, 17, 31, 32, 33, 63, 64, 65};
+
+	return sc_fifo_sizes(8U, sizes, ARRAY_SIZE(sizes), async);
+}
+
+static int sc_fifo_16bit(bool async)
+{
+	static const size_t sizes[] = {15, 16, 17, 31, 32, 33};
+
+	return sc_fifo_sizes(16U, sizes, ARRAY_SIZE(sizes), async);
+}
+
+static int sc_fifo_32bit(bool async)
+{
+	static const size_t sizes[] = {15, 16, 17, 31, 32, 33};
+
+	return sc_fifo_sizes(32U, sizes, ARRAY_SIZE(sizes), async);
+}
+
+static int sc_fifo_flush(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	uint8_t tx_a[17], rx_a[17];
+	uint8_t tx_b[17], rx_b[17];
+	int ret;
+
+	memset(tx_a, 0xA5, sizeof(tx_a));
+	for (size_t i = 0; i < sizeof(tx_b); i++) {
+		tx_b[i] = (uint8_t)(i & 0xFFU);
+	}
+
+	ret = bnd_xfer_compare(&cfg, tx_a, rx_a, sizeof(tx_a), async);
+	if (ret != 0) {
+		LOG_ERR("fifo_flush A ret=%d", ret);
+		return 1;
+	}
+	ret = bnd_xfer_compare(&cfg, tx_b, rx_b, sizeof(tx_b), async);
+	if (ret != 0) {
+		LOG_ERR("fifo_flush B (stale data?) ret=%d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int sc_xfer_sweep(bool async)
+{
+	static const size_t sizes[] = {1, 2, 4, 8, 16, 32, 64, 128, 256};
+	static const uint8_t pat[] = {0xDE, 0xAD, 0xBE, 0xEF};
+	static uint8_t tx[256], rx[256];
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	int fail = 0;
+
+	for (size_t s = 0; s < ARRAY_SIZE(sizes); s++) {
+		size_t len = sizes[s];
+
+		for (size_t i = 0; i < len; i++) {
+			tx[i] = pat[i & 3U];
+		}
+		int ret = bnd_xfer_compare(&cfg, tx, rx, len, async);
+
+		if (ret != 0) {
+			LOG_ERR("xfer_sweep len=%zu ret=%d", len, ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_fifo_plus_one(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	uint8_t tx[33], rx[33];
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)(i + 1U);
+	}
+	int ret = bnd_xfer_compare(&cfg, tx, rx, sizeof(tx), async);
+
+	if (ret != 0) {
+		LOG_ERR("fifo_plus_one ret=%d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int sc_large_xfer(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	static uint8_t tx[BND_MAX_BUF], rx[BND_MAX_BUF];
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)(i & 0xFFU);
+	}
+	int ret = bnd_xfer_compare(&cfg, tx, rx, sizeof(tx), async);
+
+	if (ret != 0) {
+		LOG_ERR("large_xfer 1024 ret=%d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int sc_unaligned(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	static uint8_t tx[16], rx[16];
+	int fail = 0;
+
+	for (size_t len = 1U; len < 16U; len++) {
+		for (size_t i = 0; i < len; i++) {
+			tx[i] = (uint8_t)((i + 1U) & 0xFFU);
+		}
+		int ret = bnd_xfer_compare(&cfg, tx, rx, len, async);
+
+		if (ret != 0) {
+			LOG_ERR("unaligned len=%zu ret=%d", len, ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_cs_toggle(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U, BND_DEFAULT_FREQ);
+	static uint8_t tx[256], rx[256];
+	static const uint8_t pat[] = {0xDE, 0xAD, 0xBE, 0xEF};
+	static const size_t sizes[] = {1, 2, 4, 8, 16, 32, 64, 128, 256};
+	int fail = 0;
+	int ret;
+
+	for (size_t i = 0; i < 16U; i++) {
+		tx[i] = pat[i & 3U];
+	}
+	ret = bnd_xfer_compare(&cfg, tx, rx, 16U, async);
+	if (ret != 0) {
+		LOG_ERR("cs_toggle basic ret=%d", ret);
+		return 1;
+	}
+
+	memset(tx, 0xA5, 8U);
+	for (int i = 0; i < 50; i++) {
+		ret = bnd_xfer_compare(&cfg, tx, rx, 8U, async);
+		if (ret != 0) {
+			fail++;
+			if (fail <= 3) {
+				LOG_ERR("cs_toggle iter %d ret=%d", i, ret);
+			}
+		}
+	}
+
+	for (size_t s = 0; s < ARRAY_SIZE(sizes); s++) {
+		size_t len = sizes[s];
+
+		for (size_t i = 0; i < len; i++) {
+			tx[i] = (uint8_t)((i + s) & 0xFFU);
+		}
+		ret = bnd_xfer_compare(&cfg, tx, rx, len, async);
+		if (ret != 0) {
+			LOG_ERR("cs_toggle multi-size %zu ret=%d", len, ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_max_freq(bool async)
+{
+	struct spi_config cfg = bnd_cfg(8U,
+					SPI_TEST_MAX_FREQUENCY * SPI_FREQ_MHZ);
+	uint8_t tx[32], rx[32];
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)(0xFFU - i);
+	}
+	int ret = bnd_xfer_compare(&cfg, tx, rx, sizeof(tx), async);
+
+	if (ret != 0) {
+		LOG_ERR("max_freq ret=%d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+struct bnd_scenario {
+	const char *name;
+	int (*fn)(bool async);
+};
+
+static const struct bnd_scenario scenarios[] = {
+	{ "single_byte",   sc_single_byte   },
+	{ "fifo_8bit",     sc_fifo_8bit     },
+	{ "fifo_16bit",    sc_fifo_16bit    },
+	{ "fifo_32bit",    sc_fifo_32bit    },
+	{ "fifo_flush",    sc_fifo_flush    },
+	{ "xfer_sweep",    sc_xfer_sweep    },
+	{ "fifo_plus_one", sc_fifo_plus_one },
+	{ "large_xfer",    sc_large_xfer    },
+	{ "unaligned",     sc_unaligned     },
+	{ "cs_toggle",     sc_cs_toggle     },
+	{ "max_freq",      sc_max_freq      },
+};
+
+static int run_boundary(bool async)
+{
+	int total = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(scenarios); i++) {
+		int f = scenarios[i].fn(async);
+
+		TC_PRINT("  %-14s : %s (%d)\n", scenarios[i].name,
+			f ? "FAIL" : "OK", f);
+		total += f;
+	}
+	return total;
+}
+
+ZTEST(test_spi_boundary, test_boundary_sync)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI controller not ready");
+
+	TC_PRINT("=== SPI boundary (SYNC) ===\n");
+	int fail = run_boundary(false);
+
+	zassert_equal(fail, 0, "SYNC boundary: %d scenario failure(s)", fail);
+}
+
+#if IS_ENABLED(CONFIG_SPI_ASYNC)
+ZTEST(test_spi_boundary, test_boundary_async)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI controller not ready");
+
+	TC_PRINT("=== SPI boundary (ASYNC) ===\n");
+	int fail = run_boundary(true);
+
+	zassert_equal(fail, 0, "ASYNC boundary: %d scenario failure(s)", fail);
+}
+#endif /* CONFIG_SPI_ASYNC */
+
+static void boundary_suite_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	k_poll_signal_init(&bnd_async_sig);
+	k_poll_event_init(&bnd_async_evt, K_POLL_TYPE_SIGNAL,
+			  K_POLL_MODE_NOTIFY_ONLY, &bnd_async_sig);
+}
+
+ZTEST_SUITE(test_spi_boundary, NULL, NULL, boundary_suite_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_SPI_BOUNDARY */

--- a/tests/drivers/spi/src/test_spi_common.c
+++ b/tests/drivers/spi/src/test_spi_common.c
@@ -1,0 +1,672 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "test_spi_common.h"
+
+#include <zephyr/sys/atomic.h>
+
+LOG_MODULE_REGISTER(alif_spi_common, LOG_LEVEL_INF);
+
+#define SPI_TEST_CFG_SHADOW_DEPTH 1024U
+
+
+K_THREAD_STACK_DEFINE(controller_stack, SPI_TEST_STACKSIZE);
+struct k_thread controller_thread_data;
+
+K_THREAD_STACK_DEFINE(target_stack, SPI_TEST_STACKSIZE);
+struct k_thread target_thread_data;
+
+#if !IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+uint32_t __aligned(4) ctrl_txdata[SPI_TEST_BUFF_SIZE];
+uint32_t __aligned(4) tgt_txdata[SPI_TEST_BUFF_SIZE];
+uint32_t __aligned(4) ctrl_rxdata[SPI_TEST_BUFF_SIZE];
+uint32_t __aligned(4) tgt_rxdata[SPI_TEST_BUFF_SIZE];
+#else
+uint32_t __aligned(4) ctrl_txdata[SPI_TEST_BUFF_SIZE_PERF];
+uint32_t __aligned(4) ctrl_rxdata[SPI_TEST_BUFF_SIZE_PERF];
+uint32_t __aligned(4) tgt_txdata[SPI_TEST_BUFF_SIZE_PERF];
+uint32_t __aligned(4) tgt_rxdata[SPI_TEST_BUFF_SIZE_PERF];
+#endif
+
+atomic_t err_count;
+atomic_val_t transceive_word;
+uint32_t spi_test_op_flags;
+atomic_t spi_test_async_mode;
+
+uint32_t ctrl_ret_tx;
+uint32_t tgt_ret_tx;
+uint32_t ctrl_ret_rx;
+uint32_t tgt_ret_rx;
+
+static struct spi_config spi_test_cfg_shadow[SPI_TEST_CFG_SHADOW_DEPTH];
+static atomic_t spi_test_cfg_idx;
+static struct k_mutex cfg_shadow_mutex;
+
+
+/* ---------------------------------------------------------------------------
+ * Utility functions
+ * ---------------------------------------------------------------------------
+ */
+int spi_test_prepare_data(uint32_t *data, uint16_t pattern, uint32_t count)
+{
+	if (data == NULL) {
+		LOG_ERR("%s: NULL data pointer", __func__);
+		return -EINVAL;
+	}
+	if (count == 0) {
+		return 0;
+	}
+	for (uint32_t i = 0; i < count; i++) {
+		data[i] = ((uint32_t)pattern << 16) | i;
+	}
+	return 0;
+}
+
+int spi_test_reset_buffer(uint32_t *buffer, size_t count)
+{
+	if (buffer == NULL) {
+		LOG_ERR("%s: NULL received data pointer", __func__);
+		return -EINVAL;
+	}
+	memset(buffer, 0, count * sizeof(uint32_t));
+	return 0;
+}
+
+bool spi_test_device_ready(const struct device *dev, const char *role)
+{
+	bool ready = false;
+
+	if ((dev != NULL) && (device_is_ready(dev))) {
+		ready = true;
+	} else if (role != NULL) {
+		LOG_ERR("%s device not ready", role);
+	} else {
+		LOG_ERR("SPI device not ready");
+	}
+
+	return ready;
+}
+
+void spi_test_controller_cs_init(struct spi_cs_control *cs)
+{
+	if (cs == NULL) {
+		return;
+	}
+
+#if DT_NODE_HAS_PROP(SPI_CONTROLLER_NODE, cs_gpios)
+	*cs = (struct spi_cs_control){
+		.gpio = GPIO_DT_SPEC_GET(SPI_CONTROLLER_NODE, cs_gpios),
+		.delay = SPI_TEST_CS_DELAY_US,
+	};
+	LOG_DBG("Controller CS GPIO initialized: pin=%d, delay=%d us",
+		cs->gpio.pin, cs->delay);
+#else
+	(void)memset(cs, 0, sizeof(*cs));
+#endif
+}
+
+int spi_test_transceive(const struct device *dev,
+			const struct spi_config *cnfg,
+			const struct spi_buf_set *tx_set,
+			const struct spi_buf_set *rx_set,
+			bool force_reconfig)
+{
+	struct spi_config *active_cfg;
+	const struct spi_config *cfg_to_use;
+	atomic_val_t idx;
+
+	if (dev == NULL) {
+		LOG_ERR("%s: NULL device", __func__);
+		return -EINVAL;
+	}
+	if (cnfg == NULL) {
+		LOG_ERR("%s: NULL config", __func__);
+		return -EINVAL;
+	}
+
+	if (!force_reconfig) {
+		return spi_transceive(dev, cnfg, tx_set, rx_set);
+	}
+
+	k_mutex_lock(&cfg_shadow_mutex, K_FOREVER);
+
+	idx = atomic_inc(&spi_test_cfg_idx);
+	if ((size_t)idx >= ARRAY_SIZE(spi_test_cfg_shadow)) {
+		LOG_ERR("%s: cfg shadow exhausted (%ld >= %u)",
+			__func__, (long)idx,
+			(unsigned int)ARRAY_SIZE(spi_test_cfg_shadow));
+		k_mutex_unlock(&cfg_shadow_mutex);
+		return -ENOMEM;
+	}
+
+	active_cfg = &spi_test_cfg_shadow[idx];
+	*active_cfg = *cnfg;
+	cfg_to_use = active_cfg;
+
+	k_mutex_unlock(&cfg_shadow_mutex);
+
+	LOG_DBG("%s: forced reconfig ptr=%p idx=%ld",
+		__func__, (void *)active_cfg, (long)idx);
+
+	return spi_transceive(dev, cfg_to_use, tx_set, rx_set);
+}
+
+int spi_test_transceive_async(const struct device *dev,
+			      const struct spi_config *cnfg,
+			      const struct spi_buf_set *tx_set,
+			      const struct spi_buf_set *rx_set,
+			      bool force_reconfig)
+{
+	struct spi_config *active_cfg;
+	const struct spi_config *cfg_to_use;
+	atomic_val_t idx;
+	struct k_poll_signal async_sig;
+	struct k_poll_event async_evt;
+	int ret;
+
+	if (dev == NULL) {
+		LOG_ERR("%s: NULL device", __func__);
+		return -EINVAL;
+	}
+	if (cnfg == NULL) {
+		LOG_ERR("%s: NULL config", __func__);
+		return -EINVAL;
+	}
+
+	if (!force_reconfig) {
+		cfg_to_use = cnfg;
+	} else {
+		k_mutex_lock(&cfg_shadow_mutex, K_FOREVER);
+
+		idx = atomic_inc(&spi_test_cfg_idx);
+		if ((size_t)idx >= ARRAY_SIZE(spi_test_cfg_shadow)) {
+			LOG_ERR("%s: cfg shadow exhausted", __func__);
+			k_mutex_unlock(&cfg_shadow_mutex);
+			return -ENOMEM;
+		}
+
+		active_cfg = &spi_test_cfg_shadow[idx];
+		*active_cfg = *cnfg;
+		cfg_to_use = active_cfg;
+
+		k_mutex_unlock(&cfg_shadow_mutex);
+	}
+
+	k_poll_signal_init(&async_sig);
+	k_poll_event_init(&async_evt, K_POLL_TYPE_SIGNAL,
+			  K_POLL_MODE_NOTIFY_ONLY, &async_sig);
+
+	ret = spi_transceive_signal(dev, cfg_to_use, tx_set, rx_set, &async_sig);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = k_poll(&async_evt, 1, K_MSEC(500));
+	if (ret != 0) {
+		LOG_ERR("async xfer poll timeout");
+		return -EIO;
+	}
+
+	return async_sig.result;
+}
+
+int spi_test_controller_receive_and_check(const struct device *dev,
+				      const struct spi_config *cnfg,
+				      const uint32_t *expected_tx,
+				      uint32_t *rx_buffer,
+				      size_t word_count)
+{
+	size_t length;
+	struct spi_buf rx_buf;
+	struct spi_buf_set rx_set;
+	int ret;
+
+	if ((dev == NULL) || (cnfg == NULL) || (expected_tx == NULL) ||
+	    (rx_buffer == NULL) || (word_count == 0U)) {
+		LOG_ERR("controller_receive_and_check: invalid argument");
+		return -EINVAL;
+	}
+
+	length = word_count * sizeof(uint32_t);
+	rx_buf = (struct spi_buf){
+		.buf = rx_buffer,
+		.len = length,
+	};
+	rx_set = (struct spi_buf_set){
+		.buffers = &rx_buf,
+		.count = 1U,
+	};
+
+	LOG_DBG("Controller RX: Starting transceive (freq=%u, len=%zu)",
+		cnfg->frequency, length);
+	ret = spi_test_transceive(dev, cnfg, NULL, &rx_set, false);
+
+	if (ret < 0) {
+		LOG_ERR("Controller RX: %s failed: %d", __func__, ret);
+		return ret;
+	}
+
+	return memcmp(expected_tx, rx_buffer, length);
+}
+
+void spi_test_log_first_mismatch(const uint32_t *expected,
+				 const uint32_t *actual,
+				 size_t word_count,
+				 const char *context)
+{
+	size_t length;
+	const uint8_t *exp_bytes;
+	const uint8_t *act_bytes;
+
+	if ((expected == NULL) || (actual == NULL) || (word_count == 0U)) {
+		LOG_ERR("%s mismatch details unavailable (invalid args)",
+			(context != NULL) ? context : "SPI");
+		return;
+	}
+
+	length = word_count * sizeof(uint32_t);
+	exp_bytes = (const uint8_t *)expected;
+	act_bytes = (const uint8_t *)actual;
+
+	for (size_t i = 0U; i < length; i++) {
+		if (exp_bytes[i] != act_bytes[i]) {
+			LOG_ERR("%s: Mismatch at byte %u "
+				"(expected: 0x%02X, received: 0x%02X)",
+				(context != NULL) ? context : "SPI",
+				(unsigned int)i, exp_bytes[i], act_bytes[i]);
+			return;
+		}
+	}
+
+	LOG_ERR("%s: mismatch reported but byte diff not found",
+		(context != NULL) ? context : "SPI");
+}
+
+#define SPI_TEST_NODE_DMA_IS(node, dma) \
+	(DT_NODE_EXISTS(DT_NODELABEL(node)) && \
+	 DT_NODE_HAS_PROP(DT_NODELABEL(node), dmas) && \
+	 DT_SAME_NODE(DT_PHANDLE_BY_IDX(DT_NODELABEL(node), dmas, 0), DT_NODELABEL(dma)))
+
+/*
+ * DMA configuration functions for direct PL330 DMA controllers.
+ */
+
+#if SPI_TEST_NODE_DMA_IS(lpspi0, dma2) /* E1C/B1 LPSPI0 dma2 */
+static void configure_lpspi0_for_dma2(void)
+{
+	const uint32_t rx_req = 12U;
+	const uint32_t tx_req = 13U;
+	const uint32_t group = 1U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring lpspi0 for dma2");
+
+	sys_clear_bits(M55HE_CFG_HE_DMA_SEL, HE_DMA_SEL_LPSPI_Msk);
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* E1C/B1 LPSPI0 dma2 */
+
+#if SPI_TEST_NODE_DMA_IS(spi1, dma2) /* E1C/B1 SPI1 dma2 */
+static void configure_spi1_for_dma2(void)
+{
+	const uint32_t rx_req = 17U;
+	const uint32_t tx_req = 21U;
+	const uint32_t group = 2U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring spi1 for dma2");
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* E1C/B1 SPI1 dma2 */
+
+#if SPI_TEST_NODE_DMA_IS(spi0, dma2) /* SPI0 dma2 */
+static void configure_spi0_for_dma2(void)
+{
+	const uint32_t rx_req = 16U;
+	const uint32_t tx_req = 20U;
+	const uint32_t group = 2U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring spi0 for dma2");
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* SPI0 dma2 */
+
+#if SPI_TEST_NODE_DMA_IS(spi4, dma2) /* LPSPI(SPI4) dma2 */
+static void configure_lpspi_for_dma2(void)
+{
+	const uint32_t rx_req = 12U;
+	const uint32_t tx_req = 13U;
+
+	LOG_INF("Configuring lpspi for dma2");
+
+	sys_clear_bits(M55HE_CFG_HE_DMA_SEL, HE_DMA_SEL_LPSPI_Msk);
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos),
+			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos),
+			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
+}
+#endif /* LPSPI(SPI4) dma2 */
+
+#if SPI_TEST_NODE_DMA_IS(spi4, dma0) /* LPSPI(SPI4) dma0 */
+static void configure_lpspi_for_dma0(void)
+{
+	const uint32_t rx_req = 24U;
+	const uint32_t tx_req = 25U;
+	const uint32_t group = 2U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring lpspi for dma0");
+
+	regdata = sys_read32(M55HE_CFG_HE_DMA_SEL);
+	regdata &= ~HE_DMA_SEL_LPSPI_Msk;
+	regdata |= (0 << HE_DMA_SEL_LPSPI_Pos);
+	sys_write32(regdata, M55HE_CFG_HE_DMA_SEL);
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* LPSPI(SPI4) dma0 */
+
+
+/* dma0 */
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma0), arm_dma_pl330, okay)
+
+#if SPI_TEST_NODE_DMA_IS(spi0, dma0) /* SPI0 dma0 */
+static void configure_spi0_for_dma0(void)
+{
+	const uint32_t rx_req = 16U;
+	const uint32_t tx_req = 20U;
+	const uint32_t group = 2U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring spi0 for dma0");
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* SPI0 dma0 */
+
+#if SPI_TEST_NODE_DMA_IS(spi1, dma0) /* SPI1 dma0 */
+static void configure_spi1_for_dma0(void)
+{
+	const uint32_t rx_req = 17U;
+	const uint32_t tx_req = 21U;
+	const uint32_t group = 2U;
+	uint32_t regdata;
+
+	LOG_INF("Configuring spi1 for dma0");
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (rx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << rx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+
+	sys_write32(DMA_CTRL_ENA |
+			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
+			EVTRTR0_DMA_CTRL0 + (tx_req * 4));
+
+	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+	regdata |= (1 << tx_req);
+	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
+}
+#endif /* SPI1 dma0 */
+
+#endif /* dma0 */
+
+/*
+ * DMA EVTRTR configuration for direct PL330 DMA controllers (dma0 / dma2).
+ * Event-router DMA parents (evtrtr0 / evtrtr2) are handled by their driver.
+ * Gated by CONFIG_TEST_SPI_USE_DMA.
+ */
+#if IS_ENABLED(CONFIG_TEST_SPI_USE_DMA)
+
+/*
+ * spi_test_configure_dma() — configures DMA routing
+ * based on the DMA controller type.
+ * Event Router DMA (evtrtr0/evtrtr2) is handled by the driver.
+ * Direct PL330 DMA (dma0/dma2) requires manual event router configuration.
+ */
+
+static int spi_test_configure_dma(void)
+{
+	LOG_INF("DMA configuration - align with spi_dw sample mode split");
+
+	/* Validate DMA devices are ready before configuring */
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma0), arm_dma_pl330, okay)
+	const struct device *dma0_dev = DEVICE_DT_GET(DT_NODELABEL(dma0));
+
+	if (!device_is_ready(dma0_dev)) {
+		LOG_ERR("DMA0 (dma0) not ready");
+		return -ENODEV;
+	}
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma2), arm_dma_pl330, okay)
+	const struct device *dma2_dev = DEVICE_DT_GET(DT_NODELABEL(dma2));
+
+	if (!device_is_ready(dma2_dev)) {
+		LOG_ERR("DMA2 (dma2) not ready");
+		return -ENODEV;
+	}
+#endif
+
+	/* Direct PL330 DMA needs manual event-router configuration;
+	 * event-router DMA parents are handled by the driver.
+	 */
+
+#if DT_NODE_EXISTS(DT_NODELABEL(evtrtr2))
+#if SPI_TEST_NODE_DMA_IS(lpspi0, evtrtr2)
+	LOG_INF("lpspi0 dmas -> evtrtr2 (event-router)");
+#endif
+#if SPI_TEST_NODE_DMA_IS(spi1, evtrtr2)
+	LOG_INF("spi1 dmas -> evtrtr2 (event-router)");
+#endif
+#if SPI_TEST_NODE_DMA_IS(spi4, evtrtr2)
+	LOG_INF("spi4 dmas -> evtrtr2 (event-router)");
+#endif
+#endif /* evtrtr2 */
+
+#if DT_NODE_EXISTS(DT_NODELABEL(evtrtr0))
+#if SPI_TEST_NODE_DMA_IS(spi0, evtrtr0)
+	LOG_INF("spi0 dmas -> evtrtr0 (event-router)");
+#endif
+#if SPI_TEST_NODE_DMA_IS(spi1, evtrtr0)
+	LOG_INF("spi1 dmas -> evtrtr0 (event-router)");
+#endif
+#if SPI_TEST_NODE_DMA_IS(spi4, evtrtr0)
+	LOG_INF("spi4 dmas -> evtrtr0 (event-router)");
+#endif
+#endif /* evtrtr0 */
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma2), arm_dma_pl330, okay)
+#if SPI_TEST_NODE_DMA_IS(lpspi0, dma2)
+	configure_lpspi0_for_dma2();
+#endif
+
+#if SPI_TEST_NODE_DMA_IS(spi0, dma2)
+	configure_spi0_for_dma2();
+#endif
+
+#if SPI_TEST_NODE_DMA_IS(spi1, dma2)
+	configure_spi1_for_dma2();
+#endif
+
+#if SPI_TEST_NODE_DMA_IS(spi4, dma2)
+	configure_lpspi_for_dma2();
+#endif
+#endif /* dma2 */
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma0), arm_dma_pl330, okay)
+#if SPI_TEST_NODE_DMA_IS(spi0, dma0)
+	configure_spi0_for_dma0();
+#endif
+
+#if SPI_TEST_NODE_DMA_IS(spi1, dma0)
+	configure_spi1_for_dma0();
+#endif
+
+#if SPI_TEST_NODE_DMA_IS(spi4, dma0)
+	configure_lpspi_for_dma0();
+#endif
+#endif /* dma0 */
+
+	LOG_INF("DMA routing setup done");
+	return 0;
+}
+
+#endif /* CONFIG_TEST_SPI_USE_DMA */
+
+/* ---------------------------------------------------------------------------
+ * Ztest before-function: runs before every test case
+ * ---------------------------------------------------------------------------
+ */
+void test_before_func(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	TC_PRINT("Test setup: DMA enabled=%d\n",
+		 IS_ENABLED(CONFIG_TEST_SPI_USE_DMA));
+
+#if IS_ENABLED(CONFIG_TEST_SPI_USE_DMA)
+	TC_PRINT("About to call spi_test_configure_dma()\n");
+	int dma_ret = spi_test_configure_dma();
+
+	zassert_equal(dma_ret, 0, "DMA configuration failed: %d", dma_ret);
+#else
+	TC_PRINT("DMA not enabled - skipping DMA configuration\n");
+#endif
+	TC_PRINT("SPI test setup: mode=%s path=%s\n",
+		IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE) ?
+			"performance" : "functional",
+		IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ? "dma" : "pio");
+
+	/* Reset config index to prevent exhaustion in stress tests */
+	atomic_clear(&spi_test_cfg_idx);
+
+	/* Initialize mutex for thread-safe shadow config access */
+	k_mutex_init(&cfg_shadow_mutex);
+
+	/* Clear shadow config array to ensure clean state */
+	memset(spi_test_cfg_shadow, 0, sizeof(spi_test_cfg_shadow));
+
+#if !IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+	(void)spi_test_reset_buffer(ctrl_txdata, SPI_TEST_BUFF_SIZE);
+	(void)spi_test_reset_buffer(tgt_txdata, SPI_TEST_BUFF_SIZE);
+	(void)spi_test_reset_buffer(ctrl_rxdata, SPI_TEST_BUFF_SIZE);
+	(void)spi_test_reset_buffer(tgt_rxdata, SPI_TEST_BUFF_SIZE);
+	(void)spi_test_prepare_data(ctrl_txdata, spi_test_pattern(0xBEEF),
+				    SPI_TEST_BUFF_SIZE);
+	(void)spi_test_prepare_data(tgt_txdata, spi_test_pattern(0xCAFE),
+				    SPI_TEST_BUFF_SIZE);
+#else
+	(void)spi_test_reset_buffer(ctrl_txdata, SPI_TEST_BUFF_SIZE_PERF);
+	(void)spi_test_reset_buffer(ctrl_rxdata, SPI_TEST_BUFF_SIZE_PERF);
+	(void)spi_test_reset_buffer(tgt_txdata, SPI_TEST_BUFF_SIZE_PERF);
+	(void)spi_test_reset_buffer(tgt_rxdata, SPI_TEST_BUFF_SIZE_PERF);
+	(void)spi_test_prepare_data(ctrl_txdata, spi_test_pattern(0xBEEF),
+				    SPI_TEST_BUFF_SIZE_PERF);
+	(void)spi_test_prepare_data(tgt_txdata, spi_test_pattern(0xCAFE),
+				    SPI_TEST_BUFF_SIZE_PERF);
+#endif
+
+	ctrl_ret_tx = 0;
+	tgt_ret_tx = 0;
+	ctrl_ret_rx = 0;
+	tgt_ret_rx = 0;
+
+	/* Reset atomic err_count */
+	atomic_clear(&err_count);
+
+	/* Set transceive_word from config (default 8-bit if zero) */
+	transceive_word = CONFIG_TEST_SPI_WORD_SIZE ? CONFIG_TEST_SPI_WORD_SIZE : 8U;
+
+	/* Reset async mode flag to default sync */
+	atomic_clear(&spi_test_async_mode);
+
+	LOG_INF("Test setup complete");
+}

--- a/tests/drivers/spi/src/test_spi_common.h
+++ b/tests/drivers/spi/src/test_spi_common.h
@@ -1,0 +1,189 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef TEST_SPI_COMMON_H_
+#define TEST_SPI_COMMON_H_
+
+#include <zephyr/logging/log.h>
+#include <zephyr/ztest.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util_macro.h>
+#include <soc_common.h>
+#include <stdbool.h>
+#include <string.h>
+
+/* ---------------------------------------------------------------------------
+ * Constants
+ * ---------------------------------------------------------------------------
+ */
+#define SPI_FREQ_MHZ                CONFIG_TEST_SPI_FREQUENCY
+
+/* Match sample app for DMA compatibility */
+#define SPI_TEST_BUFF_SIZE          200U
+#define SPI_TEST_BUFF_SIZE_PERF     4096U
+
+/* DMA-compatible word size - DMA controllers
+ * typically only support 8-bit reliably
+ */
+#define SPI_TEST_DMA_WORD_SIZE      8U     /* Use 8-bit for DMA transfers */
+
+/* Convenience macro to avoid repeating the long ternary in every test file */
+#define SPI_TEST_WORD_SIZE \
+	SPI_WORD_SET(IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ? \
+		     SPI_TEST_DMA_WORD_SIZE : (uint32_t)transceive_word)
+
+#define SPI_TEST_STACKSIZE          (1024U * 20U)
+#define SPI_TEST_MAX_FREQUENCY      25U
+#define SPI_TEST_NUM_TRANSFERS      1U
+
+#define SPI_TEST_SLEEPTIME_MS       500U
+#define SPI_TEST_PRIORITY_CONTROLLER    7
+#define SPI_TEST_PRIORITY_TARGET        6
+
+#define SPI_TEST_CS_DELAY_US        100U
+#define SPI_TEST_TARGET_HEADSTART_US 10000U  /* Increased for DMA timing */
+
+/* Devicetree node aliases */
+#define SPI_CONTROLLER_NODE         DT_ALIAS(controller_spi)
+#define SPI_TARGET_NODE             DT_ALIAS(target_spi)
+
+/* DMA event router control bits */
+#ifndef DMA_CTRL_ACK_TYPE_Pos
+#define DMA_CTRL_ACK_TYPE_Pos       16U
+#endif
+#ifndef DMA_CTRL_ENA
+#define DMA_CTRL_ENA                (1U << 4)
+#endif
+#ifndef HE_DMA_SEL_LPSPI_Pos
+#define HE_DMA_SEL_LPSPI_Pos        4U
+#endif
+#ifndef HE_DMA_SEL_LPSPI_Msk
+#define HE_DMA_SEL_LPSPI_Msk        (0x3U << HE_DMA_SEL_LPSPI_Pos)
+#endif
+
+/* ---------------------------------------------------------------------------
+ * Shared data (defined in test_spi_common.c)
+ * ---------------------------------------------------------------------------
+ */
+K_THREAD_STACK_DECLARE(controller_stack, SPI_TEST_STACKSIZE);
+extern struct k_thread controller_thread_data;
+
+K_THREAD_STACK_DECLARE(target_stack, SPI_TEST_STACKSIZE);
+extern struct k_thread target_thread_data;
+
+#if !IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+extern uint32_t ctrl_txdata[SPI_TEST_BUFF_SIZE];
+extern uint32_t tgt_txdata[SPI_TEST_BUFF_SIZE];
+extern uint32_t ctrl_rxdata[SPI_TEST_BUFF_SIZE];
+extern uint32_t tgt_rxdata[SPI_TEST_BUFF_SIZE];
+#else
+extern uint32_t ctrl_txdata[SPI_TEST_BUFF_SIZE_PERF];
+extern uint32_t ctrl_rxdata[SPI_TEST_BUFF_SIZE_PERF];
+extern uint32_t tgt_txdata[SPI_TEST_BUFF_SIZE_PERF];
+extern uint32_t tgt_rxdata[SPI_TEST_BUFF_SIZE_PERF];
+#endif
+
+extern atomic_t err_count;
+extern atomic_val_t transceive_word;
+extern uint32_t spi_test_op_flags;  /* CPOL/CPHA*/
+extern atomic_t spi_test_async_mode; /* 0 = sync, 1 = async */
+
+/* Performance error counters */
+extern uint32_t ctrl_ret_tx;
+extern uint32_t tgt_ret_tx;
+extern uint32_t ctrl_ret_rx;
+extern uint32_t tgt_ret_rx;
+
+/* ---------------------------------------------------------------------------
+ * Utility functions (test_spi_common.c)
+ * ---------------------------------------------------------------------------
+ */
+/* Generate a pattern seed that varies with the current word size */
+static inline uint16_t spi_test_pattern(uint16_t seed)
+{
+	return (uint16_t)(seed ^ ((uint16_t)transceive_word << 8));
+}
+
+/* 32-bit seed derived from the word-size-aware pattern */
+static inline uint32_t spi_test_seed32(uint32_t base)
+{
+	uint16_t p = spi_test_pattern((uint16_t)base);
+
+	return ((uint32_t)p << 16) | (uint32_t)(~p & 0xFFFFU);
+}
+
+int spi_test_prepare_data(uint32_t *data, uint16_t pattern, uint32_t count);
+int spi_test_reset_buffer(uint32_t *buffer, size_t count);
+bool spi_test_device_ready(const struct device *dev, const char *role);
+void spi_test_controller_cs_init(struct spi_cs_control *cs);
+
+/* Inline helper: create spi_config with CS pre-configured from DT */
+static inline struct spi_config spi_test_config(uint32_t operation,
+						  uint32_t frequency)
+{
+
+#if DT_NODE_HAS_PROP(SPI_CONTROLLER_NODE, cs_gpios)
+	struct spi_cs_control cs = {
+		.gpio = GPIO_DT_SPEC_GET(SPI_CONTROLLER_NODE, cs_gpios),
+		.delay = SPI_TEST_CS_DELAY_US,
+	};
+#else
+	struct spi_cs_control cs = {0};
+#endif
+	return (struct spi_config){
+		.frequency = frequency,
+		.operation = operation,
+		.slave = 0,
+		.cs = cs,
+	};
+}
+int spi_test_transceive(const struct device *dev,
+			const struct spi_config *cnfg,
+			const struct spi_buf_set *tx_set,
+			const struct spi_buf_set *rx_set,
+			bool force_reconfig);
+int spi_test_transceive_async(const struct device *dev,
+			      const struct spi_config *cnfg,
+			      const struct spi_buf_set *tx_set,
+			      const struct spi_buf_set *rx_set,
+			      bool force_reconfig);
+int spi_test_controller_receive_and_check(const struct device *dev,
+				      const struct spi_config *cnfg,
+				      const uint32_t *expected_tx,
+				      uint32_t *rx_buffer,
+				      size_t word_count);
+void spi_test_log_first_mismatch(const uint32_t *expected,
+				 const uint32_t *actual,
+				 size_t word_count,
+				 const char *context);
+
+/* Ztest before-function: called by ZTEST_SUITE in each test file */
+void test_before_func(void *fixture);
+
+/* ---------------------------------------------------------------------------
+ * Thread entry functions (test_spi_threads.c)
+ * ---------------------------------------------------------------------------
+ */
+
+/* MOSI: controller transmit, target receive */
+void controller_spi_transmit(void *p1, void *p2, void *p3);
+void target_spi_receive(void *p1, void *p2, void *p3);
+
+/* MISO: controller receive, target transmit */
+void controller_receive(void *p1, void *p2, void *p3);
+void target_send(void *p1, void *p2, void *p3);
+
+/* Transceive: full-duplex controller and target */
+void controller_spi(void *p1, void *p2, void *p3);
+void target_spi(void *p1, void *p2, void *p3);
+
+#endif /* TEST_SPI_COMMON_H_ */

--- a/tests/drivers/spi/src/test_spi_loopback.c
+++ b/tests/drivers/spi/src/test_spi_loopback.c
@@ -1,0 +1,292 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+#if IS_ENABLED(CONFIG_TEST_SPI_LOOPBACK)
+
+#include "test_spi_common.h"
+
+LOG_MODULE_REGISTER(alif_spi_loop, LOG_LEVEL_INF);
+
+#define LB_DEFAULT_FREQ_HZ  SPI_FREQ_MHZ
+#define LB_BUF_MAX          64
+
+/* Word-size selection: use CONFIG_TEST_SPI_WORD_SIZE */
+#define LB_PINNED_WORD       CONFIG_TEST_SPI_WORD_SIZE
+#define LB_WORDS             ((const uint32_t[]){LB_PINNED_WORD})
+
+static const struct device *const controller_dev =
+	DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+static int do_xfer(const struct spi_config *cfg,
+		   const struct spi_buf_set *tx,
+		   const struct spi_buf_set *rx)
+{
+	return spi_transceive(controller_dev, cfg, tx, rx);
+}
+
+static int xfer_compare(const struct spi_config *cfg,
+			void *tx, void *rx, size_t len)
+{
+	struct spi_buf tb = { .buf = tx, .len = len };
+	struct spi_buf rb = { .buf = rx, .len = len };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
+	int ret;
+
+	memset(rx, 0, len);
+	ret = do_xfer(cfg, &ts, &rs);
+	if (ret < 0) {
+		return ret;
+	}
+	return memcmp(tx, rx, len) == 0 ? 0 : -EIO;
+}
+
+static inline struct spi_config lb_cfg(uint32_t op_extra,
+					     uint32_t word, uint32_t freq)
+{
+	uint32_t operation = SPI_OP_MODE_MASTER |
+			     SPI_WORD_SET(word) | op_extra;
+
+	if (IS_ENABLED(CONFIG_TEST_SPI_INTERNAL_LOOPBACK)) {
+		operation |= SPI_MODE_LOOP;
+	}
+	return spi_test_config(operation, freq);
+}
+
+
+static int sc_word_sweep(void)
+{
+	static const uint8_t pat[] = {0xDE, 0xAD, 0xBE, 0xEF};
+	static uint8_t tx[32], rx[32];
+	const uint32_t *words = LB_WORDS;
+	const size_t n_words = ARRAY_SIZE(LB_WORDS);
+	int fail = 0;
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = pat[i & 3U];
+	}
+	for (size_t w = 0; w < n_words; w++) {
+		struct spi_config cfg = lb_cfg(0, words[w], LB_DEFAULT_FREQ_HZ);
+		int ret = xfer_compare(&cfg, tx, rx, sizeof(tx));
+
+		if (ret) {
+			LOG_ERR("word_sweep w=%u ret=%d", words[w], ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_walking_bit(void)
+{
+	static const size_t sizes[] = {1, 4, 16, 64};
+	static uint8_t tx[LB_BUF_MAX], rx[LB_BUF_MAX];
+	struct spi_config cfg = lb_cfg(0, 8, LB_DEFAULT_FREQ_HZ);
+	int fail = 0;
+
+	for (size_t s = 0; s < ARRAY_SIZE(sizes); s++) {
+		size_t len = sizes[s];
+
+		for (size_t i = 0; i < len; i++) {
+			tx[i] = (uint8_t)(1U << (i & 7U));
+		}
+		int ret = xfer_compare(&cfg, tx, rx, len);
+
+		if (ret) {
+			LOG_ERR("walking_bit len=%zu ret=%d", len, ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_cpol_cpha(void)
+{
+	static const uint32_t modes[] = {
+		0,
+		SPI_MODE_CPHA,
+		SPI_MODE_CPOL,
+		SPI_MODE_CPOL | SPI_MODE_CPHA,
+	};
+	static uint8_t tx[16], rx[16];
+	int fail = 0;
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)(0x5A ^ i);
+	}
+	for (size_t m = 0; m < ARRAY_SIZE(modes); m++) {
+		struct spi_config cfg = lb_cfg(modes[m], 8, LB_DEFAULT_FREQ_HZ);
+		int ret = xfer_compare(&cfg, tx, rx, sizeof(tx));
+
+		if (ret) {
+			LOG_ERR("cpol_cpha mode=0x%02x ret=%d", modes[m], ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+static int sc_tmod_tx(void)
+{
+	uint8_t tx[16];
+	struct spi_buf tb = { .buf = tx, .len = sizeof(tx) };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_config cfg = lb_cfg(0, 8, LB_DEFAULT_FREQ_HZ);
+	int ret;
+
+	memset(tx, 0xA5, sizeof(tx));
+	ret = do_xfer(&cfg, &ts, NULL);
+	if (ret < 0) {
+		LOG_ERR("tmod_tx ret=%d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int sc_config_reuse(void)
+{
+	static struct spi_config cfg;
+	uint8_t tx[16], rx[16];
+	struct spi_buf tb = { .buf = tx, .len = sizeof(tx) };
+	struct spi_buf rb = { .buf = rx, .len = sizeof(rx) };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
+	int ret;
+
+	cfg = lb_cfg(0, 8, LB_DEFAULT_FREQ_HZ);
+	memset(tx, 0x5A, sizeof(tx));
+
+	for (int pass = 0; pass < 2; pass++) {
+		memset(rx, 0, sizeof(rx));
+		ret = do_xfer(&cfg, &ts, &rs);
+		if (ret < 0 || memcmp(tx, rx, sizeof(tx)) != 0) {
+			LOG_ERR("config_reuse pass=%d ret=%d", pass, ret);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int sc_miso_not_stuck(void)
+{
+	uint8_t tx[32], rx[32];
+	struct spi_config cfg = lb_cfg(0, 8, LB_DEFAULT_FREQ_HZ);
+	bool all_zero = true, all_ff = true;
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)i;
+	}
+	memset(rx, 0xCC, sizeof(rx));
+
+	int ret = xfer_compare(&cfg, tx, rx, sizeof(tx));
+
+	if (ret < 0) {
+		LOG_ERR("miso_not_stuck xfer ret=%d", ret);
+		return 1;
+	}
+	for (size_t i = 0; i < sizeof(rx); i++) {
+		if (rx[i] != 0x00U) {
+			all_zero = false;
+		}
+		if (rx[i] != 0xFFU) {
+			all_ff = false;
+		}
+	}
+	if (all_zero || all_ff) {
+		LOG_ERR("MISO stuck %s", all_zero ? "LOW" : "HIGH");
+		return 1;
+	}
+	return 0;
+}
+
+static int sc_freq_sweep(void)
+{
+	static const uint32_t freqs_hz[] = {
+		1U  * SPI_FREQ_MHZ,
+		5U  * SPI_FREQ_MHZ,
+		12U * SPI_FREQ_MHZ,
+		25U * SPI_FREQ_MHZ,
+	};
+	static uint8_t tx[32], rx[32];
+	int fail = 0;
+
+	for (size_t i = 0; i < sizeof(tx); i++) {
+		tx[i] = (uint8_t)(0xC3 ^ i);
+	}
+	for (size_t f = 0; f < ARRAY_SIZE(freqs_hz); f++) {
+		struct spi_config cfg = lb_cfg(0, 8, freqs_hz[f]);
+		int ret = xfer_compare(&cfg, tx, rx, sizeof(tx));
+
+		if (ret) {
+			LOG_ERR("freq_sweep %u Hz ret=%d", freqs_hz[f], ret);
+			fail++;
+		}
+	}
+	return fail;
+}
+
+struct scenario {
+	const char *name;
+	int (*fn)(void);
+};
+
+static const struct scenario scenarios[] = {
+	{ "word_sweep",   sc_word_sweep    },
+	{ "walking_bit",  sc_walking_bit   },
+	{ "cpol_cpha",    sc_cpol_cpha     },
+	{ "tmod_tx",      sc_tmod_tx       },
+	{ "config_reuse", sc_config_reuse  },
+	{ "freq_sweep",   sc_freq_sweep    },
+};
+
+static int run_loopback(void)
+{
+	int total = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(scenarios); i++) {
+		int f = scenarios[i].fn();
+
+		TC_PRINT("  %-12s : %s (%d)\n", scenarios[i].name,
+			f ? "FAIL" : "OK", f);
+		total += f;
+	}
+	return total;
+}
+
+
+ZTEST(test_spi_loopback, test_loopback_sync)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI controller not ready");
+
+	TC_PRINT("=== SPI loopback (SYNC) ===\n");
+	int fail = run_loopback();
+
+	int wf = sc_miso_not_stuck();
+
+	TC_PRINT("  %-12s : %s (%d)\n", "miso_wiring", wf ? "FAIL" : "OK", wf);
+	fail += wf;
+
+	zassert_equal(fail, 0, "SYNC loopback: %d scenario failure(s)", fail);
+}
+
+
+static void loopback_suite_before(void *fixture)
+{
+	test_before_func(fixture);
+}
+
+ZTEST_SUITE(test_spi_loopback, NULL, NULL, loopback_suite_before, NULL, NULL);
+
+#endif /* CONFIG_TEST_SPI_LOOPBACK */

--- a/tests/drivers/spi/src/test_spi_negative.c
+++ b/tests/drivers/spi/src/test_spi_negative.c
@@ -1,0 +1,209 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/sys/util_macro.h>
+
+#if IS_ENABLED(CONFIG_TEST_SPI_NEGATIVE)
+
+#include "test_spi_common.h"
+
+LOG_MODULE_REGISTER(alif_spi_neg, LOG_LEVEL_INF);
+
+static const struct device *const controller_dev =
+	DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+static struct spi_config neg_test_cfg(uint32_t extra_flags,
+					uint32_t word_size,
+					uint32_t freq_hz)
+{
+	struct spi_config cfg = {
+		.frequency = freq_hz,
+		.operation = (spi_operation_t)(
+			SPI_OP_MODE_MASTER |
+			extra_flags | SPI_WORD_SET(word_size)),
+		.slave = 0,
+	};
+
+	return cfg;
+}
+
+static int do_loopback_xfer(const struct spi_config *cfg,
+			    void *tx, size_t tx_len,
+			    void *rx, size_t rx_len)
+{
+	struct spi_buf tb = { .buf = tx, .len = tx_len };
+	struct spi_buf rb = { .buf = rx, .len = rx_len };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
+
+	struct spi_buf_set *txs = tx_len ? &ts : NULL;
+	struct spi_buf_set *rxs = rx_len ? &rs : NULL;
+
+	return spi_test_transceive(controller_dev, cfg, txs, rxs, false);
+}
+
+
+static int subtest_lsb_first(void)
+{
+	struct spi_config cfg = neg_test_cfg(SPI_TRANSFER_LSB,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  LSB-first: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_release_wrong_cfg(void)
+{
+	struct spi_config cfg1 = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+	uint8_t rx[4];
+	int ret;
+
+	ret = do_loopback_xfer(&cfg1, tx, sizeof(tx),
+			       rx, sizeof(rx));
+	if (ret < 0) {
+		LOG_ERR("  release_wrong: initial xfer failed %d", ret);
+		return 1;
+	}
+
+	struct spi_config cfg2 = neg_test_cfg(0, 16U, 2 * SPI_FREQ_MHZ);
+
+	ret = spi_release(controller_dev, &cfg2);
+	if (ret != -EINVAL) {
+		LOG_ERR("  release_wrong: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_freq_exceed(void)
+{
+	struct spi_config cfg = neg_test_cfg(0, 8U, UINT32_MAX);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  freq_exceed: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_null_buf(void)
+{
+	struct spi_config cfg = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
+	struct spi_buf tb = { .buf = NULL, .len = 16 };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	int ret = spi_test_transceive(controller_dev, &cfg, &ts, NULL, false);
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  null_buf: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_word_exceed(void)
+{
+	struct spi_config cfg = neg_test_cfg(0, 33U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -ENOTSUP) {
+		LOG_ERR("  word_exceed: expected -ENOTSUP, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_word_zero_invalid(void)
+{
+	struct spi_config cfg = neg_test_cfg(0, 0U, SPI_FREQ_MHZ);
+	int ret = spi_test_transceive(controller_dev, &cfg, NULL, NULL, false);
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  word_zero: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_word_len_unaligned(void)
+{
+	struct spi_config cfg = neg_test_cfg(0, 16U, SPI_FREQ_MHZ);
+	uint8_t tx[3] = {0xAA, 0xBB, 0xCC};
+	uint8_t rx[3];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  word_len_unaligned: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+
+ZTEST(test_spi_negative, test_comprehensive_negative)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+
+	int fail = 0;
+	int f;
+
+	TC_PRINT("=== Comprehensive Negative Validation ===\n");
+
+	f = subtest_lsb_first();
+	fail += f;
+	TC_PRINT("  lsb_first        : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_release_wrong_cfg();
+	fail += f;
+	TC_PRINT("  release_wrong    : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_freq_exceed();
+	fail += f;
+	TC_PRINT("  freq_exceed      : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_null_buf();
+	fail += f;
+	TC_PRINT("  null_buf         : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_word_exceed();
+	fail += f;
+	TC_PRINT("  word_exceed      : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_word_zero_invalid();
+	fail += f;
+	TC_PRINT("  word_zero        : %s\n", f ? "FAIL" : "OK");
+
+	f = subtest_word_len_unaligned();
+	fail += f;
+	TC_PRINT("  word_len_unalign : %s\n", f ? "FAIL" : "OK");
+
+	TC_PRINT("=== Result: %d failures ===\n", fail);
+	zassert_equal(fail, 0, "Comprehensive negative: %d failures", fail);
+}
+
+ZTEST_SUITE(test_spi_negative, NULL, NULL, test_before_func,
+	    NULL, NULL);
+
+#endif /* CONFIG_TEST_SPI_NEGATIVE */

--- a/tests/drivers/spi/src/test_spi_perf.c
+++ b/tests/drivers/spi/src/test_spi_perf.c
@@ -1,0 +1,95 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/sys/util_macro.h>
+
+#if IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+
+#include "test_spi_threads.h"
+
+LOG_MODULE_REGISTER(alif_spi_perf, LOG_LEVEL_INF);
+
+static void assert_mosi_perf_clean(const char *tag)
+{
+	zassert_equal(ctrl_ret_tx, 0U,
+		      "%s: controller TX failures=%u", tag, ctrl_ret_tx);
+	zassert_equal(tgt_ret_rx, 0U,
+		      "%s: target RX failures=%u", tag, tgt_ret_rx);
+	TC_PRINT("%s: OK\n", tag);
+}
+
+static void assert_miso_perf_clean(const char *tag)
+{
+	zassert_equal(tgt_ret_tx, 0U,
+		      "%s: target TX failures=%u", tag, tgt_ret_tx);
+	zassert_equal(ctrl_ret_rx, 0U,
+		      "%s: controller RX failures=%u", tag, ctrl_ret_rx);
+	TC_PRINT("%s: OK\n", tag);
+}
+
+static void assert_xcv_perf_clean(const char *tag)
+{
+	zassert_equal(ctrl_ret_tx, 0U,
+		      "%s: controller TX failures=%u", tag, ctrl_ret_tx);
+	zassert_equal(tgt_ret_tx, 0U,
+		      "%s: target TX failures=%u", tag, tgt_ret_tx);
+	zassert_equal(ctrl_ret_rx, 0U,
+		      "%s: controller RX failures=%u", tag, ctrl_ret_rx);
+	zassert_equal(tgt_ret_rx, 0U,
+		      "%s: target RX failures=%u", tag, tgt_ret_rx);
+	TC_PRINT("%s: OK\n", tag);
+}
+
+/* Controller TX -> Target RX */
+
+ZTEST(test_spi_perf_mosi, test_perf_mosi)
+{
+	zassert_ok(spi_test_prepare_data(ctrl_txdata,
+					 spi_test_pattern(0xBEEF),
+					 SPI_TEST_BUFF_SIZE_PERF),
+		   "Failed to prepare controller TX data");
+	run_spi_test_threads(controller_spi_transmit, target_spi_receive);
+	assert_mosi_perf_clean("MOSI perf");
+}
+
+ZTEST_SUITE(test_spi_perf_mosi, NULL, NULL, test_before_func, NULL, NULL);
+
+/* Target TX -> Controller RX */
+
+ZTEST(test_spi_perf_miso, test_perf_miso)
+{
+	zassert_ok(spi_test_prepare_data(tgt_txdata,
+					 spi_test_pattern(0xCAFE),
+					 SPI_TEST_BUFF_SIZE_PERF),
+		   "Failed to prepare target TX data");
+	run_spi_test_threads(controller_receive, target_send);
+	assert_miso_perf_clean("MISO perf");
+}
+
+ZTEST_SUITE(test_spi_perf_miso, NULL, NULL, test_before_func, NULL, NULL);
+
+/* Full-duplex Controller <-> Target */
+
+ZTEST(test_spi_perf_transceive, test_perf_xcv)
+{
+	zassert_ok(spi_test_prepare_data(ctrl_txdata,
+					 spi_test_pattern(0xBEEF),
+					 SPI_TEST_BUFF_SIZE_PERF),
+		   "Failed to prepare controller TX data");
+	zassert_ok(spi_test_prepare_data(tgt_txdata,
+					 spi_test_pattern(0xCAFE),
+					 SPI_TEST_BUFF_SIZE_PERF),
+		   "Failed to prepare target TX data");
+	run_spi_test_threads(controller_spi, target_spi);
+	assert_xcv_perf_clean("XCV perf");
+}
+
+ZTEST_SUITE(test_spi_perf_transceive, NULL, NULL, test_before_func, NULL, NULL);
+
+#endif /* CONFIG_TEST_SPI_PERFORMANCE */

--- a/tests/drivers/spi/src/test_spi_stress.c
+++ b/tests/drivers/spi/src/test_spi_stress.c
@@ -1,0 +1,173 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * SPI stress validation suite.
+ *
+ * Goal: exercise long-running, back-to-back SPI activity to surface
+ *       bus-stability issues that a single transfer cannot reveal:
+ *         - FIFO leakage between transfers
+ *         - DMA channel reuse / state retention
+ *         - Interrupt and polling-path stability under churn
+ *
+ * Design (one-transfer-per-iteration):
+ *   Each iteration is a single full-duplex transceive between the
+ *   controller (SPI1) and target (SPI0), driven by the proven
+ *   `run_spi_test_threads(controller_spi, target_spi)` helper used by
+ *   the performance/TI/NI suites. Spawning fresh threads per iteration
+ *   keeps the slave from getting stuck if the bus desyncs - thread
+ *   join naturally bounds each iteration.
+ *
+ * Variation is done by mutating the shared ctrl_txdata / tgt_txdata
+ * buffers between iterations.
+ *
+ * Length variation is intentionally NOT done here; the boundary suite
+ * covers FIFO-edge transfer sizes. Stress focuses on volume.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+#if IS_ENABLED(CONFIG_TEST_SPI_STRESS)
+
+#include "test_spi_threads.h"
+
+LOG_MODULE_REGISTER(alif_spi_stress, LOG_LEVEL_INF);
+
+#define STRESS_DEFAULT_ITERS    100
+#define STRESS_PATTERN_ITERS    50
+
+static void fill_tx_pattern(uint32_t seed_ctrl, uint32_t seed_tgt)
+{
+	for (size_t i = 0; i < SPI_TEST_BUFF_SIZE; i++) {
+		ctrl_txdata[i] = seed_ctrl ^ (uint32_t)i;
+		tgt_txdata[i]  = seed_tgt  ^ (uint32_t)i;
+	}
+}
+
+static uint32_t stress_seed(uint16_t idx)
+{
+	static const uint16_t bases[] = {
+		0xA5A5, 0x5A5A, 0xDEAD, 0xCAFE,
+		0x1234, 0x8765, 0x0000, 0xFFFF,
+	};
+
+	return spi_test_seed32(bases[idx % ARRAY_SIZE(bases)]);
+}
+
+/*
+ * Scenario 1: fixed pattern, many iterations.
+ * Detects FIFO leakage and state retention across repeated transfers.
+ */
+static int sc_repeat(bool async)
+{
+	atomic_set(&spi_test_async_mode, async ? 1 : 0);
+
+	for (int i = 0; i < STRESS_DEFAULT_ITERS; i++) {
+		fill_tx_pattern(stress_seed(0), stress_seed(1));
+		atomic_clear(&err_count);
+
+		/* run_spi_test_threads asserts err_count == 0 internally,
+		 * so the test aborts on the first failing iteration.
+		 */
+		run_spi_test_threads(controller_spi, target_spi);
+	}
+	atomic_clear(&spi_test_async_mode);
+	return 0;
+}
+
+/*
+ * Scenario 2: rotating patterns.
+ * Detects pattern-dependent bugs (e.g. all-zero or all-one sensitive
+ * paths in the IP, DMA word alignment).
+ */
+static int sc_pattern_rotate(bool async)
+{
+	atomic_set(&spi_test_async_mode, async ? 1 : 0);
+
+	for (int i = 0; i < STRESS_PATTERN_ITERS; i++) {
+		uint32_t s_ctrl = stress_seed((uint16_t)i);
+		uint32_t s_tgt  = stress_seed((uint16_t)(i + 3));
+
+		fill_tx_pattern(s_ctrl, s_tgt);
+		atomic_clear(&err_count);
+
+		/* run_spi_test_threads asserts err_count == 0 internally,
+		 * so the test aborts on the first failing iteration.
+		 */
+		run_spi_test_threads(controller_spi, target_spi);
+	}
+	atomic_clear(&spi_test_async_mode);
+	return 0;
+}
+
+struct stress_scenario {
+	const char *name;
+	int (*fn)(bool async);
+};
+
+static const struct stress_scenario scenarios[] = {
+	{ "repeat",          sc_repeat         },
+	{ "pattern_rotate",  sc_pattern_rotate },
+};
+
+static int run_stress(bool async)
+{
+	int total = 0;
+	int64_t t_start = k_uptime_get();
+
+	for (size_t i = 0; i < ARRAY_SIZE(scenarios); i++) {
+		int f = scenarios[i].fn(async);
+
+		TC_PRINT("  %-16s : %s\n", scenarios[i].name,
+			 f ? "FAIL" : "OK");
+		total += f;
+	}
+	TC_PRINT("Stress run total: %lld ms\n",
+		 (long long)(k_uptime_get() - t_start));
+	return total;
+}
+
+ZTEST(test_spi_stress, test_stress_sync)
+{
+	zassert_true(spi_test_device_ready(DEVICE_DT_GET(SPI_CONTROLLER_NODE),
+					   "Controller"),
+		     "SPI controller not ready");
+	zassert_true(spi_test_device_ready(DEVICE_DT_GET(SPI_TARGET_NODE),
+					   "Target"),
+		     "SPI target not ready");
+
+	TC_PRINT("=== SPI stress (SYNC) ===\n");
+	int fail = run_stress(false);
+
+	zassert_equal(fail, 0, "SYNC stress: %d scenario failure(s)", fail);
+}
+
+#if IS_ENABLED(CONFIG_SPI_ASYNC)
+ZTEST(test_spi_stress, test_stress_async)
+{
+	zassert_true(spi_test_device_ready(DEVICE_DT_GET(SPI_CONTROLLER_NODE),
+					   "Controller"),
+		     "SPI controller not ready");
+	zassert_true(spi_test_device_ready(DEVICE_DT_GET(SPI_TARGET_NODE),
+					   "Target"),
+		     "SPI target not ready");
+
+	TC_PRINT("=== SPI stress (ASYNC) ===\n");
+	int fail = run_stress(true);
+
+	zassert_equal(fail, 0, "ASYNC stress: %d scenario failure(s)", fail);
+}
+#endif /* CONFIG_SPI_ASYNC */
+
+ZTEST_SUITE(test_spi_stress, NULL, NULL, test_before_func, NULL, NULL);
+
+#endif /* CONFIG_TEST_SPI_STRESS */

--- a/tests/drivers/spi/src/test_spi_threads.c
+++ b/tests/drivers/spi/src/test_spi_threads.c
@@ -1,0 +1,750 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include "test_spi_threads.h"
+
+LOG_MODULE_REGISTER(alif_spi_threads, LOG_LEVEL_INF);
+
+/* Controller-side sync/async selector for thread-based tests.
+ * Target-side always stays sync — the slave must have its RX armed
+ * synchronously before the controller clocks data.
+ */
+static int controller_xfer(const struct device *dev,
+			   const struct spi_config *cfg,
+			   const struct spi_buf_set *tx,
+			   const struct spi_buf_set *rx)
+{
+	if (atomic_get(&spi_test_async_mode)) {
+		return spi_test_transceive_async(dev, cfg, tx, rx, false);
+	}
+	return spi_transceive(dev, cfg, tx, rx);
+}
+
+
+void run_spi_test_threads(void (*controller_func)(void *, void *, void *),
+			  void (*target_func)(void *, void *, void *))
+{
+	int higher_prio =
+		MIN(SPI_TEST_PRIORITY_CONTROLLER, SPI_TEST_PRIORITY_TARGET);
+	int lower_prio =
+		MAX(SPI_TEST_PRIORITY_CONTROLLER, SPI_TEST_PRIORITY_TARGET);
+	int controller_prio;
+	int target_prio;
+
+	if (IS_ENABLED(CONFIG_TEST_SPI_USE_DMA)) {
+		/* Sample parity: prefer higher
+		 * controller priority in DMA mode.
+		 */
+		controller_prio = higher_prio;
+		target_prio = lower_prio;
+	} else {
+		/* PIO robustness: prefer higher target
+		 * priority to arm RX first.
+		 */
+		controller_prio = lower_prio;
+		target_prio = higher_prio;
+	}
+
+	TC_PRINT("Creating SPI test threads (controller: %p, target: %p)\n",
+		 controller_func, target_func);
+	TC_PRINT("Thread scheduling: mode=%s controller_prio=%d target_prio=%d\n",
+		 IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ? "dma" : "pio",
+		 controller_prio, target_prio);
+
+	k_tid_t tids = k_thread_create(&target_thread_data, target_stack,
+				       SPI_TEST_STACKSIZE, target_func,
+				       (void *)1, NULL, NULL,
+				       target_prio, 0, K_FOREVER);
+	zassert_not_null(tids, "Failed to create target thread");
+
+	k_tid_t tidm = k_thread_create(
+		&controller_thread_data, controller_stack,
+		SPI_TEST_STACKSIZE, controller_func,
+		(void *)1, NULL, NULL,
+		controller_prio, 0, K_FOREVER);
+	zassert_not_null(tidm, "Failed to create controller thread");
+
+	LOG_DBG("Creating SPI test threads (controller: %p, target: %p)",
+		 &controller_thread_data, &target_thread_data);
+
+	LOG_DBG("Starting target thread");
+	k_thread_start(&target_thread_data);
+
+	k_msleep(100);
+
+	LOG_DBG("Starting controller thread");
+	k_thread_start(&controller_thread_data);
+
+	LOG_DBG("Waiting for threads to complete");
+	k_thread_join(&target_thread_data, K_FOREVER);
+	k_thread_join(&controller_thread_data, K_FOREVER);
+
+	TC_PRINT("SPI test threads completed (errors: %ld)\n",
+		 atomic_get(&err_count));
+	zassert_equal(atomic_get(&err_count), 0,
+		      "Test case failed with %ld errors",
+		      atomic_get(&err_count));
+}
+
+#if !IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+
+static int func_controller_transmit(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | spi_test_op_flags |
+		SPI_TEST_WORD_SIZE,
+		1 * SPI_FREQ_MHZ);
+
+	LOG_DBG("Controller: Starting simple transceive");
+	int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret >= 0) {
+		TC_PRINT("Controller transceive success: %d\n", ret);
+	} else {
+		LOG_ERR("Controller transceive failed: %d", ret);
+		atomic_inc(&err_count);
+	}
+
+	return ret;
+}
+
+static int func_target_receive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.frequency = 1 * SPI_FREQ_MHZ,
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	LOG_DBG("Target: Starting simple transceive");
+	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret >= 0) {
+		TC_PRINT("Target transceive success: %d\n", ret);
+		ret = memcmp(ctrl_txdata, tgt_rxdata, length);
+		if (ret) {
+			LOG_ERR("Target RX / Controller TX data mismatch: %d", ret);
+			atomic_inc(&err_count);
+		} else {
+			TC_PRINT("Target RX / Controller TX data match\n");
+		}
+	} else {
+		LOG_ERR("Target transceive failed: %d", ret);
+		atomic_inc(&err_count);
+	}
+
+	return ret;
+}
+
+void controller_spi_transmit(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+	TC_PRINT("MOSI: controller TX (word %ld bits)\n",
+		 transceive_word);
+
+	func_controller_transmit(dev);
+}
+
+void target_spi_receive(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+	TC_PRINT("MOSI: target RX (word %ld bits)\n",
+		 transceive_word);
+	func_target_receive(dev);
+}
+
+int func_target_transmit(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.frequency = 1 * SPI_FREQ_MHZ,
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	LOG_DBG("Target: Starting simple transceive (word size: %ld)",
+		IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ?
+		SPI_TEST_DMA_WORD_SIZE : transceive_word);
+	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret >= 0) {
+		TC_PRINT("Target transceive success: %d\n", ret);
+	} else {
+		LOG_ERR("Target transceive failed: %d", ret);
+		atomic_inc(&err_count);
+	}
+
+	return ret;
+}
+
+int func_controller_receive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | spi_test_op_flags |
+		SPI_TEST_WORD_SIZE,
+		1 * SPI_FREQ_MHZ);
+
+	LOG_DBG("Controller: Starting simple transceive");
+	int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		LOG_ERR("Controller transceive failed: %d", ret);
+		atomic_inc(&err_count);
+	} else {
+		int cmp_ret = memcmp(tgt_txdata, ctrl_rxdata, length);
+
+		if (cmp_ret) {
+			LOG_ERR("RX: %08x %08x %08x %08x %08x %08x %08x %08x",
+				ctrl_rxdata[0], ctrl_rxdata[1],
+				ctrl_rxdata[2], ctrl_rxdata[3],
+				ctrl_rxdata[4], ctrl_rxdata[5],
+				ctrl_rxdata[6], ctrl_rxdata[7]);
+			LOG_ERR("TX: %08x %08x %08x %08x %08x %08x %08x %08x",
+				tgt_txdata[0], tgt_txdata[1],
+				tgt_txdata[2], tgt_txdata[3],
+				tgt_txdata[4], tgt_txdata[5],
+				tgt_txdata[6], tgt_txdata[7]);
+			LOG_ERR("Controller RX / Target TX data mismatch: %d", cmp_ret);
+			atomic_inc(&err_count);
+		} else {
+			TC_PRINT("Controller RX / Target TX data match\n");
+		}
+	}
+
+	return ret;
+}
+
+void controller_receive(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+	TC_PRINT("MISO: controller RX (word %ld bits)\n",
+		 transceive_word);
+
+	func_controller_receive(dev);
+}
+
+void target_send(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+	TC_PRINT("MISO: target TX (word %ld bits)\n",
+		 transceive_word);
+	func_target_transmit(dev);
+}
+
+static int func_controller_transceive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | spi_test_op_flags |
+		SPI_TEST_WORD_SIZE,
+		1 * SPI_FREQ_MHZ);
+
+	LOG_DBG("Controller: Starting simple transceive (word size: %ld)",
+		IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ?
+		SPI_TEST_DMA_WORD_SIZE : transceive_word);
+	int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		LOG_ERR("Controller transceive failed: %d", ret);
+		atomic_inc(&err_count);
+		return ret;
+	}
+
+	LOG_DBG("Controller TX: %08x %08x %08x %08x %08x",
+		ctrl_txdata[0], ctrl_txdata[1], ctrl_txdata[2],
+		ctrl_txdata[3], ctrl_txdata[4]);
+	LOG_DBG("Controller RX: %08x %08x %08x %08x %08x",
+		ctrl_rxdata[0], ctrl_rxdata[1], ctrl_rxdata[2],
+		ctrl_rxdata[3], ctrl_rxdata[4]);
+
+	ret = memcmp(ctrl_rxdata, tgt_txdata, length);
+	if (ret) {
+		LOG_ERR("Controller RX / Target TX data mismatch: %d", ret);
+		atomic_inc(&err_count);
+	} else {
+		TC_PRINT("Controller RX / Target TX data match\n");
+	}
+
+	return ret;
+}
+
+static int func_target_transceive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE * sizeof(uint32_t);
+
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.frequency = 1 * SPI_FREQ_MHZ,
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	LOG_DBG("Target: Starting simple transceive");
+	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		LOG_ERR("Target transceive failed: %d", ret);
+		atomic_inc(&err_count);
+		return ret;
+	}
+
+	LOG_DBG("Target TX: %08x %08x %08x %08x %08x",
+		tgt_txdata[0], tgt_txdata[1], tgt_txdata[2],
+		tgt_txdata[3], tgt_txdata[4]);
+	LOG_DBG("Target RX: %08x %08x %08x %08x %08x",
+		tgt_rxdata[0], tgt_rxdata[1], tgt_rxdata[2],
+		tgt_rxdata[3], tgt_rxdata[4]);
+
+	ret = memcmp(ctrl_txdata, tgt_rxdata, length);
+	if (ret) {
+		LOG_ERR("Target RX / Controller TX data mismatch: %d", ret);
+		atomic_inc(&err_count);
+	} else {
+		TC_PRINT("Target RX / Controller TX data match\n");
+	}
+
+	return ret;
+}
+
+void controller_spi(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+
+	func_controller_transceive(dev);
+}
+
+void target_spi(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+	func_target_transceive(dev);
+}
+
+#else /* CONFIG_TEST_SPI_PERFORMANCE */
+
+#define PERF_FREQ_MIN_MHZ 1U
+#define PERF_FREQ_MAX_MHZ SPI_TEST_MAX_FREQUENCY
+
+static int perf_controller_send(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+		0);
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(ctrl_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret == 0) {
+			TC_PRINT("Controller TX @%u Hz: OK\n",
+				 freq * SPI_FREQ_MHZ);
+		} else {
+			LOG_ERR("Controller TX @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			ctrl_ret_tx++;
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	return 0;
+}
+
+static int perf_target_receive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(tgt_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret >= 0) {
+			ret = memcmp(ctrl_txdata, tgt_rxdata, length);
+			if (ret != 0) {
+				LOG_ERR("Target RX @%u Hz: data mismatch "
+					"(word %ld)", freq * SPI_FREQ_MHZ,
+					transceive_word);
+				tgt_ret_rx++;
+			} else {
+				TC_PRINT("Target RX @%u Hz: data match\n",
+					 freq * SPI_FREQ_MHZ);
+			}
+		} else {
+			LOG_ERR("Target RX @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			tgt_ret_rx++;
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	return 0;
+}
+
+void controller_spi_transmit(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+
+	perf_controller_send(dev);
+}
+
+void target_spi_receive(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+
+	perf_target_receive(dev);
+}
+
+static int perf_target_transmit(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(tgt_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret >= 0) {
+			TC_PRINT("Target TX @%u Hz: OK\n",
+				 freq * SPI_FREQ_MHZ);
+		} else {
+			LOG_ERR("Target TX @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			tgt_ret_tx++;
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	return 0;
+}
+
+static int perf_controller_receive(const struct device *dev)
+{
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+		0);
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(ctrl_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret < 0) {
+			LOG_ERR("Controller RX @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			ctrl_ret_rx++;
+		} else {
+			ret = memcmp(tgt_txdata, ctrl_rxdata, length);
+
+			if (ret == 0) {
+				TC_PRINT("Controller RX @%u Hz: data match\n",
+					 freq * SPI_FREQ_MHZ);
+			} else {
+				LOG_ERR("Controller RX @%u Hz: data mismatch "
+					"(word %ld)", freq * SPI_FREQ_MHZ,
+					transceive_word);
+				spi_test_log_first_mismatch(
+					tgt_txdata, ctrl_rxdata,
+					SPI_TEST_BUFF_SIZE_PERF,
+					"Controller RX perf / Target TX");
+				ctrl_ret_rx++;
+			}
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	return 0;
+}
+
+void controller_receive(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+
+	perf_controller_receive(dev);
+}
+
+void target_send(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+
+	perf_target_transmit(dev);
+}
+
+void controller_spi(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_CONTROLLER_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Controller"),
+		     "Controller device not ready");
+
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+
+	struct spi_buf tx_buf = { .buf = ctrl_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = spi_test_config(
+		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+		0);
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(ctrl_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret < 0) {
+			LOG_ERR("Controller transceive @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			ctrl_ret_tx++;
+		} else {
+			ret = memcmp(ctrl_rxdata, tgt_txdata, length);
+			if (ret != 0) {
+				LOG_ERR("Controller RX / Target TX mismatch @%u Hz",
+					freq * SPI_FREQ_MHZ);
+				ctrl_ret_rx++;
+			} else {
+				TC_PRINT("Controller transceive @%u Hz: data match\n",
+					 freq * SPI_FREQ_MHZ);
+			}
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	TC_PRINT("Controller transceive perf sweep complete\n");
+}
+
+void target_spi(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1); ARG_UNUSED(p2); ARG_UNUSED(p3);
+
+	const struct device *dev = DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(dev, "Target"),
+		     "Target device not ready");
+
+	int length = SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t);
+
+	struct spi_buf tx_buf = { .buf = tgt_txdata, .len = length };
+	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
+	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
+
+	struct spi_config cnfg = {
+		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+			SPI_TEST_WORD_SIZE,
+		.slave = 0,
+	};
+
+	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
+		cnfg.frequency = freq * SPI_FREQ_MHZ;
+		memset(tgt_rxdata, 0, length);
+
+		uint32_t cyc_start = k_cycle_get_32();
+		int64_t time_start = k_uptime_get();
+
+		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+
+		int64_t time_end = k_uptime_get();
+		uint32_t cyc_end = k_cycle_get_32();
+
+		if (ret < 0) {
+			LOG_ERR("Target transceive @%u Hz failed: %d",
+				freq * SPI_FREQ_MHZ, ret);
+			tgt_ret_tx++;
+		} else {
+			ret = memcmp(ctrl_txdata, tgt_rxdata, length);
+			if (ret != 0) {
+				LOG_ERR("Target RX / Controller TX mismatch @%u Hz",
+					freq * SPI_FREQ_MHZ);
+				tgt_ret_rx++;
+			} else {
+				TC_PRINT("Target transceive @%u Hz: data match\n",
+					 freq * SPI_FREQ_MHZ);
+			}
+		}
+
+		TC_PRINT("  cycles: %u, time: %llu ms\n",
+			cyc_end - cyc_start,
+			(unsigned long long)(time_end - time_start));
+	}
+	TC_PRINT("Target transceive perf sweep complete\n");
+}
+
+#endif /* CONFIG_TEST_SPI_PERFORMANCE */

--- a/tests/drivers/spi/src/test_spi_threads.h
+++ b/tests/drivers/spi/src/test_spi_threads.h
@@ -1,0 +1,23 @@
+/* Copyright Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef TEST_SPI_THREADS_H_
+#define TEST_SPI_THREADS_H_
+
+#include "test_spi_common.h"
+
+/* Spawn controller + target threads, join, and assert err_count == 0 */
+void run_spi_test_threads(void (*controller_func)(void *, void *, void *),
+			  void (*target_func)(void *, void *, void *));
+
+/* Simple functional SPI functions for DMA compatibility */
+int func_target_transmit(const struct device *dev);
+int func_controller_receive(const struct device *dev);
+
+#endif /* TEST_SPI_THREADS_H_ */

--- a/tests/drivers/spi/testcase.yaml
+++ b/tests/drivers/spi/testcase.yaml
@@ -1,0 +1,148 @@
+common:
+  tags:
+    - drivers
+    - spi
+    - gpio
+  extra_conf_files:
+    - prj.conf
+  platform_allow:
+    - alif_e7_dk/ae722f80f55d5xx/rtss_he
+    - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+    - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
+
+tests:
+  drivers.spi.alif.loopback:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_LOOPBACK=y
+
+  drivers.spi.alif.loopback.explicit:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_LOOPBACK=y
+      - CONFIG_TEST_SPI_WORD_SIZE=16
+
+  drivers.spi.alif.perf:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+
+  drivers.spi.alif.perf.dma:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+      - boards/spi_DMA.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.perf.dma.evtrtr:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+      - boards/spi_DMA_evtrtr.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.negative:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_NEGATIVE=y
+
+  drivers.spi.alif.loopback.ext:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_LOOPBACK=y
+      - CONFIG_TEST_SPI_INTERNAL_LOOPBACK=n
+
+  drivers.spi.alif.boundary:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_BOUNDARY=y
+
+  drivers.spi.alif.boundary.ext:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_BOUNDARY=y
+      - CONFIG_TEST_SPI_INTERNAL_LOOPBACK=n
+
+  drivers.spi.alif.stress:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+
+  drivers.spi.alif.stress.dma:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+      - boards/spi_DMA.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.stress.dma.evtrtr:
+    extra_dtc_overlay_files:
+      - boards/spi.overlay
+      - boards/spi_DMA_evtrtr.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.lpspi.loopback:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_LOOPBACK=y
+
+  drivers.spi.alif.lpspi.perf:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+
+  drivers.spi.alif.lpspi.perf.dma:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+      - boards/lpspi_DMA.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.lpspi.perf.dma.evtrtr:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+      - boards/lpspi_DMA_evtrtr.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_PERFORMANCE=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.lpspi.stress:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+
+  drivers.spi.alif.lpspi.stress.dma:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+      - boards/lpspi_DMA.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+      - CONFIG_TEST_SPI_USE_DMA=y
+
+  drivers.spi.alif.lpspi.stress.dma.evtrtr:
+    extra_dtc_overlay_files:
+      - boards/lpspi.overlay
+      - boards/lpspi_DMA_evtrtr.overlay
+    extra_configs:
+      - CONFIG_TEST_SPI_STRESS=y
+      - CONFIG_TEST_SPI_USE_DMA=y


### PR DESCRIPTION
Add a comprehensive Zephyr ZTEST-based test suite for validating the  SPI DW controller driver on E7, E8, A5, E1C, and B1 SoC variants.

Test suites included:
- Core threaded loopback (MOSI/MISO, controller/target)
- Loopback (8/16/32-bit word sizes, frequency sweep)
- Negative (invalid configs, null buffers, word-size checks)
- Boundary (FIFO limits, buffer edges, max-frequency)
- Stress (repeated transfers with rotating patterns)
- Performance (timing benchmarks with configurable frequency sweep)

Build-time features:
- Kconfig-selectable test suites (TEST_SPI_LOOPBACK, TEST_SPI_NEGATIVE, TEST_SPI_BOUNDARY, TEST_SPI_STRESS, TEST_SPI_PERFORMANCE)
- Configurable base frequency (TEST_SPI_FREQUENCY) and word size (TEST_SPI_WORD_SIZE)
- Optional DMA path (TEST_SPI_USE_DMA) with devicetree guard
- Board-common overlay macros for automatic pinmux/IRQ/DMA selection

Supported overlays:
- boards/spi.overlay — basic wired loopback (SPI1 <-> SPI0)
- boards/spi_DMA.overlay — DMA transfer path
- boards/spi_DMA_evtrtr.overlay — DMA with event router
- boards/spi_ss_sw.overlay — software chip-select
- boards/lpspi*.overlay — LPSPI instance variants