### PR TITLE
manifest: update zephyr revision to pick up mpu attributes via DT

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 080b30f9d58346fff93731ccb48a395c92a0ed10
+      revision: da1aadf42e20d92bf9c97158b5809dbf467f9b8b
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pick up configuration of TCM and SRAM MPU regions via device tree.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/487