### PR TITLE
manifest: update lpi2c0 pin-mux for e1c and balletto

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 22415942ac80a26679f623e373a7deeb13d96620
+      revision: pull/510/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update pin-mux of lpi2c0 for e1c and balletto as
the existing one is colliding with SE-UART.

This PR depends on https://github.com/alifsemi/zephyr_alif/pull/510