### PR TITLE
manifest: upated zephyr revision version for lpi2c1 dynamic clock det…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 79c4c07c145348229bf38894c826cb318d5837b5
+      revision: pull/497/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
…ection

update zephyr revision version to pick lpi2c1 dynamic clock detection from the clock control.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/497