### PR TITLE
manifest: zephyr_alif: update revision to include sdhc fix on sdk v2.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 421f4259a465248e033e90af464e32ea2464c952
+      revision: pull/494/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update revision to include sdhc driver regulator support, and fs sample snippets fix to sdk v2.3
depends-on: https://github.com/alifsemi/zephyr_alif/pull/494