### PR TITLE
Add clock control to i2ssync driver

### DIFF
--- a/drivers/i2s/i2s_sync/Kconfig
+++ b/drivers/i2s/i2s_sync/Kconfig
@@ -9,7 +9,7 @@
 menuconfig I2S_SYNC
 	bool "Alif I2S sync driver"
 	default y
-	depends on I2S && DT_HAS_ALIF_I2S_SYNC_ENABLED
+	depends on I2S && DT_HAS_ALIF_I2S_SYNC_ENABLED && CLOCK_CONTROL
 	help
 		Enable Alif I2S driver with synchronisation
 

--- a/drivers/i2s/i2s_sync/i2s_sync.c
+++ b/drivers/i2s/i2s_sync/i2s_sync.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/pm/device.h>
@@ -67,6 +68,8 @@ struct i2s_sync_dma_ch {
 
 struct i2s_sync_config_priv {
 	struct i2s_t *paddr;
+	const struct device *clk_dev;
+	clock_control_subsys_t clkid;
 	void (*irq_config)(const struct device *dev);
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
@@ -475,9 +478,6 @@ static int get_wss_cycles(size_t const bit_depth)
 
 static int enable_clock(struct i2s_t *i2s, size_t const wss_clock)
 {
-	i2s_select_clock_source(i2s);
-	i2s_enable_sclk_aon(i2s);
-	i2s_enable_module_clk(i2s);
 	i2s_global_enable(i2s);
 	i2s_disable_clk(i2s);
 	i2s_configure_clk(i2s, wss_clock);
@@ -528,6 +528,27 @@ static int i2s_sync_configure_impl(const struct device *dev, struct i2s_sync_con
 	struct i2s_sync_data *const dev_data = dev->data;
 	struct i2s_t *i2s = dev_cfg->paddr;
 
+
+	/* check device availability */
+	if (!device_is_ready(dev_cfg->clk_dev)) {
+		LOG_ERR("clock controller device not ready");
+		return -ENODEV;
+	}
+
+	/* Configure I2S clock sources */
+	ret = clock_control_configure(dev_cfg->clk_dev, dev_cfg->clkid, NULL);
+	if (ret != 0) {
+		LOG_ERR("Unable to configure clock: err:%d", ret);
+		return ret;
+	}
+
+	/* Enable I2S clock from clock manager */
+	ret = clock_control_on(dev_cfg->clk_dev, dev_cfg->clkid);
+	if (ret != 0) {
+		LOG_ERR("Unable to turn on clock: err:%d", ret);
+		return ret;
+	}
+
 	/* Disable RX and TX channels (enabled by default) */
 	i2s_rx_channel_disable(i2s);
 	i2s_tx_channel_disable(i2s);
@@ -571,13 +592,6 @@ static int i2s_sync_init(const struct device *dev)
 	int ret;
 	const struct i2s_sync_config_priv *dev_cfg = dev->config;
 	struct i2s_t *i2s = dev_cfg->paddr;
-
-	/* Configure clocks to avoid stall in configure method */
-	ret = enable_clock(i2s, dev_cfg->bit_depth);
-	if (ret) {
-		LOG_ERR("Failed to enable clock, err %d", ret);
-		return ret;
-	}
 
 #ifdef CONFIG_PINCTRL
 	/* Set up pincfg if present */
@@ -864,6 +878,8 @@ static int i2s_sync_pm_action(const struct device *dev, enum pm_device_action ac
 	static struct i2s_sync_data i2s_sync_data_##inst;                                          \
 	static const struct i2s_sync_config_priv i2s_sync_config_##inst = {                        \
 		.paddr = (struct i2s_t *)DT_INST_REG_ADDR(inst),                                   \
+		.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),		\
+		.clkid = (clock_control_subsys_t) DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, clkid),	\
 		.irq_config = i2s_sync_irq_config_func_##inst,                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
 			   (.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),))                      \

--- a/samples/drivers/i2s_sync/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
+++ b/samples/drivers/i2s_sync/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
@@ -1,0 +1,81 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/ensemble-e4-e6-e8-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+#define I2S3_IRQ_NUM  144
+#define I2S3_IRQ_PRIO 3
+
+#define I2S3_DMA_RX_CH  2
+#define I2S3_DMA_RX_REQ 27
+#define I2S3_DMA_TX_CH  3
+#define I2S3_DMA_TX_REQ 31
+
+#define AUDIO_DMA_ENABLED 1
+
+/ {
+	aliases {
+		audio-codec = &wm8904;
+		i2s-bus = &i2s3;
+	};
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+
+	wm8904: wm8904@1a {
+		compatible = "cirrus,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
+};
+
+&i2s3 {
+	/delete-property/ clock-frequency;
+	/delete-property/ driver-instance;
+	compatible = "alif,i2s-sync";
+	interrupts = <I2S3_IRQ_NUM I2S3_IRQ_PRIO>;
+	bit-depth = <16>;
+	sample-rate = <48000>;
+	status = "okay";
+#if AUDIO_DMA_ENABLED
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(I2S3_DMA_RX_CH, 1, 1) I2S3_DMA_RX_REQ>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(I2S3_DMA_TX_CH, 1, 1) I2S3_DMA_TX_REQ>;
+	dma-names = "rxdma", "txdma";
+#endif
+};
+
+&pinctrl_i2c1 {
+	group0 {
+		pinmux = <PIN_P7_2__I2C1_SDA_C>,
+			 <PIN_P7_3__I2C1_SCL_C>;
+	};
+};
+
+&pinctrl_i2s3 {
+	group0 {
+		pinmux = <PIN_P9_0__I2S3_SDI_B>,
+			 <PIN_P9_3__I2S3_SDO_A>,
+			 <PIN_P8_7__I2S3_WS_B>,
+			 <PIN_P8_6__I2S3_SCLK_B>;
+	};
+};


### PR DESCRIPTION
Add clock control to I2S sync driver for Ensemble series. Balletto does not need it but it won't harm to have it.