### PR TITLE
samples: tflite-micro: tflm_ethosu: add APSS Ethos-U85 support

### DIFF
--- a/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
+++ b/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
@@ -38,6 +38,10 @@ if(ETHOSU_TARGET_NPU_CONFIG MATCHES "^ethos-(u[0-9]+)-([0-9]+)$")
                     "For 128 MACs, use HE core board variant (rtss_he)")
             endif()
             message(STATUS "Detected RTSS_HP core - U55 restricted to 256 MACs")
+        elseif(CONFIG_APSS)
+            message(FATAL_ERROR
+                "Ethos-U55 is not directly accessible from APSS (Cortex-A32).\n"
+                "Use Ethos-U85 instead: -DETHOSU_TARGET_NPU_CONFIG=ethos-u85-256")
         else()
             # Fallback validation for other core types
             if(NOT (ETHOSU_MACS STREQUAL "64" OR ETHOSU_MACS STREQUAL "128" OR ETHOSU_MACS STREQUAL "256"))
@@ -92,13 +96,14 @@ if(ETHOSU_TARGET_NPU_CONFIG MATCHES "^ethos-(u[0-9]+)-([0-9]+)$")
                 "Use: -DETHOSU_TARGET_NPU_CONFIG=ethos-u85-256")
         endif()
 
-        # Validate overlay file matches NPU type
+        # Validate overlay file matches NPU type (catches accidental U55 overlay with U85 config)
         if(DEFINED EXTRA_DTC_OVERLAY_FILE)
             if(EXTRA_DTC_OVERLAY_FILE MATCHES "ethosu55\\.overlay")
                 message(FATAL_ERROR 
                     "Overlay mismatch: ETHOSU_TARGET_NPU_CONFIG='${ETHOSU_TARGET_NPU_CONFIG}' (U85) "
                     "but using U55 overlay '${EXTRA_DTC_OVERLAY_FILE}'.\n"
-                    "For U85, use: -DEXTRA_DTC_OVERLAY_FILE=\"boards/enable_ethosu85.overlay\"")
+                    "For U85 on RTSS, use: -S ethos-u85-enable\n"
+                    "For U85 on APSS,  use: -S ethos-u85-apss-enable")
             endif()
         endif()
 
@@ -136,3 +141,9 @@ add_subdirectory(
 )
 
 target_sources(app PRIVATE src/main.cpp)
+
+# APSS (Cortex-A32): include the SRAM1 linker snippet so the tensor arena
+# is placed into the non-cacheable SRAM1 memory region defined in the overlay.
+if(CONFIG_APSS)
+    zephyr_linker_sources(SECTIONS boards/apss_sram1_sections.ld)
+endif()

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -12,28 +12,29 @@ Runs keyword spotting CNN model optimized with Vela compiler.
 Supported Boards
 ****************
 
-+-------+--------+---------+-------------------------+
-| Board | U55    | U85     | Notes                   |
-+=======+========+=========+=========================+
-| B1    | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
-| E1C   | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
-| E3    | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
-| E4    | Yes    | Yes     | Dual NPU                |
-+-------+--------+---------+-------------------------+
-| E7    | Yes    | No      | U55 only                |
-+-------+--------+---------+-------------------------+
-| E8    | Yes    | Yes     | Dual NPU                |
-+-------+--------+---------+-------------------------+
++-------+--------+---------+---------+-------------------------+
+| Board | U55    | U85     | APSS    | Notes                   |
++=======+========+=========+=========+=========================+
+| B1    | Yes    | No      | No      | U55 only                |
++-------+--------+---------+---------+-------------------------+
+| E1C   | Yes    | No      | No      | U55 only                |
++-------+--------+---------+---------+-------------------------+
+| E3    | Yes    | No      | No      | U55 only                |
++-------+--------+---------+---------+-------------------------+
+| E4    | Yes    | Yes     | No      | Dual NPU                |
++-------+--------+---------+---------+-------------------------+
+| E7    | Yes    | No      | Yes     | U55 only                |
++-------+--------+---------+---------+-------------------------+
+| E8    | Yes    | Yes     | Yes     | Dual NPU                |
++-------+--------+---------+---------+-------------------------+
 
 Core Type Restrictions
 **********************
 
 - **HE cores (rtss_he)**: U55 supports 128 MACs only
 - **HP cores (rtss_hp)**: U55 supports 256 MACs only
-- **U85**: Always 256 MACs (both HE and HP cores)
+- **APSS cores (apss)**: U85 with 256 MACs only (Cortex-A32)
+- **U85**: Always 256 MACs (HE, HP, and APSS cores)
 
 Building and Running
 ********************
@@ -44,23 +45,13 @@ This sample uses TCM/MRAM/SRAM memory and does not require external OSPI flash.
 Building for Alif B1 DK
 ------------------------
 
-**HP Core with U55-256:**
-
-.. code-block:: console
-
-   west build -b alif_b1_dk/ab1c1f4m51820hh0/rtss_hp \
-       -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
-       -p always -- \
-       -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-256
-
 **HE Core with U55-128:**
 
 .. code-block:: console
 
    west build -b alif_b1_dk/ab1c1f4m51820hh0/rtss_he \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
 
@@ -73,7 +64,7 @@ Building for Alif E1C DK
 
    west build -b alif_e1c_dk/ae1c1f4051920hh/rtss_he \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
 
@@ -86,7 +77,7 @@ Building for Alif E7 DK
 
    west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-256
 
@@ -96,7 +87,7 @@ Building for Alif E7 DK
 
    west build -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
 
@@ -109,7 +100,7 @@ Building for Alif E8 DK
 
    west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-256
 
@@ -119,7 +110,7 @@ Building for Alif E8 DK
 
    west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
        -S ethos-u85-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u85-256
 
@@ -129,9 +120,28 @@ Building for Alif E8 DK
 
    west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_he \
        -S ethos-u55-enable \
-       samples/modules/tflite-micro/tflm_ethosu \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
        -p always -- \
        -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128
+
+**APSS Core (Cortex-A32) with U85-256:**
+
+.. code-block:: console
+
+   west build -b alif_e8_dk/ae822fa0e5597xx0/apss \
+       ../alif/samples/modules/tflite-micro/tflm_ethosu \
+       -p always \
+       -S ethos-u85-apss-enable \
+       -- -DETHOSU_TARGET_NPU_CONFIG=ethos-u85-256
+
+.. note::
+
+   The ``ethos-u85-apss-enable`` snippet defines the Ethos-U85 NPU node with
+   GIC interrupt routing (GIC_SPI 355) and the SRAM1 memory region for the
+   non-cacheable tensor arena. Using a snippet is the Zephyr-idiomatic approach
+   and is consistent with how ``ethos-u55-enable`` and ``ethos-u85-enable`` work
+   for RTSS cores. The tensor arena is placed in SRAM1 to ensure cache coherency
+   with the NPU without explicit cache maintenance.
 
 Configuration Options
 *********************
@@ -142,8 +152,9 @@ Configuration Options
 
 **Snippets:**
 
-- ``-S ethos-u55-enable``: Enable U55 NPU (all boards)
-- ``-S ethos-u85-enable``: Enable U85 NPU (E4/E8 only)
+- ``-S ethos-u55-enable``: Enable U55 NPU on RTSS cores (all boards)
+- ``-S ethos-u85-enable``: Enable U85 NPU on RTSS cores (E4/E8 only)
+- ``-S ethos-u85-apss-enable``: Enable U85 NPU on APSS (Cortex-A32) core (E8 only)
 
 Snippets automatically apply the necessary device tree overlays to enable the NPU.
 

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/alif_e8_dk_ae822fa0e5597xx0_apss.conf
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/alif_e8_dk_ae822fa0e5597xx0_apss.conf
@@ -1,0 +1,14 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# APSS (Cortex-A32) board-specific Kconfig for tflm_ethosu sample.
+# Auto-selected when building for alif_e8_dk/ae822fa0e5597xx0/apss.
+
+# NPU configuration — Ethos-U85 with 256 MACs
+CONFIG_ARM_ETHOS_U85_256=y
+
+# Multithreading required by Ethos-U driver
+CONFIG_MULTITHREADING=y
+
+# Heap for k_malloc / k_queue_alloc_append
+CONFIG_HEAP_MEM_POOL_SIZE=65536

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/apss_sram1_sections.ld
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/apss_sram1_sections.ld
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Linker snippet: Place the TFLM tensor arena into the SRAM1 memory region.
+ *
+ * SRAM1 is mapped as non-cacheable in the MMU so the NPU and CPU share
+ * a coherent view without explicit cache maintenance.
+ *
+ * The Zephyr build system generates a SRAM1 output section from the
+ * "zephyr,memory-region" devicetree property.  We use an input-section
+ * pattern that matches the attribute used in main.cpp:
+ *   __attribute__((section("SRAM1.tflm_arena")))
+ */
+
+SECTION_DATA_PROLOGUE(SRAM1.tflm_arena, (NOLOAD),)
+{
+    . = ALIGN(16);
+    *(.SRAM1.tflm_arena)
+    *(.SRAM1.tflm_arena.*)
+    . = ALIGN(16);
+} GROUP_LINK_IN(SRAM1)

--- a/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
+++ b/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
@@ -106,8 +106,16 @@ volatile int totalCompletedJobs = 0;
 /* TensorArena allocation using TENSOR_ARENA_SIZE from model header
  * Note: TENSOR_ARENA_SIZE macro is defined in model headers (e.g., model_u85_256.h)
  * For keyword_spotting: U55 uses ~50KB, U85 uses ~50KB
+ *
+ * On APSS (Cortex-A32) the arena is placed into SRAM1 which is mapped
+ * non-cacheable by the MMU, ensuring coherency with the Ethos-U85 NPU.
+ * On RTSS (Cortex-M55) the arena goes into .bss.tflm_arena (DTCM/SRAM0).
  */
+#if defined(CONFIG_APSS)
+__attribute__((section("SRAM1.tflm_arena"), aligned(16)))
+#else
 __attribute__((section(".bss.tflm_arena"), aligned(16)))
+#endif
 uint8_t inferenceProcessTensorArena[NUM_INFERENCE_TASKS][TENSOR_ARENA_SIZE];
 
 /* Allocate and initialize heap */

--- a/snippets/ethos-u85-apss-enable/apss.overlay
+++ b/snippets/ethos-u85-apss-enable/apss.overlay
@@ -1,0 +1,46 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * Ethos-U85 NPU + SRAM1 enable overlay for APSS (Cortex-A32).
+ *
+ * APSS board DTS files do not inherit the common RTSS DTSI which defines
+ * ethosu1 and sram1, so both nodes are declared here.
+ *
+ * NPU:   Ethos-U85 at 0x49042000
+ *        GIC_SPI 355  (Alif interrupt routing: M55 NVIC 366 - 11 = 355)
+ *        privilege-enable only — A32 runs in non-secure world; setting
+ *        secure-enable from normal world causes verify_access_state() to fail.
+ *
+ * SRAM1: 4MB at 0x02400000
+ *        Mapped non-cacheable by the MMU (mmu_regions.c) so the NPU and
+ *        CPU share a coherent view without explicit cache maintenance.
+ */
+
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+&{/soc} {
+	ethosu1: ethosu85@49042000 {
+		compatible = "arm,ethos-u";
+		reg = <0x49042000 0x1000>;
+		/* Interrupt routing for APSS GIC:
+		 * Alif shared-peripheral routing: GIC_SPI = M55_NVIC - 11.
+		 * Ethos-U85 M55 NVIC = 366  →  GIC_SPI = 355.
+		 */
+		interrupts = <GIC_SPI 355 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		privilege-enable;
+		status = "okay";
+	};
+
+	sram1: sram@2400000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x02400000 0x400000>;
+		zephyr,memory-region = "SRAM1";
+	};
+};

--- a/snippets/ethos-u85-apss-enable/snippet.yml
+++ b/snippets/ethos-u85-apss-enable/snippet.yml
@@ -1,0 +1,8 @@
+name: ethos-u85-apss-enable
+
+boards:
+  # APSS (Cortex-A32): define ethosu1 + SRAM1 from scratch — these nodes are
+  # not inherited from any RTSS DTSI on the A32 board files.
+  /alif_e8_(dk|ak)/.*/apss/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: apss.overlay

--- a/west.yml
+++ b/west.yml
@@ -25,9 +25,10 @@ manifest:
   #
   # Please add items below based on alphabetical order
   projects:
+
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
+      revision: 1c52ccff1d44b4c5f30b4c1d97c9e6821c403bc4
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects
@@ -76,7 +77,7 @@ manifest:
       revision: 85f6b92af0f6ac72594d391f895c45cc30847e41
       path: modules/hal/cmsis
       groups:
-        - hal
+         - hal
 
     - name: hal_infineon
       remote: zephyrproject


### PR DESCRIPTION
- Add APSS (Cortex-A32) support with U85 NPU, SRAM1 tensor arena placement
- Add ethos-u85-apss-enable snippet, board config, and linker sections
- Update zephyr revision for APSS Ethos-U85 HAL and MMU support