### PR TITLE
tests: drivers: spi: fix DMA and DTC overlay configuration

### DIFF
--- a/tests/drivers/spi/CMakeLists.txt
+++ b/tests/drivers/spi/CMakeLists.txt
@@ -1,107 +1,34 @@
 cmake_minimum_required(VERSION 3.20.0)
 
-# ==================== BOARD AUTO-DETECTION ==================
-# Set ALIF_BOARD macro for overlay preprocessor so every overlay
-# automatically picks the right pins / interrupts / console.
-# Override on the command line:  west build -b <board> -- -DALIF_BOARD=ALIF_BOARD_E7_HP
-if(NOT DEFINED ALIF_BOARD)
-  if(BOARD MATCHES "e7.*rtss_he")
-    set(ALIF_BOARD "ALIF_BOARD_E7_HE")
-  elseif(BOARD MATCHES "e7.*rtss_hp")
-    set(ALIF_BOARD "ALIF_BOARD_E7_HP")
-  elseif(BOARD MATCHES "e8.*rtss_he")
-    set(ALIF_BOARD "ALIF_BOARD_E8_HE")
-  elseif(BOARD MATCHES "e8.*rtss_hp")
-    set(ALIF_BOARD "ALIF_BOARD_E8_HP")
-  elseif(BOARD MATCHES "a5")
-    set(ALIF_BOARD "ALIF_BOARD_A5")
-  elseif(BOARD MATCHES "e1c.*rtss_he")
-    set(ALIF_BOARD "ALIF_BOARD_E1C")
-  elseif(BOARD MATCHES "b1.*rtss_he")
-    set(ALIF_BOARD "ALIF_BOARD_B1")
-  else()
-    set(ALIF_BOARD "ALIF_BOARD_E8_HP")
-    message(WARNING "Unknown board '${BOARD}' — defaulting to E8 HP pin mapping.
-            Set -DALIF_BOARD=... to override.")
-  endif()
-endif()
-
-# Pass to the devicetree preprocessor so overlays resolve the macros.
-# C code does not need ALIF_BOARD, but the C preprocessor that runs on .overlay
-# files uses DTS_EXTRA_CPPFLAGS.
-list(APPEND DTS_EXTRA_CPPFLAGS "-DALIF_BOARD=${ALIF_BOARD}")
-message(STATUS "SPI test overlay board: ${ALIF_BOARD}")
-
-# Default overlay for plain west builds; Twister/CLI overlays take precedence.
-if(NOT DTC_OVERLAY_FILE)
-  set(DTC_OVERLAY_FILE
-      ${CMAKE_CURRENT_SOURCE_DIR}/boards/spi.overlay
-      CACHE STRING "Default SPI test overlay" FORCE)
+# ==================== BOARD OVERRIDE (optional) ==================
+# ALIF_BOARD is auto-detected in board_common.overlay from Zephyr
+# Kconfig symbols (CONFIG_SOC_SERIES_* / CONFIG_RTSS_*).
+# To override manually: west build -b <board> -- -DALIF_BOARD=ALIF_BOARD_E7_HP
+if(DEFINED ALIF_BOARD)
+  list(APPEND DTS_EXTRA_CPPFLAGS "-DALIF_BOARD=${ALIF_BOARD}")
+  message(STATUS "SPI test overlay board (manual override): ${ALIF_BOARD}")
 endif()
 
 # ==================== ZEPHYR PROJECT SETUP ==================
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(alif_spi)
 
-
-
 # ==================== STACK SIZES ==========================
 # Stack sizes are defined in prj.conf (20KB default for all tests)
 
 target_include_directories(app PRIVATE src)
 
-# ==================== SOURCE FILE DEFINITIONS ================
-set(SPI_CORE_SOURCES
+# ==================== SOURCE FILES ==========================
+target_sources(app PRIVATE
   src/test_spi_common.c
   src/test_spi_threads.c
 )
 
-set(SPI_LOOPBACK_SOURCES
-  src/test_spi_loopback.c
-)
-
-set(SPI_NEGATIVE_SOURCES
-  src/test_spi_negative.c
-)
-
-set(SPI_BOUNDARY_SOURCES
-  src/test_spi_boundary.c
-)
-
-set(SPI_STRESS_SOURCES
-  src/test_spi_stress.c
-)
-
-set(SPI_PERF_SOURCES
-  src/test_spi_perf.c
-)
-
-# ==================== CORE TEST BUILD ========================
-set(SPI_TEST_SOURCES ${SPI_CORE_SOURCES})
-
-# ==================== CONDITIONAL TEST SUITES ==============
-# Include test sources based on Kconfig selections
-if(CONFIG_TEST_SPI_LOOPBACK)
-  list(APPEND SPI_TEST_SOURCES ${SPI_LOOPBACK_SOURCES})
-endif()
-
-if(CONFIG_TEST_SPI_NEGATIVE)
-  list(APPEND SPI_TEST_SOURCES ${SPI_NEGATIVE_SOURCES})
-endif()
-
-if(CONFIG_TEST_SPI_BOUNDARY)
-  list(APPEND SPI_TEST_SOURCES ${SPI_BOUNDARY_SOURCES})
-endif()
-
-if(CONFIG_TEST_SPI_STRESS)
-  list(APPEND SPI_TEST_SOURCES ${SPI_STRESS_SOURCES})
-endif()
-
-if(CONFIG_TEST_SPI_PERFORMANCE)
-  list(APPEND SPI_TEST_SOURCES ${SPI_PERF_SOURCES})
-endif()
-
-target_sources(app PRIVATE ${SPI_TEST_SOURCES})
+target_sources_ifdef(CONFIG_TEST_SPI_LOOPBACK    app PRIVATE src/test_spi_loopback.c)
+target_sources_ifdef(CONFIG_TEST_SPI_NEGATIVE   app PRIVATE src/test_spi_negative.c)
+target_sources_ifdef(CONFIG_TEST_SPI_BOUNDARY   app PRIVATE src/test_spi_boundary.c)
+target_sources_ifdef(CONFIG_TEST_SPI_STRESS     app PRIVATE src/test_spi_stress.c)
+target_sources_ifdef(CONFIG_TEST_SPI_PERFORMANCE app PRIVATE src/test_spi_perf.c)
 
 # ==================== COMPILATION FLAGS ======================
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tests/drivers/spi/Kconfig
+++ b/tests/drivers/spi/Kconfig
@@ -40,9 +40,43 @@ config TEST_SPI_PERFORMANCE
 	bool "Performance tests"
 	help
 	  Enable the SPI performance test suite.  It runs back-to-back
-	  MOSI, MISO and full-duplex transceive tests across 8, 16 and
-	  32-bit word sizes while sweeping frequencies from 1x to 25x
-	  the base rate, reporting cycle counts and elapsed time.
+	  MOSI, MISO and full-duplex transceive tests while sweeping the
+	  frequency from TEST_SPI_PERF_FREQ_MIN_MHZ to
+	  TEST_SPI_PERF_FREQ_MAX_MHZ (defaults 1x..50x the base rate) in
+	  TEST_SPI_PERF_FREQ_STEP_MHZ increments, reporting cycle counts
+	  and elapsed time.
+
+# ---------------------------------------------------------------------------
+# Performance sweep range (multipliers of TEST_SPI_FREQUENCY)
+# ---------------------------------------------------------------------------
+
+config TEST_SPI_PERF_FREQ_MIN_MHZ
+	int "Performance sweep start frequency (x base)"
+	depends on TEST_SPI_PERFORMANCE
+	default 1
+	help
+	  First frequency multiplier of the performance sweep, in units
+	  of TEST_SPI_FREQUENCY (default base 1 MHz).  With the default
+	  base of 1 MHz this is the start frequency in MHz.
+
+config TEST_SPI_PERF_FREQ_MAX_MHZ
+	int "Performance sweep end frequency (x base)"
+	depends on TEST_SPI_PERFORMANCE
+	default 5
+	help
+	  Last frequency multiplier of the performance sweep, in units
+	  of TEST_SPI_FREQUENCY (default base 1 MHz).  With the default
+	  base of 1 MHz this is the end frequency in MHz.
+
+config TEST_SPI_PERF_FREQ_STEP_MHZ
+	int "Performance sweep step (x base)"
+	depends on TEST_SPI_PERFORMANCE
+	range 1 5
+	default 1
+	help
+	  Increment between consecutive sweep points, in units of
+	  TEST_SPI_FREQUENCY.  The endpoint TEST_SPI_PERF_FREQ_MAX_MHZ is
+	  always tested even if it does not fall on a step boundary.
 
 # ---------------------------------------------------------------------------
 # Test options

--- a/tests/drivers/spi/README.rst
+++ b/tests/drivers/spi/README.rst
@@ -172,9 +172,24 @@ Top-level suite selection:
 
 Test tuning:
 
-- ``CONFIG_TEST_SPI_FREQUENCY``      Base SPI frequency in Hz (default 1 MHz)
+- ``CONFIG_TEST_SPI_FREQUENCY``      Base SPI frequency in Hz (default 1 MHz).
+  This is the **global base** used by all suites (loopback sweep multipliers,
+  boundary max-frequency, negative tests, and performance sweep multipliers).
 - ``CONFIG_TEST_SPI_WORD_SIZE``      Pinned word size for all suites (0 = sweep 8/16/32)
 - ``CONFIG_TEST_SPI_INTERNAL_LOOPBACK`` Use internal loopback mode
+
+Performance sweep (only when ``CONFIG_TEST_SPI_PERFORMANCE=y``):
+
+- ``CONFIG_TEST_SPI_PERF_FREQ_MIN_MHZ``   Start multiplier (default 1)
+- ``CONFIG_TEST_SPI_PERF_FREQ_MAX_MHZ``   End multiplier (default 50)
+- ``CONFIG_TEST_SPI_PERF_FREQ_STEP_MHZ``  Step increment (default 5)
+
+  The sweep evaluates frequencies from ``MIN * TEST_SPI_FREQUENCY`` up to
+  ``MAX * TEST_SPI_FREQUENCY`` in ``STEP`` increments.  The max point is always
+  tested even when it does not fall on a step boundary.
+
+  To test at a **single fixed frequency**, set ``MIN`` and ``MAX`` to the same
+  multiplier (``STEP`` is then ignored).
 
 Setting Kconfig options
 =====================

--- a/tests/drivers/spi/boards/board_common.overlay
+++ b/tests/drivers/spi/boards/board_common.overlay
@@ -30,11 +30,10 @@
 /* --- Board enum ------------------------------------------------------- */
 #define ALIF_BOARD_E7_HP 1
 #define ALIF_BOARD_E8_HP 2
-#define ALIF_BOARD_A5    3
-#define ALIF_BOARD_E7_HE 4
-#define ALIF_BOARD_E8_HE 5
-#define ALIF_BOARD_E1C   6
-#define ALIF_BOARD_B1    7
+#define ALIF_BOARD_E7_HE 3
+#define ALIF_BOARD_E8_HE 4
+#define ALIF_BOARD_E1C   5
+#define ALIF_BOARD_B1    6
 
 /* Manual override: -DALIF_BOARD=ALIF_BOARD_E7_HP on west command line  */
 #ifndef ALIF_BOARD
@@ -51,13 +50,12 @@
 #endif
 
 /* --- SPI0 pinmux ------------------------------------------------------ */
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define SPI0_MISO   PIN_P5_0__SPI0_MISO_B
   #define SPI0_MOSI   PIN_P5_1__SPI0_MOSI_B
   #define SPI0_SCLK   PIN_P5_2__SPI0_SCLK_B
   #define SPI0_SS0    PIN_P5_3__SPI0_SS0_B
-#elif ALIF_BOARD == ALIF_BOARD_E7_HP
+#elif ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E7_HE
   #define SPI0_MISO   PIN_P5_0__SPI0_MISO_B
   #define SPI0_MOSI   PIN_P5_1__SPI0_MOSI_B
   #define SPI0_SCLK   PIN_P5_3__SPI0_SCLK_B
@@ -80,8 +78,7 @@
   #define SPI1_MOSI   PIN_P14_5__SPI1_MOSI_C
   #define SPI1_SCLK   PIN_P14_6__SPI1_SCLK_C
   #define SPI1_SS0    PIN_P14_7__SPI1_SS0_C
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#elif ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define SPI1_MISO   PIN_P8_4__SPI1_MISO_C
   #define SPI1_MOSI   PIN_P8_5__SPI1_MOSI_C
   #define SPI1_SCLK   PIN_P8_6__SPI1_SCLK_C
@@ -89,8 +86,7 @@
 #endif
 
 /* --- SPI2 pinmux ------------------------------------------------------ */
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define SPI2_MISO   PIN_P7_0__SPI2_MISO_B
   #define SPI2_MOSI   PIN_P7_1__SPI2_MOSI_B
   #define SPI2_SCLK   PIN_P7_2__SPI2_SCLK_B
@@ -117,23 +113,22 @@
   #define SPI3_SS0    PIN_P12_7__SPI3_SS0_A
 #endif
 
-/* --- SPI4 / LPSPI0 pinmux (HE boards + A5) -------------------------- */
+/* --- SPI4 / LPSPI0 pinmux (HE boards) -------------------------- */
 #if ALIF_BOARD == ALIF_BOARD_E7_HE
   #define SPI4_MISO   PIN_P7_4__LPSPI_MISO_A
   #define SPI4_MOSI   PIN_P7_5__LPSPI_MOSI_A
   #define SPI4_SCLK   PIN_P7_6__LPSPI_SCLK_A
-  #define SPI4_SS0    PIN_P7_7__LPSPI_SS0_A
+  #define SPI4_SS0    PIN_P7_7__LPSPI_SS_A
 #elif ALIF_BOARD == ALIF_BOARD_E8_HE
   #define SPI4_MISO   PIN_P11_4__LPSPI_MISO_B
   #define SPI4_MOSI   PIN_P11_5__LPSPI_MOSI_B
   #define SPI4_SCLK   PIN_P11_6__LPSPI_SCLK_B
   #define SPI4_SS0    PIN_P11_7__LPSPI_SS0_B
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#elif ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define LPSPI0_MISO PIN_P1_3__LPSPI_MISO_A
   #define LPSPI0_MOSI PIN_P1_4__LPSPI_MOSI_A
   #define LPSPI0_SCLK PIN_P1_5__LPSPI_SCLK_A
-  #define LPSPI0_SS0  PIN_P2_0__LPSPI_SS0_A
+  #define LPSPI0_SS0  PIN_P2_0__LPSPI_SS_A
 #endif
 
 /* --- Interrupt numbers (instance-based, same across boards) ---------- */
@@ -141,7 +136,7 @@
 #define SPI1_IRQ    138
 #define SPI2_IRQ    139
 #define SPI3_IRQ    140
-#define SPI4_IRQ    46   /* LPSPI0 uses same number on A5 */
+#define SPI4_IRQ    46   /* LPSPI0 interrupt number */
 
 /* --- Software-CS GPIO pins (SPI1-based overlays) --------------------- */
 #if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E7_HE
@@ -152,8 +147,7 @@
   #define SPI_SS_GPIO_PIN   PIN_P14_7__GPIO
   #define SPI_SS_GPIO_BANK  gpio14
   #define SPI_SS_GPIO_NUM   7
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#elif ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define SPI_SS_GPIO_PIN   PIN_P8_7__GPIO
   #define SPI_SS_GPIO_BANK  gpio8
   #define SPI_SS_GPIO_NUM   7
@@ -168,21 +162,10 @@
   #define LPSPI_SS_GPIO_PIN   PIN_P11_7__GPIO
   #define LPSPI_SS_GPIO_BANK  gpio11
   #define LPSPI_SS_GPIO_NUM   7
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#elif ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
   #define LPSPI_SS_GPIO_PIN   PIN_P2_0__GPIO
   #define LPSPI_SS_GPIO_BANK  gpio2
   #define LPSPI_SS_GPIO_NUM   0
-#endif
-
-/* --- DMA controller per board ----------------------------------------- */
-#if ALIF_BOARD == ALIF_BOARD_E7_HP || ALIF_BOARD == ALIF_BOARD_E8_HP
-  #define DMA_CTRL    dma1
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
-  #define DMA_CTRL    dma2
-#else  /* E7_HE, E8_HE */
-  #define DMA_CTRL    dma2
 #endif
 
 #endif /* ALIF_BOARD_COMMON_OVERLAY */

--- a/tests/drivers/spi/boards/lpspi.overlay
+++ b/tests/drivers/spi/boards/lpspi.overlay
@@ -9,7 +9,7 @@
 
 /* LPSPI / SPI test overlay.
  * HE: SPI4 controller <-> SPI0/SPI1 target (board-dependent)
- * A5: LPSPI0 controller <-> SPI1 target
+ * E1C/B1: LPSPI0 controller <-> SPI1 target
  */
 #include "board_common.overlay"
 
@@ -21,8 +21,7 @@
 #elif ALIF_BOARD == ALIF_BOARD_E8_HE
 		controller-spi = &spi4;
 		target-spi     = &spi1;
-#elif ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#elif ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 		controller-spi = &lpspi0;
 		target-spi     = &spi1;
 #else
@@ -45,8 +44,7 @@
 	status = "disabled";
 };
 
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 &lpspi0 {
 	status = "okay";
 	interrupts = <SPI4_IRQ 0>;
@@ -80,6 +78,8 @@
 			 < SPI0_SCLK >,
 			 < SPI0_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #endif
@@ -92,12 +92,13 @@
 			 < SPI1_SCLK >,
 			 < SPI1_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #endif
 
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 &pinctrl_lpspi0 {
 	group0 {
 		pinmux = < LPSPI0_MISO >,
@@ -105,6 +106,8 @@
 			 < LPSPI0_SCLK >,
 			 < LPSPI0_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #else
@@ -115,6 +118,8 @@
 			 < SPI4_SCLK >,
 			 < SPI4_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #endif

--- a/tests/drivers/spi/boards/lpspi_DMA.overlay
+++ b/tests/drivers/spi/boards/lpspi_DMA.overlay
@@ -8,35 +8,38 @@
  */
 
 /* DMA overlay for LPSPI test instances.  Stack with boards/lpspi.overlay.
- * HP boards use dma1; HE / A5 / E1C / B1 use dma2.
+ * spi4/lpspi0 uses dma2; spi0/spi1 uses dma0.
  */
 #include "board_common.overlay"
 
-&DMA_CTRL {
+&dma0 {
 	status = "okay";
 };
 
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+&dma2 {
+	status = "okay";
+};
+
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 &lpspi0 {
-	dmas = <&DMA_CTRL 0 13>, <&DMA_CTRL 1 12>;
+	dmas = <&dma2 0 13>, <&dma2 1 12>;
 	dma-names = "txdma", "rxdma";
 };
 #else
 &spi4 {
-	dmas = <&DMA_CTRL 0 13>, <&DMA_CTRL 1 12>;
+	dmas = <&dma2 0 13>, <&dma2 1 12>;
 	dma-names = "txdma", "rxdma";
 };
 #endif
 
 #if ALIF_BOARD == ALIF_BOARD_E7_HE
 &spi0 {
-	dmas = <&DMA_CTRL 2 20>, <&DMA_CTRL 3 16>;
+	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
 };
 #else
 &spi1 {
-	dmas = <&DMA_CTRL 2 21>, <&DMA_CTRL 3 17>;
+	dmas = <&dma0 2 21>, <&dma0 3 17>;
 	dma-names = "txdma", "rxdma";
 };
 #endif

--- a/tests/drivers/spi/boards/lpspi_DMA_evtrtr.overlay
+++ b/tests/drivers/spi/boards/lpspi_DMA_evtrtr.overlay
@@ -9,11 +9,12 @@
 
 /* Event-router DMA overlay for LPSPI instances.
  * Stack with boards/lpspi.overlay.
+ * LPSPI is HE-only, uses dma2 and evtrtr2.
  */
 #include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
 #include "board_common.overlay"
 
-&DMA_CTRL {
+&dma2 {
 	status = "okay";
 };
 
@@ -21,8 +22,7 @@
 	status = "okay";
 };
 
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 &lpspi0 {
 	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 2, 1) 13>,
 	       <&evtrtr2 ALIF_DMA_ENCODE(1, 2, 1) 12>;

--- a/tests/drivers/spi/boards/lpspi_ss_sw.overlay
+++ b/tests/drivers/spi/boards/lpspi_ss_sw.overlay
@@ -12,8 +12,7 @@
  */
 #include "board_common.overlay"
 
-#if ALIF_BOARD == ALIF_BOARD_A5 || ALIF_BOARD == ALIF_BOARD_E1C || \
-	ALIF_BOARD == ALIF_BOARD_B1
+#if ALIF_BOARD == ALIF_BOARD_E1C || ALIF_BOARD == ALIF_BOARD_B1
 &lpspi0 {
 	status = "okay";
 	cs-gpios = <&LPSPI_SS_GPIO_BANK LPSPI_SS_GPIO_NUM GPIO_ACTIVE_LOW>;
@@ -27,6 +26,8 @@
 			 < LPSPI0_SCLK >,
 			 < LPSPI_SS_GPIO_PIN >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #else
@@ -43,6 +44,8 @@
 			 < SPI4_SCLK >,
 			 < LPSPI_SS_GPIO_PIN >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 #endif

--- a/tests/drivers/spi/boards/spi.overlay
+++ b/tests/drivers/spi/boards/spi.overlay
@@ -36,12 +36,22 @@
 &spi1 {
 	status = "okay";
 	interrupts = <SPI1_IRQ 0>;
+	/* Controller samples MISO. At high SCLK the round-trip
+	 * (SCLK out -> target -> MISO back) exceeds one bit period,
+	 * so delay the RX sample point. Tune this for the test freq.
+	 * Units: ssi_clk (HCLK = 200 MHz) cycles. Default in DTS is 4.
+	 */
+	/*rx-delay = <8>;*/
 };
 
 &spi0 {
 	status = "okay";
 	serial-target;
 	interrupts = <SPI0_IRQ 1>;
+	/* Same-chip target RX at 50 MHz: sample on the clock edge
+	 * (no additional delay).  Default rx-delay=4 is too late.
+	 */
+	/*rx-delay = <0>;*/
 };
 
 &pinctrl_spi0 {
@@ -51,6 +61,8 @@
 			 < SPI0_SCLK >,
 			 < SPI0_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 
@@ -61,5 +73,7 @@
 			 < SPI1_SCLK >,
 			 < SPI1_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };

--- a/tests/drivers/spi/boards/spi2.overlay
+++ b/tests/drivers/spi/boards/spi2.overlay
@@ -47,6 +47,8 @@
 			 < SPI1_SCLK >,
 			 < SPI1_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 
@@ -57,5 +59,7 @@
 			 < SPI2_SCLK >,
 			 < SPI2_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };

--- a/tests/drivers/spi/boards/spi3.overlay
+++ b/tests/drivers/spi/boards/spi3.overlay
@@ -47,6 +47,8 @@
 			 < SPI1_SCLK >,
 			 < SPI1_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };
 
@@ -57,5 +59,7 @@
 			 < SPI3_SCLK >,
 			 < SPI3_SS0 >;
 		read-enable = < 0x1 >;
+		drive-strength = < 12 >;
+		slew-rate = < 1 >;
 	};
 };

--- a/tests/drivers/spi/boards/spi_DMA.overlay
+++ b/tests/drivers/spi/boards/spi_DMA.overlay
@@ -8,20 +8,20 @@
  */
 
 /* DMA overlay for SPI1/SPI0.  Stack with boards/spi.overlay.
- * HP boards use dma1; HE / A5 / E1C / B1 use dma2.
+ * SPI instances are shared peripherals, use dma0 for both HP and HE.
  */
 #include "board_common.overlay"
 
-&DMA_CTRL {
+&dma0 {
 	status = "okay";
 };
 
 &spi1 {
-	dmas = <&DMA_CTRL 0 21>, <&DMA_CTRL 1 17>;
+	dmas = <&dma0 0 21>, <&dma0 1 17>;
 	dma-names = "txdma", "rxdma";
 };
 
 &spi0 {
-	dmas = <&DMA_CTRL 2 20>, <&DMA_CTRL 3 16>;
+	dmas = <&dma0 2 20>, <&dma0 3 16>;
 	dma-names = "txdma", "rxdma";
 };

--- a/tests/drivers/spi/prj.conf
+++ b/tests/drivers/spi/prj.conf
@@ -7,8 +7,9 @@ CONFIG_SPI_SLAVE=y
 # Zephyr test framework
 CONFIG_ZTEST=y
 
-# Logging - Fix console output issues
+
 CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=1
 
 # Kernel features
 CONFIG_EVENTS=y

--- a/tests/drivers/spi/src/test_spi_boundary.c
+++ b/tests/drivers/spi/src/test_spi_boundary.c
@@ -26,11 +26,10 @@
 
 #include "test_spi_common.h"
 
-LOG_MODULE_REGISTER(alif_spi_bnd, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_bnd, LOG_LEVEL_INF);
 
 #define BND_MAX_BUF           1024
 #define BND_DEFAULT_FREQ      SPI_FREQ_MHZ
-#define BND_ASYNC_TIMEOUT_MS  500
 
 static const struct device *const controller_dev =
 	DEVICE_DT_GET(SPI_CONTROLLER_NODE);
@@ -44,6 +43,8 @@ static int bnd_xfer(const struct spi_config *cfg,
 		    bool async)
 {
 	int ret;
+	size_t tx_len = 0U;
+	size_t rx_len = 0U;
 
 	if (!async) {
 		return spi_transceive(controller_dev, cfg, tx, rx);
@@ -57,9 +58,23 @@ static int bnd_xfer(const struct spi_config *cfg,
 	if (ret != 0) {
 		return ret;
 	}
-	ret = k_poll(&bnd_async_evt, 1, K_MSEC(BND_ASYNC_TIMEOUT_MS));
+
+	if ((tx != NULL) && (tx->buffers != NULL)) {
+		for (size_t i = 0U; i < tx->count; i++) {
+			tx_len += tx->buffers[i].len;
+		}
+	}
+	if ((rx != NULL) && (rx->buffers != NULL)) {
+		for (size_t i = 0U; i < rx->count; i++) {
+			rx_len += rx->buffers[i].len;
+		}
+	}
+
+	ret = k_poll(&bnd_async_evt, 1,
+		     spi_test_transfer_timeout(MAX(tx_len, rx_len),
+					       cfg->frequency));
 	if (ret != 0) {
-		LOG_ERR("boundary async poll timeout");
+		LOG_ERR("boundary async poll timeout @%u Hz", cfg->frequency);
 		return -ETIMEDOUT;
 	}
 	return bnd_async_sig.result;
@@ -385,7 +400,7 @@ ZTEST(test_spi_boundary, test_boundary_async)
 
 static void boundary_suite_before(void *fixture)
 {
-	ARG_UNUSED(fixture);
+	test_before_func(fixture);
 
 	k_poll_signal_init(&bnd_async_sig);
 	k_poll_event_init(&bnd_async_evt, K_POLL_TYPE_SIGNAL,

--- a/tests/drivers/spi/src/test_spi_common.c
+++ b/tests/drivers/spi/src/test_spi_common.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/sys/atomic.h>
 
-LOG_MODULE_REGISTER(alif_spi_common, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_common, LOG_LEVEL_INF);
 
 #define SPI_TEST_CFG_SHADOW_DEPTH 1024U
 
@@ -111,6 +111,26 @@ void spi_test_controller_cs_init(struct spi_cs_control *cs)
 #endif
 }
 
+uint64_t spi_test_transfer_timeout_ms(size_t bytes, uint32_t freq_hz)
+{
+	uint64_t bits;
+	uint64_t transfer_ms;
+
+	if ((bytes == 0U) || (freq_hz == 0U)) {
+		return SPI_TEST_TIMEOUT_MARGIN_MS;
+	}
+
+	bits = (uint64_t)bytes * 8U;
+	transfer_ms = (bits * 1000U + freq_hz - 1U) / freq_hz;
+	return transfer_ms + CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE +
+	       SPI_TEST_TIMEOUT_MARGIN_MS;
+}
+
+k_timeout_t spi_test_transfer_timeout(size_t bytes, uint32_t freq_hz)
+{
+	return K_MSEC(spi_test_transfer_timeout_ms(bytes, freq_hz));
+}
+
 int spi_test_transceive(const struct device *dev,
 			const struct spi_config *cnfg,
 			const struct spi_buf_set *tx_set,
@@ -163,12 +183,24 @@ int spi_test_transceive_async(const struct device *dev,
 			      const struct spi_buf_set *rx_set,
 			      bool force_reconfig)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cnfg);
+	ARG_UNUSED(tx_set);
+	ARG_UNUSED(rx_set);
+	ARG_UNUSED(force_reconfig);
+
+#if !IS_ENABLED(CONFIG_SPI_ASYNC)
+	LOG_ERR("Async SPI not enabled");
+	return -ENOTSUP;
+#else
 	struct spi_config *active_cfg;
 	const struct spi_config *cfg_to_use;
 	atomic_val_t idx;
 	struct k_poll_signal async_sig;
 	struct k_poll_event async_evt;
 	int ret;
+	size_t tx_len = 0U;
+	size_t rx_len = 0U;
 
 	if (dev == NULL) {
 		LOG_ERR("%s: NULL device", __func__);
@@ -202,18 +234,34 @@ int spi_test_transceive_async(const struct device *dev,
 	k_poll_event_init(&async_evt, K_POLL_TYPE_SIGNAL,
 			  K_POLL_MODE_NOTIFY_ONLY, &async_sig);
 
+	if ((tx_set != NULL) && (tx_set->count > 0U) &&
+	    (tx_set->buffers != NULL)) {
+		for (size_t i = 0U; i < tx_set->count; i++) {
+			tx_len += tx_set->buffers[i].len;
+		}
+	}
+	if ((rx_set != NULL) && (rx_set->count > 0U) &&
+	    (rx_set->buffers != NULL)) {
+		for (size_t i = 0U; i < rx_set->count; i++) {
+			rx_len += rx_set->buffers[i].len;
+		}
+	}
+
 	ret = spi_transceive_signal(dev, cfg_to_use, tx_set, rx_set, &async_sig);
 	if (ret != 0) {
 		return ret;
 	}
 
-	ret = k_poll(&async_evt, 1, K_MSEC(500));
+	ret = k_poll(&async_evt, 1,
+		     spi_test_transfer_timeout(MAX(tx_len, rx_len),
+					       cfg_to_use->frequency));
 	if (ret != 0) {
-		LOG_ERR("async xfer poll timeout");
+		LOG_ERR("async xfer poll timeout @%u Hz", cfg_to_use->frequency);
 		return -EIO;
 	}
 
 	return async_sig.result;
+#endif /* CONFIG_SPI_ASYNC */
 }
 
 int spi_test_controller_receive_and_check(const struct device *dev,
@@ -327,62 +375,6 @@ static void configure_lpspi0_for_dma2(void)
 }
 #endif /* E1C/B1 LPSPI0 dma2 */
 
-#if SPI_TEST_NODE_DMA_IS(spi1, dma2) /* E1C/B1 SPI1 dma2 */
-static void configure_spi1_for_dma2(void)
-{
-	const uint32_t rx_req = 17U;
-	const uint32_t tx_req = 21U;
-	const uint32_t group = 2U;
-	uint32_t regdata;
-
-	LOG_INF("Configuring spi1 for dma2");
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
-
-	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << rx_req);
-	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
-
-	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << tx_req);
-	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-}
-#endif /* E1C/B1 SPI1 dma2 */
-
-#if SPI_TEST_NODE_DMA_IS(spi0, dma2) /* SPI0 dma2 */
-static void configure_spi0_for_dma2(void)
-{
-	const uint32_t rx_req = 16U;
-	const uint32_t tx_req = 20U;
-	const uint32_t group = 2U;
-	uint32_t regdata;
-
-	LOG_INF("Configuring spi0 for dma2");
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTRLOCAL_DMA_CTRL0 + (rx_req * 4));
-
-	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << rx_req);
-	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
-
-	regdata = sys_read32(EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << tx_req);
-	sys_write32(regdata, EVTRTRLOCAL_DMA_ACK_TYPE0 + (group * 4));
-}
-#endif /* SPI0 dma2 */
-
 #if SPI_TEST_NODE_DMA_IS(spi4, dma2) /* LPSPI(SPI4) dma2 */
 static void configure_lpspi_for_dma2(void)
 {
@@ -402,40 +394,6 @@ static void configure_lpspi_for_dma2(void)
 			EVTRTRLOCAL_DMA_CTRL0 + (tx_req * 4));
 }
 #endif /* LPSPI(SPI4) dma2 */
-
-#if SPI_TEST_NODE_DMA_IS(spi4, dma0) /* LPSPI(SPI4) dma0 */
-static void configure_lpspi_for_dma0(void)
-{
-	const uint32_t rx_req = 24U;
-	const uint32_t tx_req = 25U;
-	const uint32_t group = 2U;
-	uint32_t regdata;
-
-	LOG_INF("Configuring lpspi for dma0");
-
-	regdata = sys_read32(M55HE_CFG_HE_DMA_SEL);
-	regdata &= ~HE_DMA_SEL_LPSPI_Msk;
-	regdata |= (0 << HE_DMA_SEL_LPSPI_Pos);
-	sys_write32(regdata, M55HE_CFG_HE_DMA_SEL);
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTR0_DMA_CTRL0 + (rx_req * 4));
-
-	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << rx_req);
-	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
-
-	sys_write32(DMA_CTRL_ENA |
-			(0 << DMA_CTRL_ACK_TYPE_Pos) | group,
-			EVTRTR0_DMA_CTRL0 + (tx_req * 4));
-
-	regdata = sys_read32(EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
-	regdata |= (1 << tx_req);
-	sys_write32(regdata, EVTRTR0_DMA_ACK_TYPE0 + (group * 4));
-}
-#endif /* LPSPI(SPI4) dma0 */
-
 
 /* dma0 */
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma0), arm_dma_pl330, okay)
@@ -543,9 +501,6 @@ static int spi_test_configure_dma(void)
 #if SPI_TEST_NODE_DMA_IS(lpspi0, evtrtr2)
 	LOG_INF("lpspi0 dmas -> evtrtr2 (event-router)");
 #endif
-#if SPI_TEST_NODE_DMA_IS(spi1, evtrtr2)
-	LOG_INF("spi1 dmas -> evtrtr2 (event-router)");
-#endif
 #if SPI_TEST_NODE_DMA_IS(spi4, evtrtr2)
 	LOG_INF("spi4 dmas -> evtrtr2 (event-router)");
 #endif
@@ -558,22 +513,11 @@ static int spi_test_configure_dma(void)
 #if SPI_TEST_NODE_DMA_IS(spi1, evtrtr0)
 	LOG_INF("spi1 dmas -> evtrtr0 (event-router)");
 #endif
-#if SPI_TEST_NODE_DMA_IS(spi4, evtrtr0)
-	LOG_INF("spi4 dmas -> evtrtr0 (event-router)");
-#endif
 #endif /* evtrtr0 */
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(dma2), arm_dma_pl330, okay)
 #if SPI_TEST_NODE_DMA_IS(lpspi0, dma2)
 	configure_lpspi0_for_dma2();
-#endif
-
-#if SPI_TEST_NODE_DMA_IS(spi0, dma2)
-	configure_spi0_for_dma2();
-#endif
-
-#if SPI_TEST_NODE_DMA_IS(spi1, dma2)
-	configure_spi1_for_dma2();
 #endif
 
 #if SPI_TEST_NODE_DMA_IS(spi4, dma2)
@@ -588,10 +532,6 @@ static int spi_test_configure_dma(void)
 
 #if SPI_TEST_NODE_DMA_IS(spi1, dma0)
 	configure_spi1_for_dma0();
-#endif
-
-#if SPI_TEST_NODE_DMA_IS(spi4, dma0)
-	configure_lpspi_for_dma0();
 #endif
 #endif /* dma0 */
 

--- a/tests/drivers/spi/src/test_spi_common.h
+++ b/tests/drivers/spi/src/test_spi_common.h
@@ -34,7 +34,7 @@
 /* DMA-compatible word size - DMA controllers
  * typically only support 8-bit reliably
  */
-#define SPI_TEST_DMA_WORD_SIZE      8U     /* Use 8-bit for DMA transfers */
+#define SPI_TEST_DMA_WORD_SIZE      32U     /* Use 8-bit for DMA transfers */
 
 /* Convenience macro to avoid repeating the long ternary in every test file */
 #define SPI_TEST_WORD_SIZE \
@@ -51,6 +51,7 @@
 
 #define SPI_TEST_CS_DELAY_US        100U
 #define SPI_TEST_TARGET_HEADSTART_US 10000U  /* Increased for DMA timing */
+#define SPI_TEST_TIMEOUT_MARGIN_MS  500U
 
 /* Devicetree node aliases */
 #define SPI_CONTROLLER_NODE         DT_ALIAS(controller_spi)
@@ -125,6 +126,8 @@ int spi_test_prepare_data(uint32_t *data, uint16_t pattern, uint32_t count);
 int spi_test_reset_buffer(uint32_t *buffer, size_t count);
 bool spi_test_device_ready(const struct device *dev, const char *role);
 void spi_test_controller_cs_init(struct spi_cs_control *cs);
+uint64_t spi_test_transfer_timeout_ms(size_t bytes, uint32_t freq_hz);
+k_timeout_t spi_test_transfer_timeout(size_t bytes, uint32_t freq_hz);
 
 /* Inline helper: create spi_config with CS pre-configured from DT */
 static inline struct spi_config spi_test_config(uint32_t operation,

--- a/tests/drivers/spi/src/test_spi_loopback.c
+++ b/tests/drivers/spi/src/test_spi_loopback.c
@@ -16,7 +16,7 @@
 
 #include "test_spi_common.h"
 
-LOG_MODULE_REGISTER(alif_spi_loop, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_loop, LOG_LEVEL_INF);
 
 #define LB_DEFAULT_FREQ_HZ  SPI_FREQ_MHZ
 #define LB_BUF_MAX          64

--- a/tests/drivers/spi/src/test_spi_negative.c
+++ b/tests/drivers/spi/src/test_spi_negative.c
@@ -13,14 +13,18 @@
 
 #include "test_spi_common.h"
 
-LOG_MODULE_REGISTER(alif_spi_neg, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_neg, LOG_LEVEL_INF);
 
 static const struct device *const controller_dev =
 	DEVICE_DT_GET(SPI_CONTROLLER_NODE);
 
+/* ------------------------------------------------------------------
+ * Helpers
+ * ------------------------------------------------------------------
+ */
 static struct spi_config neg_test_cfg(uint32_t extra_flags,
-					uint32_t word_size,
-					uint32_t freq_hz)
+				      uint32_t word_size,
+				      uint32_t freq_hz)
 {
 	struct spi_config cfg = {
 		.frequency = freq_hz,
@@ -48,10 +52,64 @@ static int do_loopback_xfer(const struct spi_config *cfg,
 	return spi_test_transceive(controller_dev, cfg, txs, rxs, false);
 }
 
-
-static int subtest_lsb_first(void)
+/* ------------------------------------------------------------------
+ * Suite-level before function: shared setup + device-ready check
+ * ------------------------------------------------------------------
+ */
+static void test_spi_negative_before(void *fixture)
 {
-	struct spi_config cfg = neg_test_cfg(SPI_TRANSFER_LSB,
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(SPI_TRANSFER_LSB,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	struct spi_config cfg = neg_test_cfg(SPI_TRANSFER_LSB, 8U, SPI_FREQ_MHZ);
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx), rx, sizeof(rx));
+
+	zassert_equal(ret, -EINVAL,
+		      "LSB-first: expected -EINVAL, got %d", ret);
+}
+
+ZTEST(test_spi_negative, test_release_wrong_cfg)
+{
+	static struct spi_config cfg1;
+
+	cfg1 = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+	uint8_t rx[4];
+	int ret;
+
+	ret = do_loopback_xfer(&cfg1, tx, sizeof(tx), rx, sizeof(rx));
+	zassert_true(ret >= 0,
+		     "release_wrong: initial xfer failed %d", ret);
+
+	static struct spi_config cfg2;
+
+	cfg2 = neg_test_cfg(0, 16U, 2 * SPI_FREQ_MHZ);
+
+	ret = spi_release(controller_dev, &cfg2);
+	zassert_equal(ret, -EINVAL,
+		      "release_wrong: expected -EINVAL, got %d", ret);
+}
+
+ZTEST(test_spi_negative, test_freq_exceed)
+{
+	struct spi_config cfg = neg_test_cfg(0, 8U, UINT32_MAX);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	struct spi_config cfg = neg_test_cfg(0, 8U, UINT32_MAX);
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx), rx, sizeof(rx));
+
+	zassert_equal(ret, -EINVAL,
+		      "freq_exceed: expected -EINVAL, got %d", ret);
+}
+
+static int subtest_null_buf(void)
+{
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(SPI_OP_MODE_SLAVE,
 					     8U, SPI_FREQ_MHZ);
 	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
 	uint8_t rx[4];
@@ -67,9 +125,15 @@ static int subtest_lsb_first(void)
 
 static int subtest_release_wrong_cfg(void)
 {
-	struct spi_config cfg1 = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
+	static struct spi_config cfg1;
+
+	cfg1 = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
 	uint8_t tx[4] = {0xDE, 0xAD, 0xBE, 0xEF};
 	uint8_t rx[4];
+	struct spi_buf tb = { .buf = tx, .len = sizeof(tx) };
+	struct spi_buf rb = { .buf = rx, .len = sizeof(rx) };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
 	int ret;
 
 	ret = do_loopback_xfer(&cfg1, tx, sizeof(tx),
@@ -79,7 +143,9 @@ static int subtest_release_wrong_cfg(void)
 		return 1;
 	}
 
-	struct spi_config cfg2 = neg_test_cfg(0, 16U, 2 * SPI_FREQ_MHZ);
+	static struct spi_config cfg2;
+
+	cfg2 = neg_test_cfg(0, 16U, 2 * SPI_FREQ_MHZ);
 
 	ret = spi_release(controller_dev, &cfg2);
 	if (ret != -EINVAL) {
@@ -91,7 +157,9 @@ static int subtest_release_wrong_cfg(void)
 
 static int subtest_freq_exceed(void)
 {
-	struct spi_config cfg = neg_test_cfg(0, 8U, UINT32_MAX);
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(0, 8U, UINT32_MAX);
 	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
 	uint8_t rx[4];
 	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
@@ -104,38 +172,11 @@ static int subtest_freq_exceed(void)
 	return 0;
 }
 
-static int subtest_null_buf(void)
-{
-	struct spi_config cfg = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
-	struct spi_buf tb = { .buf = NULL, .len = 16 };
-	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
-	int ret = spi_test_transceive(controller_dev, &cfg, &ts, NULL, false);
-
-	if (ret != -EINVAL) {
-		LOG_ERR("  null_buf: expected -EINVAL, got %d", ret);
-		return 1;
-	}
-	return 0;
-}
-
-static int subtest_word_exceed(void)
-{
-	struct spi_config cfg = neg_test_cfg(0, 33U, SPI_FREQ_MHZ);
-	uint8_t tx[4] = {0xAA, 0xBB, 0xCC, 0xDD};
-	uint8_t rx[4];
-	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
-				   rx, sizeof(rx));
-
-	if (ret != -ENOTSUP) {
-		LOG_ERR("  word_exceed: expected -ENOTSUP, got %d", ret);
-		return 1;
-	}
-	return 0;
-}
-
 static int subtest_word_zero_invalid(void)
 {
-	struct spi_config cfg = neg_test_cfg(0, 0U, SPI_FREQ_MHZ);
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(0, 0U, SPI_FREQ_MHZ);
 	int ret = spi_test_transceive(controller_dev, &cfg, NULL, NULL, false);
 
 	if (ret != -EINVAL) {
@@ -145,65 +186,206 @@ static int subtest_word_zero_invalid(void)
 	return 0;
 }
 
-static int subtest_word_len_unaligned(void)
+static int subtest_half_duplex(void)
 {
-	struct spi_config cfg = neg_test_cfg(0, 16U, SPI_FREQ_MHZ);
-	uint8_t tx[3] = {0xAA, 0xBB, 0xCC};
-	uint8_t rx[3];
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(SPI_HALF_DUPLEX,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
 	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
 				   rx, sizeof(rx));
 
-	if (ret != -EINVAL) {
-		LOG_ERR("  word_len_unaligned: expected -EINVAL, got %d", ret);
+	if (ret != -ENOTSUP) {
+		LOG_ERR("  half_duplex: expected -ENOTSUP, got %d", ret);
 		return 1;
 	}
 	return 0;
 }
 
+static int subtest_op_mode_slave(void)
+{
+	static struct spi_config cfg;
 
-ZTEST(test_spi_negative, test_comprehensive_negative)
+	cfg = neg_test_cfg(SPI_OP_MODE_SLAVE,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -ENOTSUP) {
+		LOG_ERR("  op_mode_slave: expected -ENOTSUP, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+static int subtest_op_mode_master_on_slave(void)
+{
+	static const struct device *const target_dev =
+		DEVICE_DT_GET(SPI_TARGET_NODE);
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(0, 8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	struct spi_buf tb = { .buf = tx, .len = sizeof(tx) };
+	struct spi_buf rb = { .buf = rx, .len = sizeof(rx) };
+	struct spi_buf_set ts = { .buffers = &tb, .count = 1 };
+	struct spi_buf_set rs = { .buffers = &rb, .count = 1 };
+	int ret;
+
+	ret = spi_test_transceive(target_dev, &cfg, &ts, &rs, false);
+	if (ret != -ENOTSUP) {
+		LOG_ERR("  op_mode_master_on_slave: expected -ENOTSUP, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+#if IS_ENABLED(CONFIG_SPI_EXTENDED_MODES)
+static int subtest_extended_lines(void)
+{
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(SPI_LINES_DUAL,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -EINVAL) {
+		LOG_ERR("  extended_lines: expected -EINVAL, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+#endif
+
+static int subtest_ti_loopback(void)
+{
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(SPI_FRAME_FORMAT_TI | SPI_MODE_LOOP,
+					     8U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0x11, 0x22, 0x33, 0x44};
+	uint8_t rx[4];
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx),
+				   rx, sizeof(rx));
+
+	if (ret != -ENOTSUP) {
+		LOG_ERR("  ti_loopback: expected -ENOTSUP, got %d", ret);
+		return 1;
+	}
+	return 0;
+}
+
+ZTEST(test_spi_negative, test_word_exceed)
+{
+	static struct spi_config cfg;
+
+	cfg = neg_test_cfg(0, 33U, SPI_FREQ_MHZ);
+	uint8_t tx[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+	uint8_t rx[4];
+	struct spi_config cfg = neg_test_cfg(0, 33U, SPI_FREQ_MHZ);
+	int ret = do_loopback_xfer(&cfg, tx, sizeof(tx), rx, sizeof(rx));
+
+	zassert_equal(ret, -ENOTSUP,
+		      "word_exceed: expected -ENOTSUP, got %d", ret);
+}
+
+ZTEST(test_spi_negative, test_lsb_first)
 {
 	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
 		     "SPI device not ready");
-
-	int fail = 0;
-	int f;
-
-	TC_PRINT("=== Comprehensive Negative Validation ===\n");
-
-	f = subtest_lsb_first();
-	fail += f;
-	TC_PRINT("  lsb_first        : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_release_wrong_cfg();
-	fail += f;
-	TC_PRINT("  release_wrong    : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_freq_exceed();
-	fail += f;
-	TC_PRINT("  freq_exceed      : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_null_buf();
-	fail += f;
-	TC_PRINT("  null_buf         : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_word_exceed();
-	fail += f;
-	TC_PRINT("  word_exceed      : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_word_zero_invalid();
-	fail += f;
-	TC_PRINT("  word_zero        : %s\n", f ? "FAIL" : "OK");
-
-	f = subtest_word_len_unaligned();
-	fail += f;
-	TC_PRINT("  word_len_unalign : %s\n", f ? "FAIL" : "OK");
-
-	TC_PRINT("=== Result: %d failures ===\n", fail);
-	zassert_equal(fail, 0, "Comprehensive negative: %d failures", fail);
+	zassert_equal(subtest_lsb_first(), 0, "LSB-first negative test failed");
 }
 
-ZTEST_SUITE(test_spi_negative, NULL, NULL, test_before_func,
+ZTEST(test_spi_negative, test_release_wrong_cfg)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_release_wrong_cfg(), 0,
+		      "Release wrong config negative test failed");
+}
+
+ZTEST(test_spi_negative, test_freq_exceed)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_freq_exceed(), 0,
+		      "Frequency exceed negative test failed");
+}
+
+ZTEST(test_spi_negative, test_word_zero)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_word_zero_invalid(), 0,
+		      "Word zero negative test failed");
+}
+
+ZTEST(test_spi_negative, test_word_exceed)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_word_exceed(), 0,
+		      "Word exceed negative test failed");
+}
+
+ZTEST(test_spi_negative, test_half_duplex)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_half_duplex(), 0,
+		      "Half-duplex negative test failed");
+}
+
+ZTEST(test_spi_negative, test_op_mode_slave)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_op_mode_slave(), 0,
+		      "Operation mode slave negative test failed");
+}
+
+ZTEST(test_spi_negative, test_op_mode_master_on_slave)
+{
+	static const struct device *const target_dev =
+		DEVICE_DT_GET(SPI_TARGET_NODE);
+
+	zassert_true(spi_test_device_ready(target_dev, "Target"),
+		     "SPI target device not ready");
+	zassert_equal(subtest_op_mode_master_on_slave(), 0,
+		      "Operation mode master on slave negative test failed");
+}
+
+#if IS_ENABLED(CONFIG_SPI_EXTENDED_MODES)
+ZTEST(test_spi_negative, test_extended_lines)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_extended_lines(), 0,
+		      "Extended lines negative test failed");
+}
+#endif
+
+ZTEST(test_spi_negative, test_ti_loopback)
+{
+	zassert_true(spi_test_device_ready(controller_dev, "Controller"),
+		     "SPI device not ready");
+	zassert_equal(subtest_ti_loopback(), 0,
+		      "TI loopback negative test failed");
+}
+
+/* ------------------------------------------------------------------
+ * Suite registration
+ * ------------------------------------------------------------------
+ */
+ZTEST_SUITE(test_spi_negative, NULL, NULL, test_spi_negative_before,
 	    NULL, NULL);
 
 #endif /* CONFIG_TEST_SPI_NEGATIVE */

--- a/tests/drivers/spi/src/test_spi_perf.c
+++ b/tests/drivers/spi/src/test_spi_perf.c
@@ -13,7 +13,7 @@
 
 #include "test_spi_threads.h"
 
-LOG_MODULE_REGISTER(alif_spi_perf, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_perf, LOG_LEVEL_INF);
 
 static void assert_mosi_perf_clean(const char *tag)
 {

--- a/tests/drivers/spi/src/test_spi_stress.c
+++ b/tests/drivers/spi/src/test_spi_stress.c
@@ -40,7 +40,7 @@
 
 #include "test_spi_threads.h"
 
-LOG_MODULE_REGISTER(alif_spi_stress, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_stress, LOG_LEVEL_INF);
 
 #define STRESS_DEFAULT_ITERS    100
 #define STRESS_PATTERN_ITERS    50

--- a/tests/drivers/spi/src/test_spi_threads.c
+++ b/tests/drivers/spi/src/test_spi_threads.c
@@ -9,7 +9,52 @@
 
 #include "test_spi_threads.h"
 
-LOG_MODULE_REGISTER(alif_spi_threads, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(spi_test_threads, LOG_LEVEL_INF);
+
+static K_SEM_DEFINE(perf_sem_target_ready, 0, 1);
+static K_SEM_DEFINE(perf_sem_controller_done, 0, 1);
+
+static inline k_timeout_t perf_sync_timeout(uint32_t freq_hz)
+{
+	return spi_test_transfer_timeout(SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t),
+					 freq_hz);
+}
+
+#if IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+#define SPI_THREAD_TIMEOUT_FREQ_MIN ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_MIN_MHZ)
+#define SPI_THREAD_TIMEOUT_FREQ_MAX ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_MAX_MHZ)
+#define SPI_THREAD_TIMEOUT_FREQ_STEP ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_STEP_MHZ)
+#define SPI_THREAD_TIMEOUT_BYTES (SPI_TEST_BUFF_SIZE_PERF * sizeof(uint32_t))
+#else
+#define SPI_THREAD_TIMEOUT_BYTES (SPI_TEST_BUFF_SIZE * sizeof(uint32_t))
+#endif
+
+static k_timeout_t spi_threads_join_timeout(void)
+{
+#if IS_ENABLED(CONFIG_TEST_SPI_PERFORMANCE)
+	uint64_t timeout_ms = 0U;
+
+	for (uint32_t freq = SPI_THREAD_TIMEOUT_FREQ_MIN;
+	     freq <= SPI_THREAD_TIMEOUT_FREQ_MAX;) {
+		timeout_ms += spi_test_transfer_timeout_ms(
+			SPI_THREAD_TIMEOUT_BYTES, freq * SPI_FREQ_MHZ);
+
+		if (freq >= SPI_THREAD_TIMEOUT_FREQ_MAX) {
+			break;
+		}
+		freq += SPI_THREAD_TIMEOUT_FREQ_STEP;
+		if (freq > SPI_THREAD_TIMEOUT_FREQ_MAX) {
+			freq = SPI_THREAD_TIMEOUT_FREQ_MAX;
+		}
+	}
+
+	return K_MSEC((timeout_ms * 2U) + 2000U);
+#else
+	return K_MSEC((spi_test_transfer_timeout_ms(SPI_THREAD_TIMEOUT_BYTES,
+						    SPI_FREQ_MHZ) * 2U) +
+		      2000U);
+#endif
+}
 
 /* Controller-side sync/async selector for thread-based tests.
  * Target-side always stays sync — the slave must have its RX armed
@@ -20,10 +65,39 @@ static int controller_xfer(const struct device *dev,
 			   const struct spi_buf_set *tx,
 			   const struct spi_buf_set *rx)
 {
+	LOG_INF("ctrl_xfer: %s op=0x%08x ti=%d ws=%u freq=%u",
+		dev->name, cfg->operation,
+		!!(cfg->operation & SPI_FRAME_FORMAT_TI),
+		SPI_WORD_SIZE_GET(cfg->operation),
+		cfg->frequency);
+	/* Always force reconfig: local cnfg stack addresses can be reused
+	 * across tests, causing spi_context_configured() to falsely skip
+	 * reconfiguration when operation flags change (e.g. Motorola -> TI).
+	 */
 	if (atomic_get(&spi_test_async_mode)) {
-		return spi_test_transceive_async(dev, cfg, tx, rx, false);
+		return spi_test_transceive_async(dev, cfg, tx, rx, true);
 	}
-	return spi_transceive(dev, cfg, tx, rx);
+	return spi_test_transceive(dev, cfg, tx, rx, true);
+}
+
+/* Target-side transceive. Always sync, but must also force reconfig so the
+ * slave's CTRLR0 (frame format, mode, word size) is reprogrammed when a new
+ * config is supplied.  The local cnfg lives on the static target thread stack,
+ * so its address is reused across scenarios; without force_reconfig the driver
+ * sees the same pointer and skips reconfiguration (e.g. stays Motorola when the
+ * test selected TI).
+ */
+static int target_xfer(const struct device *dev,
+		       const struct spi_config *cfg,
+		       const struct spi_buf_set *tx,
+		       const struct spi_buf_set *rx)
+{
+	LOG_INF("tgt_xfer:  %s op=0x%08x ti=%d ws=%u freq=%u",
+		dev->name, cfg->operation,
+		!!(cfg->operation & SPI_FRAME_FORMAT_TI),
+		SPI_WORD_SIZE_GET(cfg->operation),
+		cfg->frequency);
+	return spi_test_transceive(dev, cfg, tx, rx, true);
 }
 
 
@@ -36,26 +110,27 @@ void run_spi_test_threads(void (*controller_func)(void *, void *, void *),
 		MAX(SPI_TEST_PRIORITY_CONTROLLER, SPI_TEST_PRIORITY_TARGET);
 	int controller_prio;
 	int target_prio;
+	k_timeout_t join_timeout = spi_threads_join_timeout();
+	int ret;
 
-	if (IS_ENABLED(CONFIG_TEST_SPI_USE_DMA)) {
-		/* Sample parity: prefer higher
-		 * controller priority in DMA mode.
-		 */
-		controller_prio = higher_prio;
-		target_prio = lower_prio;
-	} else {
-		/* PIO robustness: prefer higher target
-		 * priority to arm RX first.
-		 */
-		controller_prio = lower_prio;
-		target_prio = higher_prio;
-	}
+	/* The slave must arm its hardware BEFORE the master starts clocking,
+	 * regardless of PIO or DMA mode.  Give the target thread higher
+	 * scheduling priority so that after it calls k_sem_give() it
+	 * continues uninterrupted into spi_transceive(), arms the slave
+	 * DMA/FIFO, and only then blocks — allowing the controller thread
+	 * (lower priority) to run and start the transfer.
+	 */
+	controller_prio = lower_prio;
+	target_prio = higher_prio;
 
 	TC_PRINT("Creating SPI test threads (controller: %p, target: %p)\n",
 		 controller_func, target_func);
 	TC_PRINT("Thread scheduling: mode=%s controller_prio=%d target_prio=%d\n",
 		 IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ? "dma" : "pio",
 		 controller_prio, target_prio);
+
+	k_sem_reset(&perf_sem_target_ready);
+	k_sem_reset(&perf_sem_controller_done);
 
 	k_tid_t tids = k_thread_create(&target_thread_data, target_stack,
 				       SPI_TEST_STACKSIZE, target_func,
@@ -82,8 +157,20 @@ void run_spi_test_threads(void (*controller_func)(void *, void *, void *),
 	k_thread_start(&controller_thread_data);
 
 	LOG_DBG("Waiting for threads to complete");
-	k_thread_join(&target_thread_data, K_FOREVER);
-	k_thread_join(&controller_thread_data, K_FOREVER);
+	ret = k_thread_join(&controller_thread_data, join_timeout);
+	if (ret != 0) {
+		LOG_ERR("Controller thread did not finish cleanly: %d", ret);
+		k_thread_abort(&controller_thread_data);
+		k_thread_abort(&target_thread_data);
+		zassert_equal(ret, 0, "Controller thread join failed: %d", ret);
+	}
+
+	ret = k_thread_join(&target_thread_data, join_timeout);
+	if (ret != 0) {
+		LOG_ERR("Target thread did not finish cleanly: %d", ret);
+		k_thread_abort(&target_thread_data);
+		zassert_equal(ret, 0, "Target thread join failed: %d", ret);
+	}
 
 	TC_PRINT("SPI test threads completed (errors: %ld)\n",
 		 atomic_get(&err_count));
@@ -136,7 +223,7 @@ static int func_target_receive(const struct device *dev)
 	};
 
 	LOG_DBG("Target: Starting simple transceive");
-	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+	int ret = target_xfer(dev, &cnfg, &tx_set, &rx_set);
 
 	if (ret >= 0) {
 		TC_PRINT("Target transceive success: %d\n", ret);
@@ -200,7 +287,7 @@ int func_target_transmit(const struct device *dev)
 	LOG_DBG("Target: Starting simple transceive (word size: %ld)",
 		IS_ENABLED(CONFIG_TEST_SPI_USE_DMA) ?
 		SPI_TEST_DMA_WORD_SIZE : transceive_word);
-	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+	int ret = target_xfer(dev, &cnfg, &tx_set, &rx_set);
 
 	if (ret >= 0) {
 		TC_PRINT("Target transceive success: %d\n", ret);
@@ -342,7 +429,7 @@ static int func_target_transceive(const struct device *dev)
 	};
 
 	LOG_DBG("Target: Starting simple transceive");
-	int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+	int ret = target_xfer(dev, &cnfg, &tx_set, &rx_set);
 
 	if (ret < 0) {
 		LOG_ERR("Target transceive failed: %d", ret);
@@ -393,8 +480,59 @@ void target_spi(void *p1, void *p2, void *p3)
 
 #else /* CONFIG_TEST_SPI_PERFORMANCE */
 
-#define PERF_FREQ_MIN_MHZ 1U
-#define PERF_FREQ_MAX_MHZ SPI_TEST_MAX_FREQUENCY
+#define PERF_FREQ_MIN_MHZ  ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_MIN_MHZ)
+#define PERF_FREQ_MAX_MHZ  ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_MAX_MHZ)
+#define PERF_FREQ_STEP_MHZ ((uint32_t)CONFIG_TEST_SPI_PERF_FREQ_STEP_MHZ)
+
+/* Advance to the next sweep point, always landing exactly on the
+ * configured maximum as the final point even when it is not on a step
+ * boundary.  Returns a value above the max to terminate the loop.
+ */
+static inline uint32_t perf_freq_next(uint32_t freq)
+{
+	uint32_t next;
+
+	if (freq >= PERF_FREQ_MAX_MHZ) {
+		return PERF_FREQ_MAX_MHZ + 1U;
+	}
+
+	next = freq + PERF_FREQ_STEP_MHZ;
+	return (next > PERF_FREQ_MAX_MHZ) ? PERF_FREQ_MAX_MHZ : next;
+}
+
+/* The target thread (higher priority) signals perf_sem_target_ready
+ * BEFORE it arms the slave hardware inside its blocking transceive
+ * (CTRLR0, SSIENR, TX prefill, IMR unmask / DMA channel start all happen
+ * inside target_xfer).  The slave configure path can yield (clock_control
+ * mutex), which would let this lower-priority controller clock the first
+ * words before the slave RX FIFO/DMA is armed, dropping leading words and
+ * shifting the received data.  Wait a deterministic head-start so the
+ * higher-priority target reaches its armed, blocked state first.  Placed
+ * outside the timing window so it does not skew throughput numbers.
+ */
+static inline void perf_wait_target_armed(void)
+{
+	k_usleep(SPI_TEST_TARGET_HEADSTART_US);
+}
+
+/* SPI controller (spi1) source clock = ALIF_SPI_CLK = HCLK = AXI/2.
+ * On E1/E7/E8 AXI = 400 MHz, so the SPI ssi_clk is 200 MHz.
+ */
+#define SPI_CTRL_SRC_CLK_HZ 200000000U
+
+/* Mirror the DesignWare baud divider: integer divide, then the HW
+ * forces an even SCKDV (LSB is cleared). Returns the real SCLK in Hz.
+ */
+static inline uint32_t perf_actual_sclk(uint32_t req_hz)
+{
+	uint32_t div = SPI_CTRL_SRC_CLK_HZ / req_hz;
+
+	div &= ~1U;             /* HW rounds down to even */
+	if (div == 0U) {
+		div = 2U;       /* minimum divider */
+	}
+	return SPI_CTRL_SRC_CLK_HZ / div;
+}
 
 static int perf_controller_send(const struct device *dev)
 {
@@ -403,20 +541,31 @@ static int perf_controller_send(const struct device *dev)
 	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = spi_test_config(
-		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
-		0);
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = spi_test_config(
+			SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+			freq * SPI_FREQ_MHZ);
 		memset(ctrl_rxdata, 0, length);
+		TC_PRINT("Controller req %u Hz -> actual SCLK %u Hz\n",
+			 freq * SPI_FREQ_MHZ,
+			 perf_actual_sclk(freq * SPI_FREQ_MHZ));
+		if (k_sem_take(&perf_sem_target_ready,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Controller TX: target ready timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
+		perf_wait_target_armed();
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+		int ret = controller_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		k_sem_give(&perf_sem_controller_done);
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();
@@ -433,6 +582,7 @@ static int perf_controller_send(const struct device *dev)
 		TC_PRINT("  cycles: %u, time: %llu ms\n",
 			cyc_end - cyc_start,
 			(unsigned long long)(time_end - time_start));
+		k_msleep(1);
 	}
 	return 0;
 }
@@ -444,22 +594,30 @@ static int perf_target_receive(const struct device *dev)
 	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = {
-		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
-			SPI_TEST_WORD_SIZE,
-		.slave = 0,
-	};
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = (struct spi_config){
+			.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+				SPI_TEST_WORD_SIZE,
+			.frequency = freq * SPI_FREQ_MHZ,
+			.slave = 0,
+		};
 		memset(tgt_rxdata, 0, length);
+		k_sem_give(&perf_sem_target_ready);
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+		int ret = target_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		if (k_sem_take(&perf_sem_controller_done,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Target RX: controller done timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();
@@ -484,6 +642,7 @@ static int perf_target_receive(const struct device *dev)
 		TC_PRINT("  cycles: %u, time: %llu ms\n",
 			cyc_end - cyc_start,
 			(unsigned long long)(time_end - time_start));
+		k_msleep(1);
 	}
 	return 0;
 }
@@ -519,22 +678,30 @@ static int perf_target_transmit(const struct device *dev)
 	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = {
-		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
-			SPI_TEST_WORD_SIZE,
-		.slave = 0,
-	};
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = (struct spi_config){
+			.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+				SPI_TEST_WORD_SIZE,
+			.frequency = freq * SPI_FREQ_MHZ,
+			.slave = 0,
+		};
 		memset(tgt_rxdata, 0, length);
+		k_sem_give(&perf_sem_target_ready);
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+		int ret = target_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		if (k_sem_take(&perf_sem_controller_done,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Target TX: controller done timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();
@@ -551,6 +718,7 @@ static int perf_target_transmit(const struct device *dev)
 		TC_PRINT("  cycles: %u, time: %llu ms\n",
 			cyc_end - cyc_start,
 			(unsigned long long)(time_end - time_start));
+		k_msleep(1);
 	}
 	return 0;
 }
@@ -562,20 +730,28 @@ static int perf_controller_receive(const struct device *dev)
 	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = spi_test_config(
-		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
-		0);
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = spi_test_config(
+			SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+			freq * SPI_FREQ_MHZ);
 		memset(ctrl_rxdata, 0, length);
+		if (k_sem_take(&perf_sem_target_ready,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Controller RX: target ready timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
+		perf_wait_target_armed();
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+		int ret = controller_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		k_sem_give(&perf_sem_controller_done);
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();
@@ -605,6 +781,7 @@ static int perf_controller_receive(const struct device *dev)
 		TC_PRINT("  cycles: %u, time: %llu ms\n",
 			cyc_end - cyc_start,
 			(unsigned long long)(time_end - time_start));
+		k_msleep(1);
 	}
 	return 0;
 }
@@ -648,20 +825,28 @@ void controller_spi(void *p1, void *p2, void *p3)
 	struct spi_buf rx_buf = { .buf = ctrl_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = spi_test_config(
-		SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
-		0);
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = spi_test_config(
+			SPI_OP_MODE_MASTER | SPI_TEST_WORD_SIZE,
+			freq * SPI_FREQ_MHZ);
 		memset(ctrl_rxdata, 0, length);
+		if (k_sem_take(&perf_sem_target_ready,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Controller: target ready timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
+		perf_wait_target_armed();
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = controller_xfer(dev, &cnfg, &tx_set, &rx_set);
+		int ret = controller_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		k_sem_give(&perf_sem_controller_done);
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();
@@ -704,22 +889,30 @@ void target_spi(void *p1, void *p2, void *p3)
 	struct spi_buf rx_buf = { .buf = tgt_rxdata, .len = length };
 	struct spi_buf_set tx_set = { .buffers = &tx_buf, .count = 1 };
 	struct spi_buf_set rx_set = { .buffers = &rx_buf, .count = 1 };
-
-	struct spi_config cnfg = {
-		.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
-			SPI_TEST_WORD_SIZE,
-		.slave = 0,
-	};
+	static struct spi_config cnfg[2];
 
 	for (uint32_t freq = PERF_FREQ_MIN_MHZ;
-	     freq <= PERF_FREQ_MAX_MHZ; freq++) {
-		cnfg.frequency = freq * SPI_FREQ_MHZ;
+	     freq <= PERF_FREQ_MAX_MHZ; freq = perf_freq_next(freq)) {
+		cnfg[freq % 2] = (struct spi_config){
+			.operation = SPI_OP_MODE_SLAVE | spi_test_op_flags |
+				SPI_TEST_WORD_SIZE,
+			.frequency = freq * SPI_FREQ_MHZ,
+			.slave = 0,
+		};
 		memset(tgt_rxdata, 0, length);
+		k_sem_give(&perf_sem_target_ready);
 
 		uint32_t cyc_start = k_cycle_get_32();
 		int64_t time_start = k_uptime_get();
 
-		int ret = spi_transceive(dev, &cnfg, &tx_set, &rx_set);
+		int ret = target_xfer(dev, &cnfg[freq % 2], &tx_set, &rx_set);
+
+		if (k_sem_take(&perf_sem_controller_done,
+			       perf_sync_timeout(freq * SPI_FREQ_MHZ)) != 0) {
+			LOG_ERR("Target: controller done timeout @%u Hz",
+				freq * SPI_FREQ_MHZ);
+			break;
+		}
 
 		int64_t time_end = k_uptime_get();
 		uint32_t cyc_end = k_cycle_get_32();


### PR DESCRIPTION
Fix SPI driver test issues caused by DMA configuration and Dextra DTC overlay conflicts during automation execution.

Adjust overlay handling to avoid failures in automated test runs.