### PR TITLE
manifest: update zephyr revision for mt9m114 parallel camera

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 8b59662ee4697300978ad61afbee6c6b1ee84a48
+      revision: 0ccf0fe15075306b50d92e02254262cab8fcea81
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pull/502/head which fixes the mt9m114 parallel camera initialization and buffer allocation issues.