### PR TITLE
samples: usb: mass: enable sd regulator gpio status

### DIFF
--- a/samples/subsys/usb/mass/snippets/alif-msc-ramdisk-ospi-sd/alif_b1_dk.overlay
+++ b/samples/subsys/usb/mass/snippets/alif-msc-ramdisk-ospi-sd/alif_b1_dk.overlay
@@ -106,6 +106,11 @@ zephyr_udc0: &usb {
 
 /* SD card support */
 
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
 &gpio7 {
 	status = "okay";
 };

--- a/samples/subsys/usb/mass/snippets/alif-msc-ramdisk-ospi-sd/alif_e1c_dk.overlay
+++ b/samples/subsys/usb/mass/snippets/alif-msc-ramdisk-ospi-sd/alif_e1c_dk.overlay
@@ -95,6 +95,15 @@ zephyr_udc0: &usb {
 
 /* SD card support */
 
+/* GPIO0 is needed for SDHC sd-vsel regulator */
+&gpio0 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};
+
 &sdhc {
 	status = "okay";
 


### PR DESCRIPTION
enable sd regulator gpio status.


(cherry picked from commit 065856a3a5a75d7ad4d75fe4c68a7f35df2d1711)