### PR TITLE
manifest: Update Zephyr revision for CSI2 timing update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 162e865ca29e29e2c3734de0c137b84b2501a6e6
+      revision: pull/546/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: d1470349b6f866d0fa2b7a4a05b95d6ba0297f5b
+      revision: daad413c7bc2cee8a2801a8f7d58d4578e60bd8a
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision for CSI2 timing update.
This PR depends on: alifsemi/zephyr_alif/pull/546