### PR TITLE
manifest: zephyr_alif: update revision to include sdhc regulator support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 39849fc056b7659cddf7c5b58f8e4ecce117957c
+      revision: 5535eb548d459a02a0a949484b2be8791280ee7e
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update revision to include sdhc regulator support for sdhc power enable/disable.
depends-on: https://github.com/alifsemi/zephyr_alif/pull/491/