### PR TITLE
manifest: update wifi driver and hal_infineon revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 48289b31175f8332f584e259ff29591ab7f8a595
+      revision: d3009405923d4d6c575ed97e6169920ac326d00f
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects
@@ -78,6 +78,11 @@ manifest:
       path: modules/hal/cmsis
       groups:
          - hal
+
+    - name: hal_infineon
+      remote: zephyrproject
+      revision: 470f874ce432763a2b82cd322d0ff6efc89240cd
+      path: modules/hal/infineon
 
     - name: dave2d
       repo-path: alif_dave2d-driver


### PR DESCRIPTION
update zephyr_alif and hal_infineon revision for wifi support.
Depends: https://github.com/alifsemi/zephyr_alif/pull/450