### PR TITLE
manifest: Update zephyr revision to include arx3a0 default fmt

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 162e865ca29e29e2c3734de0c137b84b2501a6e6
+      revision: 92bf7e17af4fea8e7a99de81cc93b01984b36ae6
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to include the fix to add the default format for arx3a0.