### PR TITLE
manifest: zephyr_alif: update revision to include sd regulator at root

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: d18915d96d7b22a660408640bc8a7fc29053519c
+      revision: 2c8899645e871a35ed14d1270f6976859a0f682a
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
updated zephyr_alif revision to include moved sd regulator entry from soc node to root node.
depends-on: https://github.com/alifsemi/zephyr_alif/pull/522/