### PR TITLE
samples: executorch: kws_ethosu: fix DTCM placement and add U85 support

### DIFF
--- a/samples/modules/executorch/kws_ethosu/CMakeLists.txt
+++ b/samples/modules/executorch/kws_ethosu/CMakeLists.txt
@@ -217,9 +217,8 @@ add_custom_target(gen_model_header DEPENDS ${_model_pte_header})
 add_dependencies(app gen_model_header)
 
 # Memory pool sizes — Kconfig is the single source of truth.
-# Board-specific defaults (SRAM0 vs DTCM) are handled by Kconfig defaults
-# (see SOC_FAMILY_BALLETTO / SOC_SERIES_E1C guards in Kconfig).
-# Section placement is handled by DT_NODE_HAS_STATUS in main.cpp.
+# NPU scratch (temp pool) is always placed in DTCM for all boards (E7, E8, E1C, B1).
+# Method pool uses .alif_sram0 on boards that have it; see main.cpp for details.
 target_compile_definitions(
   app PRIVATE
   ET_ARM_METHOD_ALLOCATOR_POOL_SIZE=${CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE}

--- a/samples/modules/executorch/kws_ethosu/Kconfig
+++ b/samples/modules/executorch/kws_ethosu/Kconfig
@@ -18,18 +18,18 @@ config EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE
 	  Size of the method allocator pool in bytes. This memory is used
 	  for allocating ExecuTorch method instances and their metadata.
 	  Default is 64KB for boards without SRAM0 (B1, E1C) which use DTCM,
-	  and 1.5MB for boards with SRAM0 (E3/E4/E7/E8).
+	  and 1.5MB for boards with SRAM0 (E7/E8).
 
 config EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE
 	int "Temporary allocator pool size in bytes"
-	default 65536 if SOC_FAMILY_BALLETTO
-	default 65536 if SOC_SERIES_E1C
-	default 1572864
+	default 32768 if SOC_FAMILY_BALLETTO
+	default 32768 if SOC_SERIES_E1C
+	default 32768
 	depends on EXECUTORCH
 	help
 	  Size of the temporary allocator pool in bytes. This memory is used
 	  for temporary allocations during model execution such as Ethos-U
-	  scratch memory. Default is 64KB for boards without SRAM (B1, E1C),
-	  and 1.5MB for boards with SRAM (E3/E4/E7/E8).
+	  scratch memory. Must be in DTCM for all boards (NPU accesses via
+	  global alias). 32KB is sufficient; NPU needs ~22KB scratch.
 
 endmenu

--- a/samples/modules/executorch/kws_ethosu/README.rst
+++ b/samples/modules/executorch/kws_ethosu/README.rst
@@ -57,7 +57,7 @@ Supported Boards
 +-------+--------+---------+-------------------------+
 | E1C   | Yes    | No      | **Tested**              |
 +-------+--------+---------+-------------------------+
-| E7    | Yes    | No      | **Tested**              |
+| E7    | Yes    | No      | **Tested** (U55 only)   |
 +-------+--------+---------+-------------------------+
 | E8    | Yes    | Yes     | **Tested**              |
 +-------+--------+---------+-------------------------+
@@ -221,6 +221,18 @@ Building for Alif E8 DK (HP Core with U85)
 .. code-block:: console
 
    west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
+       -S ethos-u85-enable \
+       alif/samples/modules/executorch/kws_ethosu/ -- \
+       -DET_PTE_FILE_PATH=./kws_u85_256.pte \
+       -DET_PTE_SECTION=.rodata.model \
+       -DETHOSU_TARGET_NPU_CONFIG=ethos-u85-256
+
+Building for Alif E8 DK (HE Core with U85)
+===========================================
+
+.. code-block:: console
+
+   west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_he \
        -S ethos-u85-enable \
        alif/samples/modules/executorch/kws_ethosu/ -- \
        -DET_PTE_FILE_PATH=./kws_u85_256.pte \

--- a/samples/modules/executorch/kws_ethosu/prj.conf
+++ b/samples/modules/executorch/kws_ethosu/prj.conf
@@ -19,13 +19,13 @@ CONFIG_REQUIRES_FLOAT_PRINTF=y
 
 # Ethos-U NPU Driver
 CONFIG_ARM_ETHOS_U=y
-# CONFIG_ARM_ETHOS_U_LOG_LEVEL_DBG=y  # Uncomment for debug logging
+CONFIG_ARM_ETHOS_U_LOG_LEVEL_DBG=y
 
 # executorch Memory Pool Configuration
-# Method allocator: 1.5MB for model setup and tensor allocation
-CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE=1572864
-# Temp allocator: 1.5MB for Ethos-U scratch memory
-CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE=1572864
+# Pool sizes are set by Kconfig board-conditional defaults:
+#   E7/E8 (SRAM0 boards): METHOD=1.5MB (in SRAM0), TEMP=32KB (in DTCM)
+#   E1C/B1 (DTCM-only):   METHOD=64KB  (in DTCM), TEMP=32KB (in DTCM)
+# Override here only if board default is insufficient.
 
 # Selective operator build - only include ops needed by the model
 CONFIG_EXECUTORCH_BUILD_PORTABLE_OPS=n

--- a/samples/modules/executorch/kws_ethosu/sample.yaml
+++ b/samples/modules/executorch/kws_ethosu/sample.yaml
@@ -5,23 +5,71 @@ common:
   tags: executorch ml npu ethos-u kws
   depends_on: executorch arm_ethos_u
 tests:
-  # Ensemble boards with SRAM0 (E7/E8) - 1.5MB pools in SRAM
-  sample.executorch.kws_ethosu.e8_hp:
+  # Ensemble boards with SRAM0 (E7/E8) - 1.5MB method pool in SRAM0
+  # E8: has both U55 (ethosu0) and U85 (ethosu1)
+  sample.executorch.kws_ethosu.e8_hp_u55:
     build_only: true
     platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
-  sample.executorch.kws_ethosu.e8_he:
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_256.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-256
+  sample.executorch.kws_ethosu.e8_hp_u85:
+    build_only: true
+    platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    extra_args:
+      - SNIPPET=ethos-u85-enable
+      - ET_PTE_FILE_PATH=./kws_u85_256.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u85-256
+  sample.executorch.kws_ethosu.e8_he_u55:
     build_only: true
     platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_he
-  sample.executorch.kws_ethosu.e7_hp:
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_128.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+  sample.executorch.kws_ethosu.e8_he_u85:
+    build_only: true
+    platform_allow: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    extra_args:
+      - SNIPPET=ethos-u85-enable
+      - ET_PTE_FILE_PATH=./kws_u85_256.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u85-256
+  # E7: U55 only (no U85)
+  sample.executorch.kws_ethosu.e7_hp_u55:
     build_only: true
     platform_allow: alif_e7_dk/ae722f80f55d5xx/rtss_hp
-  sample.executorch.kws_ethosu.e7_he:
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_256.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-256
+  sample.executorch.kws_ethosu.e7_he_u55:
     build_only: true
     platform_allow: alif_e7_dk/ae722f80f55d5xx/rtss_he
-  # Boards without SRAM0 (E1C, B1) - 64KB pools in DTCM
-  sample.executorch.kws_ethosu.e1c_he:
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_128.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+  # Boards without SRAM0 (E1C, B1) - 64KB pools in DTCM, U55 only
+  sample.executorch.kws_ethosu.e1c_he_u55:
     build_only: true
     platform_allow: alif_e1c_dk/ae1c1f4051920hh/rtss_he
-  sample.executorch.kws_ethosu.b1_he:
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_128.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+  sample.executorch.kws_ethosu.b1_he_u55:
     build_only: true
     platform_allow: alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    extra_args:
+      - SNIPPET=ethos-u55-enable
+      - ET_PTE_FILE_PATH=./kws_u55_128.pte
+      - ET_PTE_SECTION=.rodata.model
+      - ETHOSU_TARGET_NPU_CONFIG=ethos-u55-128

--- a/samples/modules/executorch/kws_ethosu/src/main.cpp
+++ b/samples/modules/executorch/kws_ethosu/src/main.cpp
@@ -22,6 +22,7 @@
 #include <executorch/runtime/platform/runtime.h>
 #include <math.h>
 #include <stdio.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <cstring>
@@ -56,48 +57,50 @@ executorch_delegate_EthosUBackend_registered(void);
 #endif
 
 /*
- * Memory section placement for Alif boards:
- *
- * Boards WITH sram0 (E3/E4/E7/E8):
- *   - Use .alif_sram0 sections for tensor arena (fast, 4MB SRAM)
- *
- * Boards WITHOUT sram0 (E1C, B1):
- *   - Use default BSS placement in DTCM
- *
- * Pool sizes are configured via Kconfig (see EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE
- * and EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE) and passed through CMakeLists.txt as
- * compile definitions.
+ * method_allocation_pool: place in SRAM0 (fast, 4MB) on boards that
+ * have it (E7/E8). On boards without sram0 (E1C, B1) fall back to
+ * DTCM so the linker does not emit an orphan section.
  */
-#include <zephyr/devicetree.h>
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(sram0), okay)
-#define ET_TENSOR_ARENA_ATTR __attribute__((section(".alif_sram0.tensor_arena"), aligned(16)))
-#define ET_ETHOSU_SCRATCH_ATTR __attribute__((section(".alif_sram0.ethosu_scratch"), aligned(16)))
+#define ET_METHOD_POOL_ATTR __attribute__((section(".alif_sram0.tensor_arena"), aligned(16)))
 #else
-#define ET_TENSOR_ARENA_ATTR __attribute__((aligned(16)))
-#define ET_ETHOSU_SCRATCH_ATTR __attribute__((aligned(16)))
+#define ET_METHOD_POOL_ATTR __attribute__((aligned(16)))
+#endif
+
+#if !defined(ET_ARM_METHOD_ALLOCATOR_POOL_SIZE)
+#define ET_ARM_METHOD_ALLOCATOR_POOL_SIZE (1572864)
+#endif
+const size_t method_allocation_pool_size = ET_ARM_METHOD_ALLOCATOR_POOL_SIZE;
+ET_METHOD_POOL_ATTR
+unsigned char method_allocation_pool[ET_ARM_METHOD_ALLOCATOR_POOL_SIZE];
+
+#if !defined(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
+#define ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE (32768)
 #endif
 
 #if !defined(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
 #define ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x600
 #endif
 
-const size_t method_allocation_pool_size = ET_ARM_METHOD_ALLOCATOR_POOL_SIZE;
-ET_TENSOR_ARENA_ATTR
-unsigned char method_allocation_pool[ET_ARM_METHOD_ALLOCATOR_POOL_SIZE];
-
+/*
+ * NPU-accessible buffers MUST be in DTCM (BSS), NOT in SRAM0.
+ * The Ethos-U55 on Alif E8 cannot access SRAM0 (0x02000000) directly.
+ * DTCM addresses are remapped by local_to_global() to the global alias
+ * (0x50800000+offset) which the NPU can reach via the AXI fabric.
+ * This applies to ALL boards (E7, E8, E1C, B1).
+ */
 const size_t temp_allocation_pool_size =
     ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
-ET_TENSOR_ARENA_ATTR
-unsigned char temp_allocation_pool[ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
+unsigned char __attribute__((aligned(16)))
+    temp_allocation_pool[temp_allocation_pool_size];
 
 #if defined(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
 extern "C" {
 size_t ethosu_fast_scratch_size =
     ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
-ET_ETHOSU_SCRATCH_ATTR
-unsigned char dedicated_sram[ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
-unsigned char* ethosu_fast_scratch = dedicated_sram;
+unsigned char __attribute__((aligned(16)))
+    ethosu_dtcm_scratch[ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
+unsigned char* ethosu_fast_scratch = ethosu_dtcm_scratch;
 }
 #endif
 

--- a/scripts/apply_executorch_overrides.py
+++ b/scripts/apply_executorch_overrides.py
@@ -29,16 +29,66 @@ def copy_file_with_dirs(src: Path, dst: Path) -> None:
     print(f"  Copied: {src.relative_to(src.parents[3])} -> {dst.relative_to(dst.parents[5])}")
 
 
+def _resolve_latest_nightly_version(package: str, torch_url: str, nightly_date: str = None, version_prefix: str = None):
+    """
+    Query pip (via 'pip index versions') for the latest installable nightly
+    build of a package.  This is the only authoritative source: the PyTorch
+    nightly HTML index often lists wheel filenames before the files are fully
+    propagated to the CDN that pip uses, causing spurious 'not found' errors.
+
+    Args:
+        package: Package name, e.g. 'torch', 'torchvision', 'torchaudio'
+        torch_url: PyTorch nightly index URL
+        nightly_date: If given, return the version prefix that matches this date.
+        version_prefix: If given, only consider builds with this exact version
+                        prefix (e.g. '2.13.0'), so we never jump to a newer
+                        major/minor than ExecuTorch was tested against.
+
+    Returns:
+        Tuple (version_prefix, nightly_date) e.g. ('2.13.0', 'dev20260512'), or None on failure.
+    """
+    try:
+        import subprocess as _sp
+
+        result = _sp.run(
+            [sys.executable, "-m", "pip", "index", "versions", package,
+             "--pre", "--extra-index-url", torch_url],
+            capture_output=True, text=True, timeout=60,
+        )
+        # pip index versions output: "AVAILABLE VERSIONS: x.y.z, ..." or similar
+        output = result.stdout + result.stderr
+
+        matches = re.findall(
+            rf'(\d+\.\d+\.\d+)\.(dev(\d{{8}}))',
+            output,
+        )
+        if not matches:
+            return None
+
+        if version_prefix:
+            matches = [(v, d, s) for v, d, s in matches if v == version_prefix]
+            if not matches:
+                return None
+
+        if nightly_date:
+            for ver_prefix, dev_str, date_str in matches:
+                if dev_str == nightly_date:
+                    return (ver_prefix, dev_str)
+            return None
+        else:
+            latest = max(matches, key=lambda t: t[2])
+            return (latest[0], latest[1])
+    except Exception as err:
+        print(f"  Warning: Could not resolve latest nightly for {package} from pip: {err}")
+        return None
+
+
 def patch_torch_versions(executorch_dir: Path) -> bool:
     """
     Patch ExecutorTorch torch version pins to use available nightly builds.
 
-    The original versions may no longer be available on PyPI, so we update
-    to newer compatible versions using regex patterns for robustness.
-
-    Note: PyTorch nightly versions change frequently. This is a temporary
-    workaround and may need updates when ExecutorTorch upstream updates
-    their version pins.
+    The nightly version is resolved dynamically by querying the PyTorch nightly
+    index, so this never goes stale when old builds are purged from PyPI.
 
     Args:
         executorch_dir: Path to the executorch module directory
@@ -48,11 +98,57 @@ def patch_torch_versions(executorch_dir: Path) -> bool:
     """
     print("Patching PyTorch version pins...")
 
-    # Target versions - update these when newer nightlies are needed
-    TARGET_TORCH_VERSION = "2.12.0"
-    TARGET_NIGHTLY_VERSION = "dev20260223"
-    TARGET_TORCHVISION_VERSION = "0.26.0"
-    TARGET_TORCHAUDIO_VERSION = "2.11.0"
+    TORCH_NIGHTLY_URL = "https://download.pytorch.org/whl/nightly/cpu"
+    FALLBACK_NIGHTLY_VERSION = "dev20260415"
+    FALLBACK_TORCHVISION_VERSION = "0.27.0"
+    FALLBACK_TORCHAUDIO_VERSION = "2.12.0"
+
+    # Read the upstream-pinned TORCH_VERSION from torch_pin.py so we never
+    # jump to a newer major/minor than ExecuTorch was tested against.
+    torch_pin_file = executorch_dir / "torch_pin.py"
+    PINNED_TORCH_VERSION = None
+    if torch_pin_file.exists():
+        with open(torch_pin_file, 'r') as f:
+            m = re.search(r'TORCH_VERSION\s*=\s*"(\d+\.\d+\.\d+)"', f.read())
+            if m:
+                PINNED_TORCH_VERSION = m.group(1)
+
+    if PINNED_TORCH_VERSION:
+        print(f"  Upstream-pinned torch version: {PINNED_TORCH_VERSION}")
+        print(f"  Querying PyTorch nightly index for latest {PINNED_TORCH_VERSION} build...")
+        torch_result = _resolve_latest_nightly_version("torch", TORCH_NIGHTLY_URL, version_prefix=PINNED_TORCH_VERSION)
+        if not torch_result:
+            print(f"  No {PINNED_TORCH_VERSION} nightly found, trying latest available nightly...")
+            torch_result = _resolve_latest_nightly_version("torch", TORCH_NIGHTLY_URL)
+    else:
+        print(f"  Could not read upstream torch_pin.py, querying latest torch nightly...")
+        torch_result = _resolve_latest_nightly_version("torch", TORCH_NIGHTLY_URL)
+
+    if torch_result:
+        TARGET_TORCH_VERSION, TARGET_NIGHTLY_VERSION = torch_result
+        print(f"  Resolved torch: {TARGET_TORCH_VERSION}.{TARGET_NIGHTLY_VERSION}")
+    else:
+        TARGET_TORCH_VERSION = PINNED_TORCH_VERSION or "2.12.0"
+        TARGET_NIGHTLY_VERSION = FALLBACK_NIGHTLY_VERSION
+        print(f"  Could not resolve torch nightly, falling back to {TARGET_TORCH_VERSION}.{TARGET_NIGHTLY_VERSION}")
+
+    print(f"  Querying PyTorch nightly index for torchvision matching {TARGET_NIGHTLY_VERSION}...")
+    tv_result = _resolve_latest_nightly_version("torchvision", TORCH_NIGHTLY_URL, TARGET_NIGHTLY_VERSION)
+    if tv_result:
+        TARGET_TORCHVISION_VERSION = tv_result[0]
+        print(f"  Resolved torchvision: {TARGET_TORCHVISION_VERSION}.{TARGET_NIGHTLY_VERSION}")
+    else:
+        TARGET_TORCHVISION_VERSION = FALLBACK_TORCHVISION_VERSION
+        print(f"  Could not resolve torchvision nightly, falling back to {TARGET_TORCHVISION_VERSION}")
+
+    print(f"  Querying PyTorch nightly index for torchaudio matching {TARGET_NIGHTLY_VERSION}...")
+    ta_result = _resolve_latest_nightly_version("torchaudio", TORCH_NIGHTLY_URL, TARGET_NIGHTLY_VERSION)
+    if ta_result:
+        TARGET_TORCHAUDIO_VERSION = ta_result[0]
+        print(f"  Resolved torchaudio: {TARGET_TORCHAUDIO_VERSION}.{TARGET_NIGHTLY_VERSION}")
+    else:
+        TARGET_TORCHAUDIO_VERSION = FALLBACK_TORCHAUDIO_VERSION
+        print(f"  Could not resolve torchaudio nightly, falling back to {TARGET_TORCHAUDIO_VERSION}")
 
     # Patch torch_pin.py using regex for robustness
     torch_pin_file = executorch_dir / "torch_pin.py"
@@ -62,7 +158,6 @@ def patch_torch_versions(executorch_dir: Path) -> bool:
 
         original_content = content
 
-        # Use regex to match version patterns more flexibly
         # Match TORCH_VERSION = "X.Y.Z" where X, Y, Z are digits
         content = re.sub(
             r'TORCH_VERSION\s*=\s*"(\d+\.\d+\.\d+)"',


### PR DESCRIPTION
- Fix PSBT-1688: NPU scratch buffers always in DTCM; method pool conditional on sram0 presence, fixing linker failure on E1C/B1
- Kconfig/prj.conf: board-conditional pool sizes (64KB DTCM for E1C/B1, 1.5MB SRAM0 for E7/E8); remove hardcoded overrides
- sample.yaml/README: add E8 U85 test entries and build commands; apply_executorch_overrides.py: dynamic PyTorch nightly resolution