### PR TITLE
manifest: zephyr_alif: update fs_sample for synopsys sdhc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: b1bc1414a6285ea7696dcc260c812f63c87ab3de
+      revision: 1f059b7937717e35c5b4e16028f8033bacfa8e6c
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 62f6ad1f59b1880f480ab848ca45c09b90fa1d49
+      revision: pull/479/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update revision to include fs_sample support for synopsys sdhc driver.
Depends: https://github.com/alifsemi/zephyr_alif/pull/479
