### PR TITLE
manifest: update zephyr revision version for display fix on E1C

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e9e1b4aa19a432794ac535c5fb638ec2ac8636dd
+      revision: pull/541/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr revision verion to pick Fix in devicetree to add MIPI DSI, DPHY and ILI9488 nodes to support single lane display on E1C board.
zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/541