### PR TITLE
manifest: update zephyr to pick up APSS fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 79c4c07c145348229bf38894c826cb318d5837b5
+      revision: ae8780ac090617624f2eb8a5612fe13c319d61cb
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pick up addition of CONFIG_PM guards in soc_common.c and removal of a redundant SoC level MMU region.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/499