### PR TITLE
manifest: remove deprecated macros

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 22415942ac80a26679f623e373a7deeb13d96620
+      revision: pull/509/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Remove deprecated pinmux macros from alif SoCs.

This PR depends on https://github.com/alifsemi/zephyr_alif/pull/509