### PR TITLE
manifest: update zephyr revision version for CMP clock Fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e9e1b4aa19a432794ac535c5fb638ec2ac8636dd
+      revision: pull/543/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr revision verion to pick Fix CMP clock configuration for multi-clock support.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/543