### PR TITLE
samples: drivers: uart: echo_dma: fix DMA TX reliability

### DIFF
--- a/samples/drivers/uart/echo_dma/Kconfig
+++ b/samples/drivers/uart/echo_dma/Kconfig
@@ -6,16 +6,7 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_SERIAL=y
-CONFIG_UART_INTERRUPT_DRIVEN=y
-CONFIG_UART_ASYNC_API=y
 
-CONFIG_DMA=y
-CONFIG_DMA_PL330=y
+mainmenu "Alif UART DMA Echo Test"
 
-CONFIG_LOG=y
-CONFIG_LOG_DEFAULT_LEVEL=0
-CONFIG_LOG_PRINTK=n
-
-CONFIG_MAIN_STACK_SIZE=2048
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+source "Kconfig.zephyr"

--- a/samples/drivers/uart/echo_dma/src/main.c
+++ b/samples/drivers/uart/echo_dma/src/main.c
@@ -12,15 +12,19 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 #include <string.h>
+
+LOG_MODULE_REGISTER(echo_dma, LOG_LEVEL_INF);
 
 #define UART_NODE DT_CHOSEN(zephyr_shell_uart)
 
-#define RX_TIMEOUT       50
+#define RX_TIMEOUT       1000
 #define RX_DMA_BUF_SIZE  64
 #define TX_DMA_BUF_SIZE  64
 
 static const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+static const struct device *console_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 static uint8_t rx_dma_buf_a[RX_DMA_BUF_SIZE];
 static uint8_t rx_dma_buf_b[RX_DMA_BUF_SIZE];
@@ -28,9 +32,21 @@ static uint8_t *next_rx_buf = rx_dma_buf_b;
 static uint8_t tx_dma_buf[TX_DMA_BUF_SIZE];
 
 static size_t tx_len;
+static volatile bool truncated;
+static bool prev_was_cr;
 
 static struct k_sem line_ready;
 static struct k_sem tx_done;
+
+/*
+ * Print character by character to the UART interface
+ */
+static void print_uart(const char *buf)
+{
+	while (*buf) {
+		uart_poll_out(console_dev, *buf++);
+	}
+}
 
 /*
  * The application receives data over Shell UART using DMA and
@@ -51,15 +67,21 @@ static void uart_cb(const struct device *dev,
 		for (size_t i = 0; i < len; i++) {
 			uint8_t c = data[i];
 
+			/* Collapse \r\n, \n\r into single line-end */
+			if (c == '\n' && prev_was_cr) {
+				prev_was_cr = false;
+				continue;
+			}
+			prev_was_cr = (c == '\r');
+
+			/* Store everything (including \r or \n) */
 			if (tx_len < TX_DMA_BUF_SIZE) {
 				tx_dma_buf[tx_len++] = c;
-			} else if (tx_len == TX_DMA_BUF_SIZE) {
-				printk("Warning: input truncated at %d bytes\n",
-				       TX_DMA_BUF_SIZE);
-				tx_len++;
+			} else {
+				truncated = true;
 			}
 
-			/* detect ENTER */
+			/* Detect line-end / ENTER */
 			if (c == '\r' || c == '\n') {
 				k_sem_give(&line_ready);
 			}
@@ -68,24 +90,24 @@ static void uart_cb(const struct device *dev,
 	}
 
 	case UART_TX_DONE:
-		printk("DMA TX done\n");
+		LOG_DBG("TX_DONE");
 		k_sem_give(&tx_done);
 		break;
 
 	case UART_TX_ABORTED:
-		printk("DMA TX aborted\n");
+		LOG_WRN("TX_ABORTED");
 		k_sem_give(&tx_done);
 		break;
 
 	case UART_RX_BUF_REQUEST:
-		printk("RX buffer request\n");
+		LOG_DBG("BUF_REQ");
 		uart_rx_buf_rsp(dev, next_rx_buf, RX_DMA_BUF_SIZE);
 		next_rx_buf = (next_rx_buf == rx_dma_buf_a)
 			    ? rx_dma_buf_b : rx_dma_buf_a;
 		break;
 
 	case UART_RX_DISABLED:
-		printk("RX disabled -> re-enabling DMA RX\n");
+		LOG_WRN("RX_DISABLED -> re-enabling");
 		uart_rx_enable(dev, next_rx_buf, RX_DMA_BUF_SIZE, RX_TIMEOUT);
 		next_rx_buf = (next_rx_buf == rx_dma_buf_a)
 			    ? rx_dma_buf_b : rx_dma_buf_a;
@@ -117,64 +139,65 @@ int main(void)
 	int ret = 0;
 
 	if (!device_is_ready(uart_dev)) {
-		printk("UART device not ready\n");
+		print_uart("UART device not ready\n");
 		return 0;
 	}
 
-	printk("\nUART DMA Echo Test\n");
+	print_uart("\r\nUART DMA Echo Test\r\n");
 
-	k_sem_init(&line_ready, 0, 1);
+	k_sem_init(&line_ready, 0, 10);
 	k_sem_init(&tx_done, 0, 1);
 
 	ret = uart_callback_set(uart_dev, uart_cb, NULL);
 	if (ret < 0) {
-		printk("Error setting UART callback: %d\n", ret);
+		print_uart("Error setting UART callback\r\n");
 		return ret;
 	}
 
-	printk("Enabling UART RX DMA\n");
+	print_uart("Enabling UART RX DMA\r\n");
 
 	ret = uart_rx_enable(uart_dev, rx_dma_buf_a, RX_DMA_BUF_SIZE, RX_TIMEOUT);
 	if (ret < 0) {
-		printk("Error enabling UART RX DMA: %d\n", ret);
+		print_uart("Error enabling UART RX DMA\r\n");
 		return ret;
 	}
 
-	printk("Type anything on Shell UART and press ENTER! \r\n");
+	print_uart("Type anything on Shell UART and press ENTER!\r\n");
 
 	while (1) {
 		/* indefinitely wait for the user input */
 		k_sem_take(&line_ready, K_FOREVER);
 
 		if (tx_len > 0) {
-			uint8_t echo_buf[TX_DMA_BUF_SIZE];
+			uint8_t echo_buf[TX_DMA_BUF_SIZE + 10];
 			size_t echo_len;
+			size_t pos = 0;
 			unsigned int key;
 
 			/* snapshot the RX buffer under IRQ lock */
 			key = irq_lock();
 			echo_len = (tx_len > TX_DMA_BUF_SIZE)
 				 ? TX_DMA_BUF_SIZE : tx_len;
-			memcpy(echo_buf, tx_dma_buf, echo_len);
+
+			/* Build single contiguous TX: "Echo:\r\n" + received data + "\r\n" */
+			memcpy(&echo_buf[pos], "Echo:\r\n", 7);
+			pos += 7;
+			memcpy(&echo_buf[pos], tx_dma_buf, echo_len);
+			pos += echo_len;
+			echo_buf[pos++] = '\r';
+			echo_buf[pos++] = '\n';
 			tx_len = 0;
 			irq_unlock(key);
 
-			/* print "Echo" message via DMA to shell UART */
-			ret = dma_uart_send((const uint8_t *)"Echo:\r\n", sizeof("Echo:\r\n") - 1);
+			/* Single DMA send for the entire echo response */
+			ret = dma_uart_send(echo_buf, pos);
 			if (ret < 0) {
-				printk("Error sending UART TX DMA: %d\n", ret);
+				LOG_ERR("DMA TX err: %d", ret);
 			}
 
-			/* echo back user input via DMA to shell UART */
-			ret = dma_uart_send(echo_buf, echo_len);
-			if (ret < 0) {
-				printk("Error sending UART TX DMA: %d\n", ret);
-			}
-
-			/* send newline via DMA to shell UART */
-			ret = dma_uart_send((const uint8_t *)"\r\n", sizeof("\r\n") - 1);
-			if (ret < 0) {
-				printk("Error sending UART TX DMA: %d\n", ret);
+			if (truncated) {
+				truncated = false;
+				LOG_WRN("input truncated to 64 bytes!");
 			}
 		}
 	}


### PR DESCRIPTION
- Collapse \r\n sequences to avoid duplicate line-end signals
- Store line-ending characters in buffer for true raw echo
- Build single contiguous TX buffer to reduce DMA transactions
- Increase RX timeout to 1000us for character batching
- Increase line_ready semaphore max count to 10
- Disable LOG_PRINTK to avoid output interference