### PR TITLE
manifest: zephyr: pl330: store scatter gather block chains

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 22415942ac80a26679f623e373a7deeb13d96620
+      revision: pull/511/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update revision to include the pl330 block chain fixes to store the caller block chains.
Depends: https://github.com/alifsemi/zephyr_alif/pull/511