### PR TITLE
samples: drivers: jpeg: add aipm run profile

### DIFF
--- a/samples/drivers/jpeg/snippets/alif-dk-ak/alif_e8_dk_ak.overlay
+++ b/samples/drivers/jpeg/snippets/alif-dk-ak/alif_e8_dk_ak.overlay
@@ -14,3 +14,8 @@
 	quality-factor = <75>;
 	max-burst-length = <64>;
 };
+
+/* Jpeg's AIPM run profile */
+&aipm_run_default {
+	memory-blocks = < (ALIF_SRAM0_MASK | ALIF_MRAM_MASK) >;
+};


### PR DESCRIPTION
- Add AIPM run profile for JPEG.
- Reason: 
  The app contains a static image loaded in MRAM at build time and copied to SRAM0 (Heap) at   runtime.