### PR TITLE
Zrtss 784 lpi2c0 master instance change

### DIFF
--- a/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_b1_e1c_dk.overlay
+++ b/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_b1_e1c_dk.overlay
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* setting i2c0 as master and lpi2c0 instance as slave.
+ */
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &lpi2c0;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&lpi2c0 {
+	status = "okay";
+};

--- a/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_b1_e1c_dk.overlay
+++ b/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_b1_e1c_dk.overlay
@@ -12,12 +12,12 @@
 
 / {
 	aliases {
-		master-i2c = &i2c0;
+		master-i2c = &i2c1;
 		slave-i2c = &lpi2c0;
 	};
 };
 
-&i2c0 {
+&i2c1 {
 	status = "okay";
 };
 

--- a/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_e7_e8_dk.overlay
+++ b/samples/drivers/lpi2c/snippets/alif-lpi2c/alif_e7_e8_dk.overlay
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/* setting i2c0 as master and lpi2c0 instance as slave.
+ */
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &lpi2c0;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&lpi2c0 {
+	status = "okay";
+};

--- a/samples/drivers/lpi2c/snippets/alif-lpi2c/snippet.yml
+++ b/samples/drivers/lpi2c/snippets/alif-lpi2c/snippet.yml
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+name: alif-lpi2c
+
+boards:
+  /alif_(b1|e1c)_dk/.*/rtss_he/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_b1_e1c_dk.overlay
+
+  /alif_(e7|e8)_dk/.*/rtss_(hp|he)/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_e7_e8_dk.overlay


### PR DESCRIPTION
samples: drivers: Add alif-lpi2c snippet with board-specific overlays

Create alif-lpi2c snippet for LPI2C sample with separate overlays
for B1/E1C (i2c1 as master) and E4/E7/E8 (i2c0 as master) boards.