### PR TITLE
manifest: update zephyr revision for lpi2c1 clock property and timing

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 8f2fe85233f3670d304a0acd598321eb7077bb76
+      revision: c4ad830d070f5a1af95dfb2ec6c8d3969aa74c55
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr revision to pick the lpi2c1 clock property and HCNT/LCNT timing update.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/516