### PR TITLE
manifest: update zephyr revision for i2c dynamic clock detection

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 79c4c07c145348229bf38894c826cb318d5837b5
+      revision: 61a80b963fb498c6e2912752dff5cd5e28d079e3
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr revision version to pick i2c dynamic clock detection from the clock control.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/464