### PR TITLE
manifest: zephyr: update revision to pick AIPM DTS restructuring

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 1f059b7937717e35c5b4e16028f8033bacfa8e6c
+      revision: 39849fc056b7659cddf7c5b58f8e4ecce117957c
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pick up the AIPM DTS restructuring that moves run/off profile nodes out of CPU-subsystem dtsi files into dedicated per-SoC-variant files.

Depends on: https://github.com/alifsemi/zephyr_alif/pull/518