### PR TITLE
doc: update user guide and release notes for v2.3.0

### DIFF
--- a/doc/appnotes/source/conf.py
+++ b/doc/appnotes/source/conf.py
@@ -14,7 +14,7 @@ import shutil
 project = 'Application Notes for Zephyr Alif SDK'
 copyright = '2025-2026, Alif Semiconductor'
 author = 'Alif Semiconductor'
-release = '2.2.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/appnotes/source/index.rst
+++ b/doc/appnotes/source/index.rst
@@ -81,4 +81,4 @@ Document History
    * - 2.2
      - Updated the document to include OV5640 parallel camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
    * - 2.3
-     - Updated the document to include JPEG, MT9M114 MIPI serial camera sensor, USB Device MSC support, SDIO Wi-Fi support, DMA support for UART.
+     - Updated the document to include JPEG, MT9M114 MIPI serial camera sensor, Exposure modification support for ARX3A0 camera sensor, DTS-driven SE off/run profile setting, USB Device MSC support (SD/OSPI), SDIO Wi-Fi support, DMA support for UART, SPI.

--- a/doc/appnotes/source/index.rst
+++ b/doc/appnotes/source/index.rst
@@ -80,6 +80,6 @@ Document History
    * - 2.1
      - Added support for MIPI-CSI, CMP, ISP, USB-device, Ethernet.
    * - 2.2
-     - Updated the document to include OV5640 parallel camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+     - Updated the document to include OV5640 parallel camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
    * - 2.3
      - Updated the document to include JPEG, MT9M114 MIPI serial camera sensor, USB Device MSC support, SDIO Wi-Fi support, DMA support for UART.

--- a/doc/release_notes/source/_static/latex/alif_semiconductor.sty
+++ b/doc/release_notes/source/_static/latex/alif_semiconductor.sty
@@ -16,6 +16,14 @@
 % ----------------------------------------------------------------------------
 \usepackage{hyperref}
 
+% Remove footer/header section names only
+\makeatletter
+\renewcommand{\chaptermark}[1]{}
+\renewcommand{\sectionmark}[1]{}
+\let\leftmark\empty
+\let\rightmark\empty
+\makeatother
+
 % Floats and Graphics
 % ----------------------------------------------------------------------------
 \usepackage{float}
@@ -91,6 +99,11 @@
 \usepackage{etoolbox}
 \pretocmd{\tableofcontents}{\clearpage}{}{}
 \addto\captionsenglish{\renewcommand{\contentsname}{Table of Contents}}
+
+\usepackage{tocloft}
+\setlength{\cftbeforetoctitleskip}{-25pt}
+\setlength{\cftbeforesecskip}{2pt}
+\setlength{\cftbeforesubsecskip}{1pt}
 
 % Logo on First Page
 % ----------------------------------------------------------------------------

--- a/doc/release_notes/source/conf.py
+++ b/doc/release_notes/source/conf.py
@@ -12,9 +12,9 @@ import shutil
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Release Notes of Zephyr Alif SDK'
-copyright = '2024-2025, Alif Semiconductor'
+copyright = '2025-2026, Alif Semiconductor'
 author = 'Alif Semiconductor'
-release = '2.2.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/release_notes/source/conf.py
+++ b/doc/release_notes/source/conf.py
@@ -12,9 +12,9 @@ import shutil
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Release Notes of Zephyr Alif SDK'
-copyright = '2024-2025, Alif Semiconductor'
+copyright = '2025-2026, Alif Semiconductor'
 author = 'Alif Semiconductor'
-release = '2.2.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -70,7 +70,7 @@ latex_documents = [
 ]
 
 latex_logo = "_static/logo.png"
-latex_show_urls = 'footnote'
+latex_show_urls = 'no'
 latex_domain_indices = False
 
 # -- Custom setup ------------------------------------------------------------

--- a/doc/release_notes/source/index.rst
+++ b/doc/release_notes/source/index.rst
@@ -35,3 +35,5 @@ Document History
       - Updated the document to include MIPI-CSI, CMP, ISP, USB-device, Ethernet.
     * - 2.2
       - Updated the document to include OV5640 camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+    * - 2.3
+      - Updated the document to include JPEG, MT9M114 MIPI serial camera sensor, Exposure modification support for ARX3A0 camera sensor, DTS-driven SE off/run profile setting, USB Device MSC support (SD/OSPI), SDIO Wi-Fi support, DMA support for UART, SPI.

--- a/doc/release_notes/source/index.rst
+++ b/doc/release_notes/source/index.rst
@@ -34,4 +34,6 @@ Document History
     * - 2.1
       - Updated the document to include MIPI-CSI, CMP, ISP, USB-device, Ethernet.
     * - 2.2
-      - Updated the document to include OV5640 camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+      - Updated the document to include OV5640 camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+    * - 2.3
+      - Release with Zephyr v4.1.0. Added driver support for MT9M114 MIPI serial camera sensor, JPEG, Exposure modification support for ARX3A0 camera sensor, DTS-driven SE off/run profile setting, USB Device MSC support (SD/OSPI), SDIO Wi-Fi support, DMA support for UART, SPI, support for APSS.

--- a/doc/release_notes/source/links.txt
+++ b/doc/release_notes/source/links.txt
@@ -2,10 +2,11 @@
 
 .. _`ZAS User Guide`: https://github.com/alifsemi/sdk-alif/releases/download/v2.2.0/user_guide.pdf
 .. _`Alif Trademarks`: https://alifsemi.com/legal
-.. _`Alif Security Toolkit Quick Start Guide`: https://alifsemi.com/download/AUGD0005
+.. _`Alif Security Toolkit`: https://alifsemi.com/download/APFW0001
 .. _`Alif SDK`: https://github.com/alifsemi/sdk-alif
 .. _`Alif SDK - Zephyr`: https://github.com/alifsemi/zephyr_alif
 .. _`Alif SDK - HAL`: https://github.com/alifsemi/hal_alif
+.. _`Alif SE Host Services`: https://alifsemi.com/download/APFW0004
 
 .. ### Zephyr Project
 .. _`Zephyr Project website`: https://www.zephyrproject.org

--- a/doc/release_notes/source/links.txt
+++ b/doc/release_notes/source/links.txt
@@ -1,11 +1,12 @@
 .. ### This page lists links used in Alif docs.
 
-.. _`ZAS User Guide`: https://github.com/alifsemi/sdk-alif/releases/download/v2.2.0/user_guide.pdf
+.. _`ZAS User Guide`: https://github.com/alifsemi/sdk-alif/releases/download/v2.3.0/user_guide.pdf
 .. _`Alif Trademarks`: https://alifsemi.com/legal
-.. _`Alif Security Toolkit Quick Start Guide`: https://alifsemi.com/download/AUGD0005
+.. _`Alif Security Toolkit`: https://alifsemi.com/download/APFW0001
 .. _`Alif SDK`: https://github.com/alifsemi/sdk-alif
 .. _`Alif SDK - Zephyr`: https://github.com/alifsemi/zephyr_alif
 .. _`Alif SDK - HAL`: https://github.com/alifsemi/hal_alif
+.. _`Alif SE Host Services`: https://alifsemi.com/download/APFW0004
 
 .. ### Zephyr Project
 .. _`Zephyr Project website`: https://www.zephyrproject.org

--- a/doc/release_notes/source/release_note.rst
+++ b/doc/release_notes/source/release_note.rst
@@ -11,7 +11,7 @@ Supported Development Kits
 
 - **DK-E7**: Configurable to emulate E5, and E3 series devices (Ethos-U55 microNPUs)
 - **DK-E8**: Configurable to emulate E6 and E4 series devices (Ethos-U55 and Ethos-U85 microNPUs)
-- **DK-E1C**: Compact series development platform
+- **DK-E1C**: Features Ethos-U55 microNPU and Cortex-M55 core
 
 **Balletto Series** - Wireless-enabled MCUs with AI/ML acceleration:
 
@@ -54,23 +54,23 @@ The following are the software components used in the latest release.
      - Version
      - Link
    * -  Alif SDK
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK`_
    * -  Alif Zephyr RTOS
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK - Zephyr`_
    * -  Alif SDK - HAL
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK - HAL`_
    * -  Alif Secure Enclave (SE)
-     - v1.109
-     - `Alif Security Toolkit Quick Start Guide`_
+     - v1.110
+     - `Alif Security Toolkit`_
    * -  SE Host Services
-     - v0.50.9
+     - v0.50.10
      - `Alif SE Host Services`_
 
 .. note::
-   This release requires Secure Enclave software version v1.109 or later for proper operation.
+   This release requires Secure Enclave software version v1.110 or later for proper operation.
 
 New Features
 ------------

--- a/doc/release_notes/source/release_note.rst
+++ b/doc/release_notes/source/release_note.rst
@@ -9,13 +9,18 @@ Supported Development Kits
 
 **Ensemble Series** - High-performance multi-core MCUs with Arm Cortex-M55 cores:
 
-- **DK-E7**: Configurable to emulate E5, and E3 series devices (Ethos-U55 microNPUs)
+- **DK-E7**: Configurable to emulate E5, E3, and E1 series devices (Ethos-U55 microNPUs)
 - **DK-E8**: Configurable to emulate E6 and E4 series devices (Ethos-U55 and Ethos-U85 microNPUs)
-- **DK-E1C**: Compact series development platform
+- **DK-E1C**: Features Ethos-U55 microNPU and Cortex-M55 core
+- **AK-E7**: Configurable to emulate E5, E3, and E1 series devices (Ethos-U55 microNPUs)
+- **AK-E8**: Configurable to emulate E6 and E4 series devices (Ethos-U55 and Ethos-U85 microNPUs)
+- **SK-E1C**: Features Ethos-U55 microNPU and Cortex-M55 core
+
 
 **Balletto Series** - Wireless-enabled MCUs with AI/ML acceleration:
 
 - **DK-B1**: Features Bluetooth Low Energy 5.3, Ethos-U55 microNPU, and Cortex-M55 core
+- **SK-B1**: Features Bluetooth Low Energy 5.3, Ethos-U55 microNPU, and Cortex-M55 core
 
 Installing the SDK and Building the Application
 -----------------------------------------------
@@ -54,23 +59,23 @@ The following are the software components used in the latest release.
      - Version
      - Link
    * -  Alif SDK
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK`_
    * -  Alif Zephyr RTOS
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK - Zephyr`_
    * -  Alif SDK - HAL
-     - v2.0-zas-branch
+     - v2.3-zas-branch
      - `Alif SDK - HAL`_
    * -  Alif Secure Enclave (SE)
-     - v1.109
-     - `Alif Security Toolkit Quick Start Guide`_
+     - v1.110
+     - `Alif Security Toolkit`_
    * -  SE Host Services
-     - v0.50.9
+     - v0.50.10
      - `Alif SE Host Services`_
 
 .. note::
-   This release requires Secure Enclave software version v1.109 or later for proper operation.
+   This release requires Secure Enclave software version v1.110 or later for proper operation.
 
 New Features
 ------------
@@ -90,6 +95,22 @@ This release adds two new APIs to the SE Host Services component:
      - Request to process a TOC entry.
    * - read_otp
      - Read an OTP word specified by offset.
+
+Compatibility Notes
+-------------------
+
+- **USB Device**
+
+  - Default USB PHY power-gating settings have been moved from `SoC_common.cfile` to the application overlays through the AIPM run profile.
+  - Applications using USB Device functionality must ensure that the required AIPM run profile settings are enabled in the corresponding overlay files.
+
+- **SDMMC**
+
+  - The Intel eMMC Host driver has been deprecated in this release. Going forward, the Alif SDHC driver (`sdhc_dwc.c`) will be used as the default SD/MMC host controller driver for all Wi-Fi and filesystem samples across Alif targets.
+
+  - SD regulators are defined in the board DTSI and are disabled by default.
+  - Applications must enable the regulator (`CONFIG_REGULATOR=y`) in the application configuration file for the E8 DevKit, AppKit, and Spark A6 boards.
+    boards.
 
 Supported Peripheral Drivers and Features
 ------------------------------------------
@@ -148,9 +169,9 @@ Display Interfaces
    * - MIPI-DSI
      - MIPI Display Serial Interface supporting high-speed, low-power video data transmission to external LCD/OLED panels. Integrated with Zephyr’s display subsystem.
    * - CDC-200
-     - Configurable Display Controller (CDC-200) PHY for MIPI-DSI, enabling reliable high-speed display link operation.
+     - CDC-200 is a fully customizable display controller IP supporting the OpenWF Display API specification, capable of combining image layers from memory and generating video output streams for display interfaces such as MIPI-DSI.
    * - Touch screen
-     - Capacitive touch controller supporting multi-touch gestures via I2C or SPI. Provides touch coordinates and wake-on-touch capability.
+     - Capacitive touch controller supporting multi-touch gestures via I2C, providing touch coordinates and wake-on-touch capability.
 
 Display Support
 ~~~~~~~~~~~~~~~
@@ -167,10 +188,10 @@ Display Support
      - DevKit E7, DevKit E8
    * - ILI9488
      - 1-Lane Serial (MIPI-DSI)
-     - E1C, B1 A5/A6
+     - E1C, B1 A7
    * - Parallel Display
      - Parallel
-     - DevKit E7, DevKit E8, E1C, B1 A5/A6
+     - DevKit E7, DevKit E8, E1C, B1 A7
 
 Audio Interfaces
 ~~~~~~~~~~~~~~~~
@@ -375,7 +396,7 @@ Camera Sensors Support
      - DevKit E7, DevKit E8
    * - MT9M114
      - Parallel (CPI)
-     - DevKit E7, DevKit E8, E1C, B1 A5/A6
+     - DevKit E7, DevKit E8, E1C, B1 A7
    * - OV5640
      - Parallel (CPI)
      - E1C StartKit
@@ -406,7 +427,7 @@ Wireless Connectivity
        - Common settings storage support shared by Alif BLE samples
 
 Bug Fixes
-----------
+---------
 
 .. list-table::
    :header-rows: 1
@@ -414,22 +435,24 @@ Bug Fixes
 
    * - **Component**
      - **Fix**
-   * - Alif BLE Audio
-     - Fixed unicast initiator bonding handling on the ROM-based stack
-   * - Alif BLE Audio
-     - Fixed bonded device reconnection in unicast audio
-   * - Alif BLE Audio
-     - Fixed Auracast delegator to work with encrypted streams
-   * - Alif BLE PM
-     - Fixed ROM-based BLE PM build issues
-   * - CRC Driver
-     - Corrected DTS property ``crc_algo`` to ``crc-algo`` and updated enum values to lowercase
-   * - Eagle SoC SRAM
-     - Corrected SRAM1 mapping from ``0x08000000`` to ``0x02400000``
-   * - Touchscreen
-     - Fixed issue where touch screen events were intermittently dropped
-   * - I2C
-     - Fixed I2C target ``read_requested`` and ``read_processed`` callback handling
+   * - BLE Audio
+     - Fixed audio unicast initiator issue when opening a second channel using the host stack
+   * - SPI1 DMA
+     - Resolved inconsistent SPI1 DMA operation behavior
+   * - OSPI Boot
+     - Verified OSPI boot functionality
+   * - Power Management
+     - Fixed PM demo application error when running from HE-MRAM on Spark-A6
+   * - LP Camera
+     - Updated LP Camera overlay configuration to use I2C1 on B1-DK
+   * - Executorch
+     - Added support for Executorch on E1C
+   * - CMP
+     - Fixed CMP functionality on Balletto
+   * - ADC
+     - Added testing and functional support for ADC on A1
+   * - Power Management
+     - Fixed PM sample application functionality on B1
 
 Planned Deprecations
 --------------------
@@ -449,27 +472,19 @@ The following items are planned for deprecation in the next release:
   devicetree ``clocks`` configuration instead of manually enabling clocks
   through the register.
 
-- **E3-DK and E4-DK Board Support**
-
-  Support for **E3-DK** and **E4-DK** board files will be removed. Support for **E3** and **E4** SoCs will continue to be available through **E8-DK** and **E7-DK** builds.
-
 - **DMA Node Referencing**
 
   Referring to DMA nodes directly in device driver nodes will be deprecated. All drivers using DMA must reference DMA resources through **EVTRTR** nodes.
 
 Known Issues
--------------
+----------------
 
-- BLE (Alif ROM stack) audio unicast initiator fails to open a second channel when using the host stack.
-- SPI1 DMA operations exhibit inconsistent behavior.
-- OSPI boot has not been verified.
-- When running from HE-MRAM, the PM demo application throws an error message on spark-A6.
-- LPCMP sample is not functional on all families.
-- LP Camera node in the overlay file needs to be updated to I2C1 for B1-DK.
-- Executorch is not supported on E1C.
-- CMP is not functional on Balletto.
-- ADC is not tested or not functional on A1.
-- PM sample application is not functional on B1.
+* The LPPDM sample application does not function as expected.
+* On the e8_dk board, the Wi-Fi Shell sample application requires ``CONFIG_UHS_PROTOCOL`` to be commented out.
+* USB Device MSC (SD, RAMDISK, and OSPI) test applications may exhibit inconsistent behavior when booting from MRAM.
+* The SDMMC test application may not operate reliably with the SanDisk 32GB card.
+* The LPCMP sample application does not function as expected.
+
 
 External References
 -------------------

--- a/doc/user_guide/source/_static/latex/alif_semiconductor.sty
+++ b/doc/user_guide/source/_static/latex/alif_semiconductor.sty
@@ -15,6 +15,14 @@
 % ----------------------------------------------------------------------------
 \usepackage{hyperref}
 
+% Remove footer/header section names only
+\makeatletter
+\renewcommand{\chaptermark}[1]{}
+\renewcommand{\sectionmark}[1]{}
+\let\leftmark\empty
+\let\rightmark\empty
+\makeatother
+
 % Floats and Graphics
 % ----------------------------------------------------------------------------
 \usepackage{float}
@@ -60,6 +68,7 @@
 % ----------------------------------------------------------------------------
 \usepackage{eso-pic}
 \usepackage{tikz}
+
 
 % Page Geometry
 % ----------------------------------------------------------------------------

--- a/doc/user_guide/source/building_and_flashing.rst
+++ b/doc/user_guide/source/building_and_flashing.rst
@@ -111,15 +111,21 @@ Supported Board Targets as per new hardware model v2 (Zephyr v4.1.0 and onwards)
 - alif_e7_dk/ae722f80f55d5xx/rtss_he
 - alif_e7_dk/ae722f80f55d5xx/rtss_hp
 - alif_e7_dk/ae722f80f55d5xx/apss
+- alif_e7_dk/ae302f80f55d5xx/rtss_he
+- alif_e7_dk/ae302f80f55d5xx/rtss_hp
+- alif_e7_ak/ae722f80f55d5xx/rtss_he
+- alif_e7_ak/ae722f80f55d5xx/rtss_hp
+- alif_e8_dk/ae822fa0e5597xx0/apss
 - alif_e8_dk/ae822fa0e5597xx0/rtss_he
 - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
-- alif_e8_dk/ae822fa0e5597xx0/apss
+- alif_e8_dk/ae402fa0e5597xx0/rtss_he
+- alif_e8_dk/ae402fa0e5597xx0/rtss_hp
+- alif_e8_ak/ae822fa0e5597xx0/rtss_he
+- alif_e8_ak/ae822fa0e5597xx0/rtss_hp
 - alif_e1c_dk/ae1c1f4051920hh/rtss_he
-- alif_b1_dk/ab1c1f4m51820hh0/rtss_he
 - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
 - alif_b1_dk/ab1c1f1m41820hh0/rtss_he
 - alif_b1_dk/ab1c1f1m41820ph0/rtss_he
-
 
 a. Navigate to the Zephyr directory:
 

--- a/doc/user_guide/source/building_and_flashing.rst
+++ b/doc/user_guide/source/building_and_flashing.rst
@@ -110,14 +110,21 @@ Supported Board Targets as per new hardware model v2 (Zephyr v4.1.0 and onwards)
 
 - alif_e7_dk/ae722f80f55d5xx/rtss_he
 - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+- alif_e7_dk/ae302f80f55d5xx/rtss_he
+- alif_e7_dk/ae302f80f55d5xx/rtss_hp
+- alif_e7_ak/ae722f80f55d5xx/rtss_he
+- alif_e7_ak/ae722f80f55d5xx/rtss_hp
 - alif_e8_dk/ae822fa0e5597xx0/rtss_he
 - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+- alif_e8_dk/ae402fa0e5597xx0/rtss_he
+- alif_e8_dk/ae402fa0e5597xx0/rtss_hp
+- alif_e8_ak/ae822fa0e5597xx0/rtss_he
+- alif_e8_ak/ae822fa0e5597xx0/rtss_hp
 - alif_e1c_dk/ae1c1f4051920hh/rtss_he
 - alif_b1_dk/ab1c1f4m51820hh0/rtss_he
 - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
 - alif_b1_dk/ab1c1f1m41820hh0/rtss_he
 - alif_b1_dk/ab1c1f1m41820ph0/rtss_he
-
 
 a. Navigate to the Zephyr directory:
 

--- a/doc/user_guide/source/conf.py
+++ b/doc/user_guide/source/conf.py
@@ -12,9 +12,9 @@ import shutil
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Getting Started with Zephyr Alif SDK'
-copyright = '2024-2025, Alif Semiconductor'
+copyright = '2025-2026, Alif Semiconductor'
 author = 'Alif Semiconductor'
-release = '2.2.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -77,7 +77,7 @@ latex_documents = [
 ]
 
 latex_logo = "_static/logo.png"
-latex_show_urls = 'footnote'
+latex_show_urls = 'no'
 latex_domain_indices = False
 
 # -- Custom setup ------------------------------------------------------------

--- a/doc/user_guide/source/conf.py
+++ b/doc/user_guide/source/conf.py
@@ -12,9 +12,9 @@ import shutil
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Getting Started with Zephyr Alif SDK'
-copyright = '2024-2025, Alif Semiconductor'
+copyright = '2025-2026, Alif Semiconductor'
 author = 'Alif Semiconductor'
-release = '2.2.0'
+release = '2.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/user_guide/source/index.rst
+++ b/doc/user_guide/source/index.rst
@@ -36,4 +36,6 @@ Document History
     * - 2.1
       - Updated the document to include MIPI-CSI, CMP, ISP, USB-device, Ethernet.
     * - 2.2
-      - Updated the document to include OV5640 camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+      - Updated the document to include OV5640 parallel camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+    * - 2.3
+      - Release with Zephyr v4.1.0. Added driver support for MT9M114 MIPI serial camera sensor, JPEG, Exposure modification support for ARX3A0 camera sensor, DTS-driven SE off/run profile setting, USB Device MSC support (SD/OSPI), SDIO Wi-Fi support, DMA support for UART, SPI, support for APSS.

--- a/doc/user_guide/source/index.rst
+++ b/doc/user_guide/source/index.rst
@@ -36,4 +36,6 @@ Document History
     * - 2.1
       - Updated the document to include MIPI-CSI, CMP, ISP, USB-device, Ethernet.
     * - 2.2
-      - Updated the document to include OV5640 camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+      - Updated the document to include OV5640 parallel camera sensor, ultrasonic TOF sensor, CAN-FD, Macronix Flash (MX66UW), HexSPI support for AP memory PSRAM (APS512XXN), EVTRTR, UART HFOSC_CLK support, basic Power Management (I2S, SPI, I2C, RTC, UART), Deep Sleep IWIC support, and AI Acceleration section updates (Executorch, InferenceRunner, TFLite Micro samples).
+    * - 2.3
+      - Updated the document to include JPEG, MT9M114 MIPI serial camera sensor, Exposure modification support for ARX3A0 camera sensor, DTS-driven SE off/run profile setting, USB Device MSC support (SD/OSPI), SDIO Wi-Fi support, DMA support for UART, SPI.

--- a/doc/user_guide/source/introduction.rst
+++ b/doc/user_guide/source/introduction.rst
@@ -15,8 +15,8 @@ In this user guide, we cover the following steps:
 4. **Running the Application from MRAM:**
     - Discover how to run applications directly from MRAM. Learn about the supported targets, specific MRAM boot addresses for RTSS-HE and RTSS-HP, and the necessary build commands.
 
-Zephyr RTOS and Toolchain
------------------------------
+Zephyr RTOS
+-------------
 
 The real-time subsystems boot with Zephyr OS, a small RTOS for connected, resource-constrained, and embedded devices. Zephyr supports multiple architectures and is available under the Apache 2.0 license.
 
@@ -32,12 +32,16 @@ Host Requirements
 **Hardware Requirements**
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ensure you have one of the following development kits to proceed with your project setup:
+Ensure you have one of the following Alif development kits to proceed with your project setup:
 
 - Ensemble DevKit (DK-E7)
 - Ensemble DevKit (DK-E8)
 - Ensemble E1C DevKit (DK-E1C)
 - Balletto DevKit (DK-B1)
+- Ensemble AppKit (AK-E7)
+- Ensemble AppKit (AK-E8)
+- Ensemble E1C StarterKit (SK-E1C)
+- Balletto StarterKit (SK-B1)
 
 Ensure you have the following debugger available to proceed with your project setup:
 
@@ -51,7 +55,7 @@ Ensure you have the following debugger available to proceed with your project se
 
 
 2. **Alif Security Toolkit:**
-    - SE version is 1.109.0
+    - SE version is 1.110
 
     * Available at `Alif Toolkit Download`_
 
@@ -104,31 +108,17 @@ The Alif DevKit is a development board featuring an Alif multi-core SoC, offerin
         - An Ethos-U55 microNPU for AI acceleration
         - A Cortex-M55 MCU core
 
-**Toolchains**
-~~~~~~~~~~~~~~
-
-The following toolchains have been tested for the SDK application:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Compiler
-     - Version
-     - Link
-   * - GCC (GNU Compiler Collection)
-     - v12.2.0
-     - `GCC Download`_
-
-
 **Target Reference Board**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Alif DevKit Ensemble E3
-- Alif DevKit Ensemble E4
-- Alif DevKit Ensemble E7
-- Alif DevKit Ensemble E8
-- Alif DevKit Ensemble E1C
-- Alif DevKit Balletto B1
+- Ensemble DevKit (DK-E7)
+- Ensemble DevKit (DK-E8)
+- Ensemble E1C DevKit (DK-E1C)
+- Balletto DevKit (DK-B1)
+- Ensemble AppKit (AK-E7)
+- Ensemble AppKit (AK-E8)
+- Ensemble E1C StarterKit (SK-E1C)
+- Balletto StarterKit (SK-B1)
 
 **Software Components**
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user_guide/source/introduction.rst
+++ b/doc/user_guide/source/introduction.rst
@@ -15,8 +15,8 @@ In this user guide, we cover the following steps:
 4. **Running the Application from MRAM:**
     - Discover how to run applications directly from MRAM. Learn about the supported targets, specific MRAM boot addresses for RTSS-HE and RTSS-HP, and the necessary build commands.
 
-Zephyr RTOS and Toolchain
------------------------------
+Zephyr RTOS
+-------------
 
 The real-time subsystems boot with Zephyr OS, a small RTOS for connected, resource-constrained, and embedded devices. Zephyr supports multiple architectures and is available under the Apache 2.0 license.
 
@@ -32,12 +32,16 @@ Host Requirements
 **Hardware Requirements**
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ensure you have one of the following development kits to proceed with your project setup:
+Ensure you have one of the following Alif development kits to proceed with your project setup:
 
 - Ensemble DevKit (DK-E7)
 - Ensemble DevKit (DK-E8)
 - Ensemble E1C DevKit (DK-E1C)
 - Balletto DevKit (DK-B1)
+- Ensemble AppKit (AK-E7)
+- Ensemble AppKit (AK-E8)
+- Ensemble E1C StarterKit (SK-E1C)
+- Balletto StarterKit (SK-B1)
 
 Ensure you have the following debugger available to proceed with your project setup:
 
@@ -51,7 +55,7 @@ Ensure you have the following debugger available to proceed with your project se
 
 
 2. **Alif Security Toolkit:**
-    - SE version is 1.109.0
+    - SE version is 1.110
 
     * Available at `Alif Toolkit Download`_
 
@@ -73,62 +77,23 @@ Ensure you have the following debugger available to proceed with your project se
    Ensemble Gen2 Family
 
 
-The Alif DevKit is a development board featuring an Alif multi-core SoC, offering both high-performance and low-power execution.
+The Alif development board featuring an Alif multi-core SoC, offering both high-performance and low-power execution.
 
-- **DK-E7:**
-    - Features:
-        - Two Cortex-M55 CPU cores
-        - Two Ethos-U55 neural network processor cores
-        - Two Cortex-A32 MPU cores
-    - Allows configuration of the E7 MCU to operate like other Ensemble MCUs with fewer cores, enabling exploration of the E5, E3, and E1 series devices using a single kit.
+- **Ensemble DevKit (DK-E7):**
+    - The Ensemble E7 DevKit (DK-E7) is a cost-effective, single-board solution that brings out all signals on the device to easily access pins for power and performance profiling, prototyping, and more. The DevKit can be configured to operate as your choice of the E1, E3, E5, or E7 series MCU devices in the Ensemble family, with superset E7 series device having two Cortex-M55 CPU cores, two Ethos-U55 neural network processors cores, and two Cortex-A32 MPU cores.
 
-- **DK-E8:**
-    - Features:
-        - Two Cortex-M55 CPU cores
-        - Two Ethos-U55 + One Ethos-U85 neural network processor cores
-        - Two Cortex-A32 MPU cores
-        - Allows configuration of the E8 MCU to operate like other Ensemble MCUs with fewer cores, enabling exploration of the E6, and E4 series devices using a single kit.
+- **Ensemble DevKit (DK-E8):**
+    - The Ensemble E8 DevKit (DK-E8) is a cost-effective, single-board solution that brings out all signals on the device to easily access pins for power and performance profiling, prototyping, and more. The DevKit can be configured to operate as your choice of the E4, E6, or E8 series MCU devices in the Ensemble family, with superset E8 series device having two Cortex-M55 CPU cores, two Ethos-U55 + one Ethos-U85 neural network processors cores, and two Cortex-A32 MPU cores.
 
-- **DK-E1C:**
-    - Designed to explore the Compact series of Ensemble devices.
-    - Features:
-        - A Cortex-M55 CPU core
-        - Arm Ethos-U55 micro NPU
-    - Known for its low power consumption within the Ensemble family.
+- **Ensemble E1C DevKit (DK-E1C):**
+    - The Ensemble E1C DevKit is a cost-effective, single-board platform that brings out all signals on the E1C MCU to easily access pins for power and performance profiling, prototyping, and more. The E1C MCU on the board has a Cortex M55 CPU core with Helium-M Vector Extension, operating at 160 MHz, an Ethos-U55 neural network processor core with 128 MACs per cycle, 2MB of SRAM and 1.9MB of NVM, off-chip OSPI flash and PSRAM memory devices (64MB and 32MB respectively), plus a variety of digital and analog interfaces.
 
-- **DK-B1:**
-    - Introduces the Balletto B1 series, a wireless MCU with integrated hardware acceleration for AI/ML workloads.
-    - Features:
-        - Bluetooth Low Energy 5.3
-        - 802.15.4 based Thread protocols
-        - An Ethos-U55 microNPU for AI acceleration
-        - A Cortex-M55 MCU core
+- **Balletto DevKit (DK-B1):**
+    - The Balletto B1 DevKit (DK-B1) is a cost-effective, single-board platform that brings out all signals on the Balletto B1 MCU to easily access pins for power and performance profiling, prototyping, and more. The B1 MCU on the board has a Cortex M-55 CPU core with Helium-M Vector Extension, operating at 160 MHz, an Ethos-U55 neural network processor core with 128 MACs per cycle, 2MB of SRAM and 1.8MB of NVM, off-chip OSPI flash and PSRAM memory devices (64MB and 32MB respectively), a variety of digital and analog interfaces, plus and a BLE 5.3 + 802.15.4 radio subsystem with a chip antenna.
 
-**Toolchains**
-~~~~~~~~~~~~~~
+- **Ensemble AppKit (AK-E7):**
+    - The Ensemble E7 AI/ML AppKit (AK-E7-AIML) enables quick software development and evaluation for Endpoint Machine Learning use cases. Powered by an Alif Ensemble E7 fusion processor with four compute cores (two Arm Cortex-M55 and two Cortex-A32), and two machine learning accelerator coprocessors (two Arm Ethos-U55 microNPUs) with ample memory and peripherals, this kit is the ideal platform to build Endpoint ML projects that input sensor data and leverage ML in an extremely power-efficient way. On board is a camera/image sensor for snapshots or video input, plus motion and sound sensors to round out a variety of Endpoint ML use case scenarios. Several pre-built applications are available for the AI/ML AppKit so you can quickly get started.
 
-The following toolchains have been tested for the SDK application:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Compiler
-     - Version
-     - Link
-   * - GCC (GNU Compiler Collection)
-     - v12.2.0
-     - `GCC Download`_
-
-
-**Target Reference Board**
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- Alif DevKit Ensemble E3
-- Alif DevKit Ensemble E4
-- Alif DevKit Ensemble E7
-- Alif DevKit Ensemble E8
-- Alif DevKit Ensemble E1C
-- Alif DevKit Balletto B1
 
 **Software Components**
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user_guide/source/links.txt
+++ b/doc/user_guide/source/links.txt
@@ -1,12 +1,7 @@
 .. ### This page lists links used in Alif docs.
 
 .. _`Toolchain Selection`: https://docs.zephyrproject.org/latest/develop/toolchains/index.html
-.. _`GCC Download`: https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.17.0
-.. _`ArmCLang Download`: https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Embedded
-.. _`LLVM Download`: https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases
-.. _`Alif Toolkit Download`: https://alifsemi.com/download/APFW0002
-.. _`Alif Zephyr SDK Source`: https://github.com/alifsemi/zephyr_alif
-.. _`Alif Security Toolkit Quick Start Guide`: https://alifsemi.com/download/AUGD0005
+.. _`Alif Toolkit Download`: https://alifsemi.com/download/APFW0001
 .. _`zephyr_alif`: https://github.com/alifsemi/zephyr_alif
 .. _`mcuboot_alif`: https://github.com/alifsemi/mcuboot_alif
 .. _`cmsis_alif`: https://github.com/alifsemi/cmsis_alif

--- a/doc/user_guide/source/overview.rst
+++ b/doc/user_guide/source/overview.rst
@@ -89,13 +89,6 @@ The Documentation section provides essential resources to help developers quickl
 - **README**: Comprehensive project overview.
 - **AppNotes**: Application notes offering practical implementation examples, design guidelines, and best practices for specific use cases with the Zephyr Alif SDK.
 
-Toolchains
-----------
-
-SDK supports the following development toolchains:
-
-- **GCC (GNU Compiler Collection v12.2.0)** - Used through the Zephyr Project.
-
 Zephyr RTOS
 -------------
 


### PR DESCRIPTION
Update document history for the user guide and release notes for v2.3.0

Update conf.py version from v2.2 to v2.3 in the user guide and release notes

Update SE tool latest version links

Update supported board targets in the user guide

Remove toolchain references from the user guide and retained them only in the release notes

Update references from compiler version to SDK version

Remove unnecessary links from the bottom of pages in the
User Guide and Release Notes PDFs

Update user guide and release notes for v2.3.0