### PR TITLE
samples: drivers: i2c_dw: fix sample output formatting

### DIFF
--- a/samples/drivers/i2c_dw/README.rst
+++ b/samples/drivers/i2c_dw/README.rst
@@ -30,6 +30,7 @@ The overlay used in the snippet configures i2c master and slave instances.
 Sample Output
 =============
 .. code-block:: console
+
    Received a byte in slave : 0xaa
    Received a byte in slave : 0xab
    Received a byte in slave : 0xac


### PR DESCRIPTION
Fixed formatting issues in the sample output logs.