### PR TITLE
manifest: zephyr_alif: update revision to include default disabled 1.8v

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 2c82b457efb2943a92f947307436f71154b2e0af
+      revision: 132e1390d9d92e3baf58fa65ab3fc495deb35f56
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update revision to include default disabled UHS mode(1.8v) for all cards, As all cards doesn't support 1.8v operation.
depends-on: https://github.com/alifsemi/zephyr_alif/pull/523/