### PR TITLE
manifest: Update zephyr revision for Alif PDM PM support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e9e1b4aa19a432794ac535c5fb638ec2ac8636dd
+      revision: pull/545/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated zephyr revision version for Alif PDM PM support
This PR depends on: https://github.com/alifsemi/zephyr_alif/pull/545