### PR TITLE
samples: drivers: ipm: add MHU doorbell sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build*/
 *.bkp
 *.orig
 *.pyc
+.cache/

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/CMakeLists.txt
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ipm_arm_mhu_doorbell)
+
+target_include_directories(app PRIVATE include)
+
+target_sources_ifdef(CONFIG_HE_HP_S  app PRIVATE src/m55he_to_m55hp_initiator.c)
+target_sources_ifdef(CONFIG_HP_HE_R  app PRIVATE src/m55hp_to_m55he_responder.c)
+target_sources_ifdef(CONFIG_HE_A32_S app PRIVATE src/m55_to_a32_initiator.c)
+target_sources_ifdef(CONFIG_A32_HE_R app PRIVATE src/a32_to_m55_responder.c)

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/Kconfig
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/Kconfig
@@ -1,0 +1,57 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+
+mainmenu "MHU Doorbell Sample Configuration"
+
+choice
+	prompt "MHU doorbell test case"
+	default HE_HP_S
+	help
+	  Select which inter-processor communication test case to build.
+	  Exactly one test case is built per image.
+
+config HE_HP_S
+	bool "RTSS-HE (M55) to RTSS-HP (M55) initiator/sender"
+	help
+	  Build the RTSS-HE (M55) to RTSS-HP (M55) shared memory &
+	  doorbell initiator/sender.
+
+config HP_HE_R
+	bool "RTSS-HP (M55) to RTSS-HE (M55) responder"
+	help
+	  Build the RTSS-HP (M55) to RTSS-HE (M55) shared memory &
+	  doorbell responder.
+
+config HE_A32_S
+	bool "RTSS-HE (M55) to APSS (A32) initiator/sender"
+	help
+	  Build the RTSS-HE (M55) to APSS (A32) shared memory &
+	  doorbell initiator/sender.
+
+config A32_HE_R
+	bool "APSS (A32) to RTSS-HE (M55) responder"
+	help
+	  Build the APSS (A32, Zephyr) responder for messages initiated by
+	  the RTSS-HE (M55) shared memory & doorbell initiator (counterpart
+	  to CONFIG_HE_A32_S).
+
+endchoice
+
+config USE_MHU1
+	bool "Use MHU1 instead of MHU0 for inter-core communication"
+	default n
+	help
+	  Select MHU1 channel for communication between M55 cores.
+	  Default is MHU0.
+
+source "Kconfig.zephyr"
+
+# Automatically enable power management when one of the pm-system-off-*
+# snippets is applied. Those snippets enable the aipm-off DTS node, so the
+# default build (without the snippet) is unaffected.
+config PM
+	default y if $(dt_nodelabel_enabled,aipm_off)
+
+config COUNTER
+	default y if $(dt_nodelabel_enabled,aipm_off)

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/README.rst
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/README.rst
@@ -1,0 +1,318 @@
+.. _ipm_arm_mhu_doorbell_sample:
+
+MHU Doorbell Sample
+###################
+
+Overview
+********
+
+This sample demonstrates inter-processor communication (IPC) using
+MHU doorbell interrupts on the Alif Ensemble family of devices. The MHU
+channel is used as a doorbell: the 32-bit value it carries notifies the
+other core and carries the address of a shared-memory data block that the
+other core reads, validates, and echoes or frees.
+
+**M55-HE to M55-HP (shared-heap data exchange)**
+
+The two M55 cores share a ``struct sys_heap`` whose control block and
+managed memory both live in shared SRAM1, so both cores operate on the
+same heap instance.
+
+* The initiator (HE) dynamically allocates a message block from the
+  shared heap, fills it with a payload, and rings the MHU doorbell
+  passing the physical address of the allocated block.
+* The responder (HP) invalidates its D-cache, reads and validates the
+  block, frees it back to the shared heap, and rings the doorbell back
+  with the freed address as an acknowledgment.
+* The initiator verifies the acknowledged address matches the block it
+  sent.
+
+Because both M55 cores have D-cache enabled, the writer cleans (flushes)
+its D-cache after writing shared SRAM and the reader invalidates its
+D-cache before reading. The strict doorbell ping-pong guarantees only one
+core touches the shared heap at a time.
+
+**M55-HE/HP to A32/APSS (shared-heap data exchange)**
+
+This case uses the same shared ``struct sys_heap`` mechanism as the
+HE-to-HP case, but with the A32/APSS core (running Zephyr) as the
+responder. The M55 initiator runs on either core (RTSS-HE or RTSS-HP).
+Because A32 cannot operate on the Zephyr heap, the M55 initiator owns both
+the allocation and the free; A32 only reads and writes the data block
+whose address the M55 passes over the doorbell.
+
+* The initiator (M55) dynamically allocates a message block from the
+  shared heap, fills it with a payload, and rings the MHU doorbell
+  passing the physical address of the allocated block.
+* The responder (A32) maps the shared SRAM1 heap page non-cacheable,
+  reads and validates the block, writes its response into the same
+  block, and rings the doorbell back with the block address as an
+  acknowledgment.
+* The initiator invalidates its D-cache, validates A32's response (magic
+  value, message id and checksum), and frees the block back to the shared
+  heap.
+
+The heap base is page-aligned and its whole span fits in one 4 KB page so
+the A32 reaches every block through a single mapping. The M55 writer
+cleans (flushes) its D-cache after writing the shared block and
+invalidates its D-cache before reading; the A32 maps the region
+non-cacheable, so its accesses go straight to memory and need no cache
+maintenance.
+
+This sample includes test cases for communication between:
+
+* M55-HE (initiator) and M55-HP (responder) -- shared-heap data exchange
+* M55-HE/HP (initiator) and A32/APSS (responder, running Zephyr) --
+  shared-heap data exchange
+
+Requirements
+************
+
+* Alif E8 DevKit
+* Two or more cores enabled (e.g., RTSS-HE and RTSS-HP, or RTSS-HE and APSS)
+
+Supported Targets
+*****************
+
+* alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+* alif_e8_dk/ae822fa0e5597xx0/rtss_he
+* alif_e8_dk/ae822fa0e5597xx0/apss
+
+Building
+********
+
+The code can be found in :zephyr_file:`samples/drivers/ipm/ipm_arm_mhu_doorbell`.
+
+Select the test case with the corresponding Kconfig option:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``CONFIG_HE_HP_S``
+     - M55-HE to M55-HP initiator/sender
+   * - ``CONFIG_HP_HE_R``
+     - M55-HP to M55-HE responder
+   * - ``CONFIG_HE_A32_S``
+     - M55-HE/HP to A32 (APSS) initiator/sender
+   * - ``CONFIG_A32_HE_R``
+     - A32 (APSS, Zephyr) responder to M55-HE/HP initiator
+
+By default MHU0 is used for communication. To use MHU1 instead, add
+``-DCONFIG_USE_MHU1=y`` to the build command.
+
+Building M55-HE to M55-HP communication (requires both images):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HE_HP_S=y
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HP_HE_R=y
+   :compact:
+
+Built like this (without a ``pm-system-off-*`` snippet) the HE<->HP variant
+runs with power management disabled: the two cores exchange messages
+back-to-back and stop after 10 exchanges (``NUM_EXCHANGES``), printing a
+pass/fail summary. Building both cores with the matching snippet instead
+enables the low-power, reset-based model described in `Low-power Operation`_.
+
+Building inter-core communication using MHU1 (requires both images):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HE_HP_S=y -DCONFIG_USE_MHU1=y
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HP_HE_R=y -DCONFIG_USE_MHU1=y
+   :compact:
+
+Building M55-HE/HP to A32 communication (M55 initiates, A32 responds):
+
+The M55 initiator is core-agnostic; build it for the RTSS-HE or RTSS-HP
+board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HE_A32_S=y
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_HE_A32_S=y
+   :compact:
+
+The A32 responder for this case is a Zephyr application built for the APSS
+target with ``CONFIG_A32_HE_R``. The A32 has a separate MHU to each M55
+core, so the responder listens on both the HE and HP channels and replies
+on whichever one rang -- the initiator can therefore run on either M55 core
+with the same A32 image. It maps the shared SRAM1 heap page non-cacheable
+and needs no cache maintenance:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/apss
+   :goals: build
+   :west-args: -p always
+   :gen-args: -DCONFIG_A32_HE_R=y
+   :compact:
+
+
+Low-power Operation
+*******************
+
+The M55-HE to M55-HP variant optionally runs both cores under power
+management. PM is enabled automatically (via Kconfig) when the build
+includes one of the ``pm-system-off-*`` snippets, which apply the SE
+run/off power profiles and deep off-state nodes in devicetree.
+
+Both cores spend their idle time in ``PM_STATE_SOFT_OFF`` -- the deepest
+state, which power-gates the subsystem. On this MRAM-boot image (vector
+table in MRAM, ``VTOR >= 0x80000000``) a SOFT_OFF wake re-enters through the
+reset vector, so each wake is a full **reset/reboot** that re-runs
+``main()``. A real dual-core SOFT_OFF does not retain SRAM1 content, so no
+state carries across the power-off: every boot re-creates the cross-core
+heap and performs exactly one HE->HP exchange. The test runs indefinitely
+(one exchange per boot).
+
+Each core has its own SOFT_OFF wake source:
+
+* **M55-HE (initiator)** arms the always-on ``LPTIMER0`` for a 2 s wake
+  before entering SOFT_OFF. Each LPTIMER0 wake resets HE, which performs one
+  doorbell exchange and powers off again. While waiting for HP's ack
+  during an exchange, HE idles in ``PM_STATE_SUSPEND_TO_IDLE`` (IWIC-woken by
+  the MHU RX IRQ; the LPRTC idle timer backs the ``k_sleep()`` poll
+  timeouts).
+* **M55-HP (responder)** has no timer; it enters SOFT_OFF while waiting for a
+  doorbell. The MHU RX IRQ wakes it: the M55 core's external wake controller
+  (EWIC) automatically monitors the enabled NVIC interrupts (numbers < 64,
+  which includes MHU0=41 / MHU1=43), so HE ringing the doorbell wakes HP --
+  again via reset. On reboot HP re-arms its receivers and the latched
+  doorbell is delivered, so it handles one exchange per boot.
+
+Because the SOFT_OFF off-profile retains only MRAM (+SERAM on HP) by
+default, the overlays add SRAM1 (``ALIF_SRAM1_MASK``) to the off-profile
+``memory-blocks`` so the cross-core heap stays powered while one core is off
+and the other is still running. Retaining SRAM1 *content* through a full
+dual-core power-off would require ``ALIF_SRAM1_RET_MASK``, which keeps a rail
+up and defeats the deep SOFT_OFF this sample demonstrates -- so the sample
+treats every boot as a fresh exchange rather than carrying a counter.
+
+Two overlays are passed on the command line:
+
+* ``lpm_shared_sram1.overlay`` (both cores) keeps the ``VBAT_AON`` power
+  domain (so the LPRTC idle timer keeps ticking) and the shared SRAM1
+  block retained across the SE run and SOFT_OFF profiles, and enables the
+  ``suspend_idle`` state node on RTSS-HP.
+* ``lpuart.overlay`` (RTSS-HE) moves the HE console to the LPUART, enables
+  ``LPTIMER0`` and its SOFT_OFF wake, points the off-profile wake vector
+  back at the MRAM image start, and lowers the SOFT_OFF min-residency so the
+  policy selects SOFT_OFF for the 2 s inter-iteration sleep.
+
+Build both cores with the matching snippet and overlays (MRAM boot, i.e. no
+``CONFIG_FLASH_*`` TCM overrides):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p always
+   :snippets: pm-system-off-he
+   :gen-args: -DCONFIG_HE_HP_S=y "-DEXTRA_DTC_OVERLAY_FILE=lpuart.overlay;lpm_shared_sram1.overlay"
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_arm_mhu_doorbell
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p always
+   :snippets: pm-system-off-hp
+   :gen-args: -DCONFIG_HP_HE_R=y -DEXTRA_DTC_OVERLAY_FILE=lpm_shared_sram1.overlay
+   :compact:
+
+
+Sample Output
+*************
+
+M55-HE to M55-HP shared-heap exchange. Built without a ``pm-system-off-*``
+snippet (default), power management is disabled: the cores run 10 exchanges
+back-to-back and then stop with a pass/fail summary:
+
+.. code-block:: none
+
+   *** Booting Zephyr OS build e9e1b4aa19a4 ***
+==========================================
+M55-HP <-> M55-HE : MHU Doorbell + Shared SRAM1 heap (responder)
+  MHU0 heap ctrl: 0x027dc000
+  MHU1 heap ctrl: 0x027dc800
+  PM: disabled -- exchanges run back-to-back (build with -S pm-system-off-hp for SOFT_OFF)
+==========================================
+MHU devices ready
+Waiting for HE doorbell...
+
+M55-HP: Doorbell RX (MHU0) addr=0x027dc134
+HE->HP: block @ 0x027dc134 msg_id=0 len=16 cksum=0x78/0x78 PASS
+HP: freed block @ 0x027dc134
+M55-HP: Doorbell TX (MHU0) done
+Complete
+
+
+Built with the ``pm-system-off-*`` snippets, both cores run under power
+management. Each LPTIMER0 wake resets HE, so every cycle reboots and runs one
+exchange:
+
+.. code-block:: none
+
+   *** Booting Zephyr OS build e9e1b4aa19a4 ***
+
+   ==========================================
+   M55-HE -> M55-HP : MHU0 Doorbell + Shared SRAM1 heap (initiator)
+     Shared heap ctrl: 0x027dc000
+     Shared heap mem : 0x027dc100 (size 0x700)
+     PM: SOFT_OFF between exchanges, 2000 ms LPTIMER0 wake (each wake resets HE)
+   ==========================================
+   HE->HP: alloc block @ 0x027dc134 msg_id=0 len=16 cksum=0x78
+   M55-HE: Doorbell TX (MHU0) done
+   M55-HE: Doorbell RX (MHU0) addr=0x027dc134
+   HP->HE: ack free of block @ 0x027dc134 PASS
+
+   M55-HE: entering SOFT_OFF; LPTIMER0 wake in 2000 ms (core resets)
+
+   *** Booting Zephyr OS build e9e1b4aa19a4 ***
+
+   ==========================================
+   M55-HE -> M55-HP : MHU0 Doorbell + Shared SRAM1 heap (initiator)
+     Shared heap ctrl: 0x027dc000
+     Shared heap mem : 0x027dc100 (size 0x700)
+     PM: SOFT_OFF between exchanges, 2000 ms LPTIMER0 wake (each wake resets HE)
+   ==========================================
+   HE->HP: alloc block @ 0x027dc134 msg_id=0 len=16 cksum=0x78
+   M55-HE: Doorbell TX (MHU0) done
+   M55-HE: Doorbell RX (MHU0) addr=0x027dc134
+   HP->HE: ack free of block @ 0x027dc134 PASS
+
+   M55-HE: entering SOFT_OFF; LPTIMER0 wake in 2000 ms (core resets)
+   ...

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_apss.conf
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_apss.conf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright Alif Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# The APSS (A32) board defconfig does not enable MHU support (the A32 normally
+# has no MHU nodes). This sample adds them via the board overlay, so pull in
+# the SoC MHUv2 support here -- it selects IPM and ARM_MHUV2 -- for the A32
+# responder build (CONFIG_A32_HE_R).
+CONFIG_SOC_SUPPORT_ARM_MHUV2=y

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_apss.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_apss.overlay
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * APSS (A32) board overlay for the MHU doorbell sample.
+ *
+ * The A32 is the peer of the RTSS-HE core: it receives the doorbell the
+ * RTSS-HE initiator sends and replies back. Unlike the M55 cores (NVIC), the
+ * A32 reaches the MHU register frames through the GIC.
+ *
+ * Register bases and GIC SPI interrupts are the A32-side MHU frames for the
+ * RTSS-HE and RTSS-HP channels on the Alif devkit-e8:
+ *   hp_mhu0_tx @ 0x1b000000  GIC_SPI 11
+ *   hp_mhu0_rx @ 0x1b010000  GIC_SPI 12
+ *   hp_mhu1_tx @ 0x1b020000  GIC_SPI 46
+ *   hp_mhu1_rx @ 0x1b030000  GIC_SPI 47
+ *   he_mhu0_tx @ 0x1b040000  GIC_SPI 13
+ *   he_mhu0_rx @ 0x1b050000  GIC_SPI 14
+ *   he_mhu1_tx @ 0x1b060000  GIC_SPI 48
+ *   he_mhu1_rx @ 0x1b070000  GIC_SPI 49
+ *
+ * The shared SRAM1 heap (0x027DDxxx) is not in the A32's default MMU map; the
+ * responder maps it at runtime, non-cacheable, via k_mem_map_phys_bare().
+ */
+
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	chosen {
+		zephyr,console = &uart4;
+		zephyr,shell-uart = &uart4;
+		zephyr,uart-mcumgr = &uart4;
+	};
+
+	aliases {
+		apssmhu0r = &apss_rtsshe_mhu0_r;
+		apssmhu0s = &apss_rtsshe_mhu0_s;
+		apssmhu1r = &apss_rtsshe_mhu1_r;
+		apssmhu1s = &apss_rtsshe_mhu1_s;
+		apsshpmhu0r = &apss_rtsshp_mhu0_r;
+		apsshpmhu0s = &apss_rtsshp_mhu0_s;
+		apsshpmhu1r = &apss_rtsshp_mhu1_r;
+		apsshpmhu1s = &apss_rtsshp_mhu1_s;
+	};
+};
+
+&uart4 {
+	status = "okay";
+};
+
+&{/soc} {
+	/* MHU0 sender: A32 sends to RTSS-HP */
+	apss_rtsshp_mhu0_s: mhu@1b000000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b000000 0x1000>;
+		interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "tx";
+		status = "okay";
+	};
+
+	/* MHU0 receiver: A32 receives from RTSS-HP */
+	apss_rtsshp_mhu0_r: mhu@1b010000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b010000 0x1000>;
+		interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "rx";
+		status = "okay";
+	};
+
+	/* MHU1 sender: A32 sends to RTSS-HP */
+	apss_rtsshp_mhu1_s: mhu@1b020000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b020000 0x1000>;
+		interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "tx";
+		status = "okay";
+	};
+
+	/* MHU1 receiver: A32 receives from RTSS-HP */
+	apss_rtsshp_mhu1_r: mhu@1b030000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b030000 0x1000>;
+		interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "rx";
+		status = "okay";
+	};
+
+	/* MHU0 sender: A32 sends to RTSS-HE */
+	apss_rtsshe_mhu0_s: mhu@1b040000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b040000 0x1000>;
+		interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "tx";
+		status = "okay";
+	};
+
+	/* MHU0 receiver: A32 receives from RTSS-HE */
+	apss_rtsshe_mhu0_r: mhu@1b050000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b050000 0x1000>;
+		interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "rx";
+		status = "okay";
+	};
+
+	/* MHU1 sender: A32 sends to RTSS-HE */
+	apss_rtsshe_mhu1_s: mhu@1b060000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b060000 0x1000>;
+		interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "tx";
+		status = "okay";
+	};
+
+	/* MHU1 receiver: A32 receives from RTSS-HE */
+	apss_rtsshe_mhu1_r: mhu@1b070000 {
+		compatible = "arm,mhuv2";
+		reg = <0x1b070000 0x1000>;
+		interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "rx";
+		status = "okay";
+	};
+};

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
@@ -1,0 +1,10 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+#include "alif_ensemble_dk.overlay"

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
@@ -1,0 +1,10 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+#include "alif_ensemble_dk.overlay"

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_ensemble_dk.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/boards/alif_ensemble_dk.overlay
@@ -1,0 +1,22 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/{
+	aliases {
+		apssmhu0r = &apss_rtsshe_mhu0_r;
+		apssmhu0s = &rtsshe_apss_mhu0_s;
+		apssmhu1r = &apss_rtsshe_mhu1_r;
+		apssmhu1s = &rtsshe_apss_mhu1_s;
+		rtssmhu0r = &rtsshp_rtsshe_mhu0_r;
+		rtssmhu0s = &rtsshe_rtsshp_mhu0_s;
+		rtssmhu1r = &rtsshp_rtsshe_mhu1_r;
+		rtssmhu1s = &rtsshe_rtsshp_mhu1_s;
+	};
+};

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/include/mhu_doorbell_heap.h
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/include/mhu_doorbell_heap.h
@@ -1,0 +1,48 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * Shared SRAM1 cross-core heap layout for the MHU doorbell sample.
+ *
+ * Each shared heap is a struct sys_heap control block immediately followed by
+ * the memory it manages, both placed in shared SRAM1 so the two participating
+ * cores operate on the same heap instance. The control block plus managed
+ * memory occupy one SHARED_HEAP_SPAN region; the managed area itself is
+ * SHARED_HEAP_SIZE bytes. There is one heap per MHU channel.
+ *
+ * The addresses are a fixed contract shared by every participant (M55-HE,
+ * M55-HP and the A32/APSS side), so they live in one header rather than being
+ * duplicated per test case. The A32 (HE<->A32) heaps are page-aligned and each
+ * whole span fits in one 4 KB page so the A32 side can reach every block
+ * through a single mapping.
+ *
+ *   SRAM1 layout (ctrl / mem, each span 0x800):
+ *     HE<->HP   MHU0: ctrl 0x027DC000, mem 0x027DC100
+ *     HE<->HP   MHU1: ctrl 0x027DC800, mem 0x027DC900
+ *     HE<->A32  MHU0: ctrl 0x027DD000, mem 0x027DD100
+ *     HE<->A32  MHU1: ctrl 0x027DE000, mem 0x027DE100
+ */
+
+#ifndef MHU_DOORBELL_HEAP_H
+#define MHU_DOORBELL_HEAP_H
+
+#define SHARED_HEAP_SIZE  0x700   /* managed memory size */
+#define SHARED_HEAP_SPAN  0x800   /* ctrl block + managed memory */
+
+/* M55-HE <-> M55-HP heaps (one per MHU channel). */
+#define SHARED_HEAP_HEHP_MHU0_CTRL  0x027DC000
+#define SHARED_HEAP_HEHP_MHU0_MEM   0x027DC100
+#define SHARED_HEAP_HEHP_MHU1_CTRL  0x027DC800
+#define SHARED_HEAP_HEHP_MHU1_MEM   0x027DC900
+
+/* M55-HE <-> A32 (APSS) heaps (one per MHU channel). */
+#define SHARED_HEAP_HEA32_MHU0_CTRL 0x027DD000
+#define SHARED_HEAP_HEA32_MHU0_MEM  0x027DD100
+#define SHARED_HEAP_HEA32_MHU1_CTRL 0x027DE000
+#define SHARED_HEAP_HEA32_MHU1_MEM  0x027DE100
+
+#endif /* MHU_DOORBELL_HEAP_H */

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/include/mhu_doorbell_msg.h
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/include/mhu_doorbell_msg.h
@@ -1,0 +1,46 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * Cross-core wire contract for the MHU doorbell sample.
+ *
+ * The doorbell carries a 32-bit value (a shared-SRAM address); the data it
+ * points at is a struct shared_msg. Every participant -- M55-HE, M55-HP and
+ * the A32/APSS side -- MUST agree on this layout and on the magic values,
+ * so it lives in one shared header rather than being duplicated per test
+ * case.
+ *
+ * Shared memory layout (struct shared_msg):
+ *   [0x00] magic      - identifies the writer (see MAGIC_* below)
+ *   [0x04] msg_id     - incrementing message counter
+ *   [0x08] data_len   - number of payload bytes (max MAX_PAYLOAD)
+ *   [0x0C] data[240]  - payload
+ *   [0xFC] checksum   - sum of payload bytes
+ */
+
+#ifndef MHU_DOORBELL_MSG_H
+#define MHU_DOORBELL_MSG_H
+
+#include <stdint.h>
+
+#define MAX_PAYLOAD 240
+
+/* Magic values identifying which core wrote the block. */
+#define MAGIC_HE  0xCAFE0E00   /* Written by M55-HE  */
+#define MAGIC_HP  0xCAFE0F00   /* Written by M55-HP  */
+#define MAGIC_A32 0xA32F055E   /* Written by A32     */
+#define MAGIC_M55 0xF055EA32   /* Written by M55 (A32 protocol) */
+
+struct shared_msg {
+	uint32_t magic;
+	uint32_t msg_id;
+	uint32_t data_len;
+	uint8_t  data[MAX_PAYLOAD];
+	uint32_t checksum;
+};
+
+#endif /* MHU_DOORBELL_MSG_H */

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/lpm_shared_sram1.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/lpm_shared_sram1.overlay
@@ -1,0 +1,75 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * Keep the cross-core shared heap (SRAM1) powered AND keep the VBAT_AON power
+ * domain (which hosts the LPRTC idle-timer) alive when the pm-system-off-*
+ * snippets are applied.
+ *
+ * The HE<->HP doorbell protocol exchanges data through a struct sys_heap that
+ * lives in SRAM1 (0x027DC000 / 0x027DC800), and HE uses the LPRTC
+ * (rtc0 = lprtc@42000000, chosen zephyr,cortex-m-idle-timer) to wake itself
+ * from PM_STATE_SUSPEND_TO_IDLE for each timed k_sleep().
+ *
+ * The Secure Enclave only lowers a power domain / drops a memory block when
+ * ALL participating cores vote for it. The pm-system-off-* snippets set the
+ * run profile to:
+ *   - retain ONLY MRAM (memory-blocks = <ALIF_MRAM_MASK>)
+ *   - keep ONLY SSE700_AON + SYST powered (power-domains = 0x44), dropping
+ *     VBAT_AON.
+ * The LPRTC at 0x42000000 lives in the VBAT_AON domain. When only one core is
+ * PM-managed the other (fully-on) core keeps both SRAM1 and VBAT_AON alive, so
+ * the protocol works. As soon as BOTH cores run a snippet, neither votes to
+ * keep VBAT_AON powered -> the SE gates it -> the LPRTC stops counting -> HE's
+ * very first k_sleep() never wakes and the system HANGS. (The same applies to
+ * SRAM1 retention for the shared heap.)
+ *
+ * Override the run profile to (a) retain SRAM1 and (b) keep VBAT_AON powered.
+ * This must be applied AFTER the snippet overlay. Only a command-line
+ * EXTRA_DTC_OVERLAY_FILE is applied after the snippet (the app's
+ * boards/<board>.overlay and any overlay appended from CMakeLists before
+ * find_package are applied BEFORE the snippet and lose to it). So pass this
+ * file explicitly on the west command line, e.g.:
+ *   HE: -DEXTRA_DTC_OVERLAY_FILE="lpuart.overlay;lpm_shared_sram1.overlay"
+ *   HP: -DEXTRA_DTC_OVERLAY_FILE=lpm_shared_sram1.overlay
+ */
+
+&aipm_run_default {
+	/* Retain the shared heap (SRAM1) in addition to MRAM. */
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SRAM1_MASK)>;
+	/* Keep VBAT_AON powered so the LPRTC idle-timer keeps ticking and can
+	 * wake HE from SUSPEND_TO_IDLE; SSE700_AON + SYST as per the snippet.
+	 */
+	aipm-power-domains = <(ALIF_PD_VBAT_AON_MASK |
+			       ALIF_PD_SSE700_AON_MASK |
+			       ALIF_PD_SYST_MASK)>;
+};
+
+/* HE idles into PM_STATE_SUSPEND_TO_IDLE during the protocol; the
+ * pm-system-off-he snippet already enables this node. The pm-system-off-hp
+ * snippet does not, so enable it here. Suspend-to-idle uses the IWIC, which
+ * wakes on the MHU RX IRQ (and, on HE, the rtc0 idle-timer), so no extra wake
+ * configuration is needed. (HP itself uses SOFT_OFF, but leaving this enabled
+ * is harmless as HP locks SUSPEND_TO_IDLE out at runtime.)
+ */
+&suspend_idle {
+	status = "okay";
+};
+
+/* Keep SRAM1 powered across SOFT_OFF so the cross-core shared heap memory stays
+ * valid while a core is off. The sample re-initialises the heap on each
+ * reset-based wake, so this only keeps SRAM1 powered and does not rely on any
+ * state surviving a SOFT_OFF cycle. The pm-system-off-*
+ * snippets retain only MRAM (+SERAM on HP) in the off profile, which would drop
+ * SRAM1 when a core powers off. Setting only memory-blocks here leaves the
+ * snippet's wakeup-events / ewic-cfg untouched. (HP's MHU wake comes from the
+ * M55 EWIC auto-monitoring enabled NVIC IRQs 0-63 -- MHU0=41, MHU1=43 -- not
+ * from the off-profile AON ewic-cfg.)
+ */
+&off_profile_soft_off {
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK | ALIF_SRAM1_MASK)>;
+};

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/lpuart.overlay
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/lpuart.overlay
@@ -1,0 +1,90 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+&uart2 {
+	status = "disabled";
+};
+
+&lpuart {
+	current-speed = <115200>;
+	dlf = <13>;
+	/*/delete-property/ dlf;*/
+	status = "okay";
+	/delete-property/ pinctrl-1; // = <&pinctrl_lpuart_sleep>;
+	pinctrl-names = "default";
+};
+
+&pinctrl {
+	pinctrl_lpuart: pinctrl_lpuart {
+		group0 {
+			pinmux = < PIN_P9_1__LPUART_RX_B >,
+				 < PIN_P9_2__LPUART_TX_B >;
+		};
+	};
+};
+/ {
+	chosen {
+		zephyr,console = &lpuart;
+		zephyr,shell-uart = &lpuart;
+		zephyr,uart-mcumgr = &lpuart;
+	};
+};
+/*
+ * Enable PM_STATE_SOFT_OFF wake for the HE core via the always-on LPTIMER0.
+ *
+ * The pm-system-off-he snippet only configures the S2RAM off-profiles
+ * (off_profile_standby / off_profile_stop -> LPRTC wake) and leaves
+ * off_profile_soft_off at its default (wakeup-events = 0, ewic-cfg = 0), so
+ * SOFT_OFF on HE has no wake source and never resumes. Mirror the HP snippet
+ * and wake SOFT_OFF from LPTIMER0 (VBAT timer, EWIC VBAT_TIMER).
+ *
+ * Only a command-line EXTRA_DTC_OVERLAY_FILE is applied AFTER the snippet, so
+ * this override must live in an overlay passed on the west command line (this
+ * file). Enabling timer0 also lets main.c arm LPTIMER0 before entering
+ * SOFT_OFF, since the LPRTC idle-timer is powered down in that profile.
+ */
+&timer0 {
+	status = "okay";
+};
+
+/*
+ * The pm-system-off-he snippet sets aipm_off vtor-address = 0x0, i.e. it tells
+ * the Secure Enclave to restore VTOR to TCM (0x0) when the core wakes from the
+ * off profile. That is correct for a TCM-boot image (S2RAM resume in place),
+ * but this build boots from MRAM (VTOR = 0x80000000). On wake from SOFT_OFF the
+ * SE would jump to the empty TCM at 0x0 and the core would never restart, so no
+ * reset is observed. Point the wake vector back at the MRAM image start so
+ * SOFT_OFF wakeup performs a clean reset/reboot (as it does on the HP core,
+ * whose snippet does not override vtor-address).
+ */
+&aipm_off {
+	vtor-address = <0x80000000>;
+};
+
+&off_profile_soft_off {
+	status = "okay";
+	/* Keep SRAM1 powered across SOFT_OFF so the cross-core shared heap
+	 * memory stays valid while HE is off. The sample re-initialises the
+	 * heap on each reset-based wake and does not rely on any state
+	 * surviving a SOFT_OFF cycle.
+	 */
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK | ALIF_SRAM1_MASK)>;
+	wakeup-events = <ALIF_WE_LPTIMER0>;
+	ewic-cfg = <ALIF_EWIC_VBAT_TIMER>;
+};
+
+/*
+ * The m55he_to_m55hp_initiator.c flow re-enters SOFT_OFF between doorbell
+ * exchanges and arms LPTIMER0 for a 2 s wake. Lower the SOFT_OFF (subsys_off)
+ * min-residency below 2 s (snippet default is 25 s) so the PM policy actually
+ * selects SOFT_OFF for that 2 s k_sleep().
+ */
+&subsys_off {
+	min-residency-us = <500000>;
+};

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/prj.conf
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/prj.conf
@@ -1,0 +1,6 @@
+# The test case (CONFIG_HE_HP_S / CONFIG_HP_HE_R / CONFIG_HE_A32_S /
+# CONFIG_A32_HE_R) and options such as CONFIG_USE_MHU1 are selected on the
+# command line -- see README.rst. Low-power operation is enabled via the
+# pm-system-off-* snippets (PM and COUNTER are turned on automatically in
+# Kconfig when the snippet's aipm-off node is present), so no additional
+# Kconfig settings are needed here.

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/sample.yaml
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/sample.yaml
@@ -1,0 +1,9 @@
+---
+sample:
+  name: MHU Doorbell & Shared SRAM Sample
+tests:
+  sample.drivers.ipm.arm_mhu_doorbell:
+    tags: doorbell
+    platform_allow:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/a32_to_m55_responder.c
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/a32_to_m55_responder.c
@@ -1,0 +1,309 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Alif Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * MHU Doorbell + Shared SRAM1 heap test: A32 (responder) <-> M55-HE/HP (initiator)
+ *
+ * Zephyr-on-A32 counterpart to src/m55_to_a32_initiator.c, using the Zephyr
+ * IPM/MHU driver. The A32 has a separate MHU to each M55 core, so the responder
+ * listens on both the HE and HP channels and replies on whichever rang; the
+ * initiator can therefore run on either M55 core.
+ *
+ * Protocol:
+ *   - A struct sys_heap and the memory it manages both live in shared SRAM1.
+ *     The M55 initiator owns the heap (it does the alloc and the free); A32
+ *     only reads/writes the data block whose physical address the M55 passes
+ *     over the MHU doorbell.
+ *   - The M55 initiator allocates a block, writes a payload (magic MAGIC_HE),
+ *     and rings the doorbell with the block address.
+ *   - A32 (responder) reads/validates the block, writes its response into the
+ *     same block (magic MAGIC_A32, payload echoed back), and rings the
+ *     doorbell back with the block address as an acknowledgment.
+ *
+ * IMPORTANT: D-cache coherency
+ *   The A32 runs under an MMU, so the shared SRAM1 heap page is mapped
+ *   non-cacheable (K_MEM_CACHE_NONE), so A32 accesses go straight to memory and
+ *   need no cache maintenance; the M55 initiator (D-cache enabled) cleans after
+ *   writing and invalidates before reading. The doorbell carries a physical
+ *   address, which A32 translates into its non-cacheable mapping.
+ *
+ * Shared memory layout (struct shared_msg):
+ *   [0x00] magic      - 0xCAFE0E00 from the M55 initiator, 0xA32F055E by A32
+ *   [0x04] msg_id     - incrementing message counter
+ *   [0x08] data_len   - number of payload bytes (max 240)
+ *   [0x0C] data[240]  - payload
+ *   [0xFC] checksum   - sum of payload bytes
+ *
+ * Test flow (per iteration):
+ *   1. A32 waits for a doorbell from either M55 core (MHU RX interrupt)
+ *   2. A32 reads and validates the block via the non-cacheable mapping
+ *   3. A32 writes its response into the same block
+ *   4. A32 rings the doorbell back to that core with the block address
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/kernel/mm.h>
+#include <string.h>
+
+#include "mhu_doorbell_msg.h"
+#include "mhu_doorbell_heap.h"
+
+#define ITERATIONS       25
+#define MAX_ERRORS       10
+#define RX_TIMEOUT_MS    5000  /* Timeout waiting for a doorbell     */
+#define TX_TIMEOUT_MS    1000  /* Timeout waiting for TX completion  */
+
+/* Shared SRAM1 cross-core heap for M55 <-> A32 communication. A32 does not
+ * operate the Zephyr heap; it only reads/writes the block the M55 passes over
+ * the doorbell, and range-checks that address against this heap's span.
+ * Addresses come from mhu_doorbell_heap.h and must match the M55 initiator.
+ * The HE and HP initiators use the same HEA32 heap region (one peer at a time).
+ */
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEA32_MHU1_CTRL
+#else
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEA32_MHU0_CTRL
+#endif
+
+/* MHU aliases as seen from the A32 (APSS) side. The A32 has a separate MHU to
+ * each M55 core, so the responder listens on both the HE and the HP channel
+ * (for the selected MHU instance) and replies on whichever one rang -- the
+ * initiator can therefore run on either M55 core with no rebuild here. The A32
+ * board overlay provides both alias sets.
+ */
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define MHU_NAME    "MHU1"
+#define HE_R_ALIAS  apssmhu1r
+#define HE_S_ALIAS  apssmhu1s
+#define HP_R_ALIAS  apsshpmhu1r
+#define HP_S_ALIAS  apsshpmhu1s
+#else
+#define MHU_NAME    "MHU0"
+#define HE_R_ALIAS  apssmhu0r
+#define HE_S_ALIAS  apssmhu0s
+#define HP_R_ALIAS  apsshpmhu0r
+#define HP_S_ALIAS  apsshpmhu0s
+#endif
+
+const struct device *mhu_he_rx_dev;  /* receive from M55-HE */
+const struct device *mhu_he_tx_dev;  /* send to M55-HE      */
+const struct device *mhu_hp_rx_dev;  /* receive from M55-HP */
+const struct device *mhu_hp_tx_dev;  /* send to M55-HP      */
+
+static volatile bool doorbell_tx_done;
+static volatile uint32_t rx_doorbell_addr;
+static const struct device *volatile active_tx_dev;
+static const char *volatile active_peer;
+
+/* Signalled from the MHU RX interrupt so the main loop can block until a
+ * doorbell actually arrives instead of polling.
+ */
+static K_SEM_DEFINE(doorbell_rx_sem, 0, 1);
+
+static void mhu_rx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+
+	/* Keep the ISR minimal: no printk here (blocking/latency in interrupt
+	 * context). Record which peer rang so the reply goes back on the same
+	 * channel; the main loop logs in thread context.
+	 */
+	rx_doorbell_addr = *((uint32_t *)data);
+	if (dev == mhu_he_rx_dev) {
+		active_tx_dev = mhu_he_tx_dev;
+		active_peer = "M55-HE";
+	} else {
+		active_tx_dev = mhu_hp_tx_dev;
+		active_peer = "M55-HP";
+	}
+	k_sem_give(&doorbell_rx_sem);
+}
+
+static void mhu_tx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+	ARG_UNUSED(data);
+
+	/* Keep the ISR minimal: no printk here. */
+	doorbell_tx_done = true;
+}
+
+static uint32_t calc_checksum(const uint8_t *buf, uint32_t len)
+{
+	uint32_t sum = 0;
+
+	for (uint32_t i = 0; i < len; i++) {
+		sum += buf[i];
+	}
+	return sum;
+}
+
+int main(void)
+{
+	int iter;
+	uint8_t *heap_virt;
+
+	printk("\n==========================================\n");
+	printk("A32 <-> M55-HE/HP : %s Doorbell + Shared SRAM1 heap (responder)\n",
+	       MHU_NAME);
+	printk("  Shared heap ctrl: 0x%08x (span 0x%x)\n",
+	       SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+	printk("==========================================\n");
+
+	/* Map the shared SRAM1 heap page non-cacheable so A32 sees the data the
+	 * M55 initiator flushes (and vice versa) without any cache maintenance.
+	 * The doorbell carries a physical block address; translate it into this
+	 * mapping via (heap_virt + (phys - SHARED_HEAP_CTRL)).
+	 */
+	k_mem_map_phys_bare(&heap_virt, SHARED_HEAP_CTRL, SHARED_HEAP_SPAN,
+			    K_MEM_CACHE_NONE | K_MEM_PERM_RW);
+
+	mhu_he_rx_dev = DEVICE_DT_GET(DT_ALIAS(HE_R_ALIAS));
+	mhu_he_tx_dev = DEVICE_DT_GET(DT_ALIAS(HE_S_ALIAS));
+	mhu_hp_rx_dev = DEVICE_DT_GET(DT_ALIAS(HP_R_ALIAS));
+	mhu_hp_tx_dev = DEVICE_DT_GET(DT_ALIAS(HP_S_ALIAS));
+
+	if (!device_is_ready(mhu_he_rx_dev) || !device_is_ready(mhu_he_tx_dev) ||
+	    !device_is_ready(mhu_hp_rx_dev) || !device_is_ready(mhu_hp_tx_dev)) {
+		printk("ERROR: %s devices not ready!\n", MHU_NAME);
+		return -1;
+	}
+	printk("%s devices ready\n", MHU_NAME);
+
+	ipm_register_callback(mhu_he_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu_he_tx_dev, mhu_tx_callback, NULL);
+	ipm_register_callback(mhu_hp_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu_hp_tx_dev, mhu_tx_callback, NULL);
+	ipm_set_enabled(mhu_he_rx_dev, true);
+	ipm_set_enabled(mhu_hp_rx_dev, true);
+
+	printk("Waiting for M55-HE/HP doorbells...\n\n");
+
+	int completed = 0;
+	int errors = 0;
+
+	for (iter = 0; iter < ITERATIONS; iter++) {
+		/* --- Wait for a doorbell from either M55 core --- */
+		if (iter == 0) {
+			/* First iteration: wait indefinitely for the M55 to boot */
+			k_sem_take(&doorbell_rx_sem, K_FOREVER);
+		} else if (k_sem_take(&doorbell_rx_sem,
+				      K_MSEC(RX_TIMEOUT_MS)) != 0) {
+			printk("ERROR: Timeout waiting for doorbell "
+			       "(%d ms)\n", RX_TIMEOUT_MS);
+			break;
+		}
+
+		unsigned int key = irq_lock();
+		uint32_t rx_addr = rx_doorbell_addr;
+		const struct device *tx_dev = active_tx_dev;
+		const char *peer = active_peer;
+
+		irq_unlock(key);
+
+		printk("A32: Doorbell RX from %s addr=0x%08x\n", peer, rx_addr);
+
+		/* --- Range-check the untrusted doorbell address --- */
+		if (rx_addr < SHARED_HEAP_CTRL ||
+		    rx_addr + sizeof(struct shared_msg) >
+			    SHARED_HEAP_CTRL + SHARED_HEAP_SPAN) {
+			printk("[%d] ERROR: doorbell addr 0x%08x outside heap "
+			       "[0x%08x, 0x%08x)\n", iter, rx_addr,
+			       SHARED_HEAP_CTRL,
+			       SHARED_HEAP_CTRL + SHARED_HEAP_SPAN);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		/* Translate the physical block address into the non-cacheable
+		 * mapping (no cache maintenance needed on the A32 side).
+		 */
+		volatile struct shared_msg *msg = (volatile struct shared_msg *)
+				(heap_virt + (rx_addr - SHARED_HEAP_CTRL));
+
+		if (msg->magic != MAGIC_HE) {
+			printk("[%d] ERROR: Bad magic 0x%08x (expected 0x%08x)\n",
+			       iter, msg->magic, MAGIC_HE);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		uint32_t rx_len = msg->data_len;
+
+		if (rx_len > MAX_PAYLOAD) {
+			printk("[%d] ERROR: data_len %u exceeds MAX_PAYLOAD\n",
+			       iter, rx_len);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		uint32_t computed = calc_checksum((const uint8_t *)msg->data,
+						  rx_len);
+		printk("[%d] %s->A32: block @ 0x%08x msg_id=%u len=%u "
+		       "cksum=0x%x/0x%x %s\n", iter, peer, rx_addr, msg->msg_id,
+		       rx_len, computed, msg->checksum,
+		       (computed == msg->checksum) ? "PASS" : "FAIL");
+
+		if (computed != msg->checksum) {
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		/* --- Write the response into the same block (echo payload) --- */
+		msg->magic = MAGIC_A32;
+		/* msg_id, data[] and data_len are the M55 payload echoed back. */
+		msg->checksum = calc_checksum((const uint8_t *)msg->data, rx_len);
+
+		/* --- Ring doorbell back to the initiator with the block address --- */
+		doorbell_tx_done = false;
+		uint32_t doorbell_val = rx_addr;
+
+		int send_ret = ipm_send(tx_dev, 0, 0, &doorbell_val, 4);
+
+		if (send_ret != 0) {
+			printk("ERROR: ipm_send failed: %d\n", send_ret);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		int tx_waited = 0;
+
+		while (!doorbell_tx_done && tx_waited < TX_TIMEOUT_MS) {
+			k_sleep(K_MSEC(1));
+			tx_waited++;
+		}
+		if (!doorbell_tx_done) {
+			printk("ERROR: Timeout waiting for TX completion "
+			       "(%d ms)\n", TX_TIMEOUT_MS);
+			break;
+		}
+
+		printk("[%d] A32->%s: block @ 0x%08x msg_id=%u len=%u "
+		       "cksum=0x%x Complete\n\n", iter, peer, rx_addr, msg->msg_id,
+		       rx_len, msg->checksum);
+		completed++;
+	}
+
+	ipm_set_enabled(mhu_he_rx_dev, false);
+	ipm_set_enabled(mhu_hp_rx_dev, false);
+	printk("Done: %d/%d passed, %d failed\n",
+	       completed, ITERATIONS, errors);
+	return (completed + errors == ITERATIONS) ? 0 : -1;
+}

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55_to_a32_initiator.c
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55_to_a32_initiator.c
@@ -1,0 +1,335 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * MHU Doorbell + Shared SRAM1 heap test: M55 (initiator) <-> A32 (responder)
+ *
+ * Runs on either M55 core (RTSS-HE or RTSS-HP); the board overlay selects the
+ * MHU instance the apssmhu* aliases resolve to.
+ *
+ * Protocol:
+ *   - A struct sys_heap and the memory it manages both live in shared
+ *     SRAM1. M55 operates on the heap; A32 only reads/writes the data block
+ *     whose physical address M55 passes over the MHU doorbell (A32 cannot
+ *     operate on the Zephyr heap, so M55 owns both the alloc and the free).
+ *   - M55 (initiator) dynamically allocates a message block from the shared
+ *     heap, fills it with a payload, and rings the MHU doorbell passing the
+ *     physical address of the allocated block.
+ *   - A32 (responder) maps the shared SRAM non-cacheable, reads/validates the
+ *     block, writes its response into the same block, and rings the doorbell
+ *     back with the block address as an acknowledgment.
+ *   - M55 invalidates its D-cache, validates A32's response, and frees the
+ *     block back to the shared heap.
+ *
+ * IMPORTANT: D-cache coherency
+ *   A32 accesses SRAM via a non-cacheable mapping, but the M55 has
+ *   D-cache enabled. After writing the shared block the M55 cleans (flushes)
+ *   its D-cache; before reading A32's response it invalidates its D-cache.
+ *
+ * Shared memory layout (struct shared_msg):
+ *   [0x00] magic      - 0xCAFE0E00 when written by M55, 0xA32F055E by A32
+ *   [0x04] msg_id     - incrementing message counter
+ *   [0x08] data_len   - number of payload bytes (max 240)
+ *   [0x0C] data[240]  - payload
+ *   [0xFC] checksum   - sum of payload bytes
+ *
+ * Test flow (per iteration):
+ *   1. M55 allocates a block from the shared heap, writes test data, flushes
+ *   2. M55 rings doorbell to A32 with the allocated block address
+ *   3. M55 waits for A32's acknowledgment doorbell
+ *   4. M55 invalidates D-cache, validates A32's response, frees the block
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/cache.h>
+#include <string.h>
+
+#include "mhu_doorbell_msg.h"
+#include "mhu_doorbell_heap.h"
+
+#define CACHE_INVALIDATE(addr, size) sys_cache_data_invd_range((void *)(addr), (size))
+#define CACHE_CLEAN(addr, size)      sys_cache_data_flush_range((void *)(addr), (size))
+
+#define ITERATIONS       25
+#define MAX_ERRORS       10
+#define RX_TIMEOUT_MS    5000
+#define TX_TIMEOUT_MS    1000
+
+/* Shared SRAM1 cross-core heap for M55 <-> A32 communication.
+ * The struct sys_heap control block and the managed memory both live in
+ * shared SRAM1 so M55 can allocate a block whose physical address is passed
+ * to A32 over the doorbell. A32 only reads/writes the data block (it cannot
+ * operate on the Zephyr heap), so M55 owns both the alloc and the free.
+ *
+ * The heap base is page-aligned and the whole span (0x800) fits in one 4 KB
+ * page so the A32 side can reach every block through a single mapping.
+ * Must match the A32 responder (a32_to_m55_responder.c).
+ *
+ *   MHU0 heap: ctrl @ 0x027DD000, mem @ 0x027DD100 (size 0x700)
+ *   MHU1 heap: ctrl @ 0x027DE000, mem @ 0x027DE100 (size 0x700)
+ *
+ * Addresses come from mhu_doorbell_heap.h.
+ */
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEA32_MHU1_CTRL
+#define SHARED_HEAP_MEM   SHARED_HEAP_HEA32_MHU1_MEM
+#else
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEA32_MHU0_CTRL
+#define SHARED_HEAP_MEM   SHARED_HEAP_HEA32_MHU0_MEM
+#endif
+
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define MHU_NAME "MHU1"
+#define MHU_R_ALIAS apssmhu1r
+#define MHU_S_ALIAS apssmhu1s
+#else
+#define MHU_NAME "MHU0"
+#define MHU_R_ALIAS apssmhu0r
+#define MHU_S_ALIAS apssmhu0s
+#endif
+
+const struct device *mhu_rx_dev;
+const struct device *mhu_tx_dev;
+
+static volatile bool doorbell_tx_done;
+static volatile bool doorbell_rx_received;
+static volatile uint32_t rx_doorbell_addr;
+
+static void mhu_rx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+
+	/* Keep the ISR minimal: no printk here (blocking/latency in interrupt
+	 * context). The main loop logs the doorbell in thread context.
+	 */
+	rx_doorbell_addr = *((uint32_t *)data);
+	doorbell_rx_received = true;
+}
+
+static void mhu_tx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+	ARG_UNUSED(data);
+
+	/* Keep the ISR minimal: no printk here. */
+	doorbell_tx_done = true;
+}
+
+static uint32_t calc_checksum(const uint8_t *buf, uint32_t len)
+{
+	uint32_t sum = 0;
+
+	for (uint32_t i = 0; i < len; i++) {
+		sum += buf[i];
+	}
+	return sum;
+}
+
+int main(void)
+{
+	int iter;
+	struct sys_heap *heap = (struct sys_heap *)SHARED_HEAP_CTRL;
+
+	printk("\n==========================================\n");
+	printk("M55 -> A32 : %s Doorbell + Shared SRAM1 heap (initiator)\n", MHU_NAME);
+	printk("  Shared heap ctrl: 0x%08x\n", SHARED_HEAP_CTRL);
+	printk("  Shared heap mem : 0x%08x (size 0x%x)\n",
+	       SHARED_HEAP_MEM, SHARED_HEAP_SIZE);
+	printk("==========================================\n");
+
+	mhu_rx_dev = DEVICE_DT_GET(DT_ALIAS(MHU_R_ALIAS));
+	mhu_tx_dev = DEVICE_DT_GET(DT_ALIAS(MHU_S_ALIAS));
+
+	if (!device_is_ready(mhu_rx_dev) || !device_is_ready(mhu_tx_dev)) {
+		printk("ERROR: %s devices not ready!\n", MHU_NAME);
+		return -1;
+	}
+	printk("%s devices ready\n", MHU_NAME);
+
+	ipm_register_callback(mhu_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu_tx_dev, mhu_tx_callback, NULL);
+	ipm_set_enabled(mhu_rx_dev, true);
+
+	/* Initialise the cross-core heap in shared SRAM. Both the control
+	 * block and the managed memory live in shared SRAM so the allocated
+	 * block address can be shared with A32. Flush so the initialised heap
+	 * is visible to the (non-cacheable) A32 mapping.
+	 */
+	sys_heap_init(heap, (void *)SHARED_HEAP_MEM, SHARED_HEAP_SIZE);
+	CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+	int completed = 0;
+	int errors = 0;
+
+	for (iter = 0; iter < ITERATIONS; iter++) {
+		/* --- Pick up the heap state freed in the previous iteration --- */
+		CACHE_INVALIDATE(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+		/* --- Dynamically allocate a message block from the heap --- */
+		volatile struct shared_msg *tx_msg =
+				sys_heap_alloc(heap, sizeof(struct shared_msg));
+
+		if (tx_msg == NULL) {
+			printk("ERROR: sys_heap_alloc failed (iter=%d)\n", iter);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		uint32_t block_addr = (uint32_t)tx_msg;
+
+		/* --- Write test data into the allocated block --- */
+		tx_msg->magic    = MAGIC_HE;
+		tx_msg->msg_id   = iter;
+		tx_msg->data_len = 16;
+
+		/* Fill payload with test pattern */
+		for (uint32_t j = 0; j < tx_msg->data_len; j++) {
+			tx_msg->data[j] = (uint8_t)(iter + j);
+		}
+		/* Zero-pad unused data[] bytes */
+		memset((void *)&tx_msg->data[tx_msg->data_len], 0,
+		       MAX_PAYLOAD - tx_msg->data_len);
+		tx_msg->checksum = calc_checksum((const uint8_t *)tx_msg->data,
+						 tx_msg->data_len);
+
+		/* --- Flush D-cache so A32 sees the allocation and payload --- */
+		CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+		printk("[%d] M55->A32: alloc block @ 0x%08x msg_id=%u len=%u "
+		       "cksum=0x%x\n", iter, block_addr, tx_msg->msg_id,
+		       tx_msg->data_len, tx_msg->checksum);
+
+		/* --- Ring doorbell to A32 with the allocated block address --- */
+		doorbell_tx_done = false;
+		doorbell_rx_received = false;
+		uint32_t doorbell_val = block_addr;
+
+		int send_ret = ipm_send(mhu_tx_dev, 0, 0, &doorbell_val, 4);
+
+		if (send_ret != 0) {
+			printk("ERROR: ipm_send failed: %d\n", send_ret);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		int waited = 0;
+
+		while (!doorbell_tx_done && waited < TX_TIMEOUT_MS) {
+			k_sleep(K_MSEC(1));
+			waited++;
+		}
+		if (!doorbell_tx_done) {
+			printk("ERROR: TX timeout (%d ms)\n", TX_TIMEOUT_MS);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+		printk("M55: Doorbell TX done\n");
+
+		/* --- Wait for A32's acknowledgment doorbell --- */
+		waited = 0;
+		while (!doorbell_rx_received && waited < RX_TIMEOUT_MS) {
+			k_sleep(K_MSEC(1));
+			waited++;
+		}
+		if (!doorbell_rx_received) {
+			printk("ERROR: Timeout waiting for A32 response "
+			       "(%d ms)\n", RX_TIMEOUT_MS);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+		printk("M55: Doorbell RX addr=0x%08x\n", rx_doorbell_addr);
+
+		/* A32 writes its response into the same block and rings back
+		 * with the block address as an acknowledgment.
+		 */
+		if (rx_doorbell_addr != block_addr) {
+			printk("[%d] A32->M55: FAIL ack addr 0x%08x != "
+			       "block 0x%08x\n", iter, rx_doorbell_addr,
+			       block_addr);
+			sys_heap_free(heap, (void *)block_addr);
+			CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+			errors++;
+			if (errors >= MAX_ERRORS)
+				break;
+			continue;
+		}
+
+		/* --- Invalidate D-cache before reading A32's response --- */
+		CACHE_INVALIDATE(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+		volatile struct shared_msg *incoming =
+				(volatile struct shared_msg *)block_addr;
+		bool ok = true;
+
+		if (incoming->magic != MAGIC_A32) {
+			printk("ERROR: Bad magic 0x%08x (expected 0x%08x)\n",
+			       incoming->magic, MAGIC_A32);
+			ok = false;
+		} else if (incoming->msg_id != (uint32_t)iter) {
+			printk("ERROR: msg_id mismatch: got %u, expected %d\n",
+			       incoming->msg_id, iter);
+			ok = false;
+		} else if (incoming->data_len > MAX_PAYLOAD) {
+			printk("ERROR: data_len %u exceeds MAX_PAYLOAD\n",
+			       incoming->data_len);
+			ok = false;
+		} else {
+			uint32_t rx_len = incoming->data_len;
+			uint32_t computed_cksum = calc_checksum(
+					(const uint8_t *)incoming->data, rx_len);
+
+			printk("[%d] A32->M55: block @ 0x%08x msg_id=%u len=%u "
+			       "cksum=0x%x/0x%x %s\n\n", iter, block_addr,
+			       incoming->msg_id, rx_len, computed_cksum,
+			       incoming->checksum,
+			       (computed_cksum == incoming->checksum) ?
+			       "PASS" : "FAIL");
+			ok = (computed_cksum == incoming->checksum);
+		}
+
+		/* --- Free the block back to the shared heap --- */
+		sys_heap_free(heap, (void *)block_addr);
+		CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+		if (ok) {
+			completed++;
+		} else {
+			errors++;
+		}
+
+		if (errors >= MAX_ERRORS) {
+			printk("ERROR: Too many errors (%d), aborting\n",
+			       errors);
+			break;
+		}
+
+		/* Small delay between iterations */
+		k_sleep(K_MSEC(500));
+	}
+
+	ipm_set_enabled(mhu_rx_dev, false);
+	printk("Done: %d/%d passed, %d failed\n",
+	       completed, ITERATIONS, errors);
+	return (completed + errors == ITERATIONS) ? 0 : -1;
+}

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55he_to_m55hp_initiator.c
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55he_to_m55hp_initiator.c
@@ -1,0 +1,483 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * MHU Doorbell + Shared SRAM1 heap test: M55-HE (initiator) <-> M55-HP (responder)
+ *
+ * Protocol:
+ *   - A struct sys_heap and the memory it manages both live in shared
+ *     SRAM1, so both cores operate on the same heap instance.
+ *   - HE (initiator) dynamically allocates a message block from the
+ *     shared heap, fills it with a payload, and rings the MHU doorbell
+ *     passing the physical address of the allocated block.
+ *   - HP (responder) reads/validates the block, frees it back to the
+ *     shared heap, and rings back the freed address as an acknowledgment.
+ *
+ * IMPORTANT: D-cache coherency
+ *   Both M55-HE and M55-HP have D-cache enabled. Before reading shared
+ *   SRAM written by the other side, the reader must invalidate its D-cache.
+ *   After writing shared SRAM, the writer must clean (flush) its D-cache.
+ *   The strict doorbell ping-pong guarantees only one core touches the
+ *   shared heap at a time, so full-region maintenance is sufficient.
+ *
+ * Shared memory layout (struct shared_msg):
+ *   [0x00] magic      - 0xCAFE0E00 when written by HE, 0xCAFE0F00 by HP
+ *   [0x04] msg_id     - incrementing message counter
+ *   [0x08] data_len   - number of payload bytes (max 240)
+ *   [0x0C] data[240]  - payload
+ *   [0xFC] checksum   - sum of payload bytes
+ *
+ * Test flow (one exchange per boot):
+ *   1. HE allocates a block from the shared heap, writes test data,
+ *      flushes D-cache
+ *   2. HE rings doorbell to HP with the allocated block address
+ *   3. HE waits for HP's acknowledgment doorbell (the freed address)
+ *   4. HE verifies the acknowledged address matches the block it sent
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/cache.h>
+#include <string.h>
+#include <errno.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/counter.h>
+
+#include "mhu_doorbell_msg.h"
+#include "mhu_doorbell_heap.h"
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+#define IDLE_TIMER_NODE DT_CHOSEN(zephyr_cortex_m_idle_timer)
+#endif
+/* LPTIMER0 (timer0) is the SOFT_OFF wake source (off_profile_soft_off ->
+ * ALIF_WE_LPTIMER0). It must be enabled in the build overlay (lpuart.overlay).
+ */
+#define SOFT_OFF_WAKE_TIMER_NODE DT_NODELABEL(timer0)
+#define SOFT_OFF_PERIOD_USEC     (2 * 1000 * 1000)   /* 2 s LPTIMER0 wake */
+
+#define CACHE_INVALIDATE(addr, size) sys_cache_data_invd_range((void *)(addr), (size))
+#define CACHE_CLEAN(addr, size)      sys_cache_data_flush_range((void *)(addr), (size))
+
+#define RX_TIMEOUT_MS    5000
+#define TX_TIMEOUT_MS    1000
+
+/* Without CONFIG_PM (no pm-system-off-he snippet) the core never resets, so run
+ * a fixed number of exchanges back-to-back and then stop with a summary.
+ */
+#define NUM_EXCHANGES    10
+
+/* Shared SRAM1 cross-core heap for HE <-> HP inter-core communication (one
+ * heap per MHU channel). The struct sys_heap control block and the memory it
+ * manages both live in shared SRAM so the initiator (HE) and responder (HP)
+ * operate on the same heap instance. Addresses come from mhu_doorbell_heap.h.
+ */
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEHP_MHU1_CTRL
+#define SHARED_HEAP_MEM   SHARED_HEAP_HEHP_MHU1_MEM
+#else
+#define SHARED_HEAP_CTRL  SHARED_HEAP_HEHP_MHU0_CTRL
+#define SHARED_HEAP_MEM   SHARED_HEAP_HEHP_MHU0_MEM
+#endif
+
+#if IS_ENABLED(CONFIG_USE_MHU1)
+#define MHU_NAME "MHU1"
+#define MHU_R_ALIAS rtssmhu1r
+#define MHU_S_ALIAS rtssmhu1s
+#else
+#define MHU_NAME "MHU0"
+#define MHU_R_ALIAS rtssmhu0r
+#define MHU_S_ALIAS rtssmhu0s
+#endif
+
+const struct device *mhu_rx_dev;
+const struct device *mhu_tx_dev;
+
+static volatile bool doorbell_tx_done;
+static volatile bool doorbell_rx_received;
+static volatile uint32_t rx_doorbell_addr;
+
+static void mhu_rx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+
+	/* Keep the ISR minimal: no printk here (blocking/latency in interrupt
+	 * context). The main loop logs the doorbell once it observes the flag.
+	 */
+	rx_doorbell_addr = *((uint32_t *)data);
+	doorbell_rx_received = true;
+}
+
+static void mhu_tx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+	ARG_UNUSED(data);
+
+	/* Keep the ISR minimal: no printk here. */
+	doorbell_tx_done = true;
+}
+
+static uint32_t calc_checksum(const uint8_t *buf, uint32_t len)
+{
+	uint32_t sum = 0;
+
+	for (uint32_t i = 0; i < len; i++) {
+		sum += buf[i];
+	}
+	return sum;
+}
+
+#if defined(CONFIG_PM)
+/*
+ * Low-power model: HE deep-sleeps to SOFT_OFF between exchanges, and HP runs
+ * its own reset-based SOFT_OFF responder (m55hp_to_m55he_responder.c).
+ *
+ * Built with the pm-system-off-he snippet, which applies the SE run/off power
+ * profiles in devicetree. Per cycle:
+ *   1. HE wakes -- on this MRAM-boot image SOFT_OFF resets the core, so the
+ *      LPTIMER0 wake re-runs main() from the reset vector.
+ *   2. HE rings the MHU doorbell to HP (which is itself in SOFT_OFF and wakes
+ *      via its EWIC -- see m55hp_to_m55he_responder.c).
+ *   3. HE waits for HP's ack in SUSPEND_TO_IDLE: that state uses the IWIC and
+ *      wakes on the MHU doorbell IRQ, and the rtc0 LPM idle-timer
+ *      (zephyr,cortex-m-idle-timer) backs the k_sleep() poll timeouts.
+ *   4. HE re-enters SOFT_OFF and arms LPTIMER0 for a 2 s wake.
+ *
+ * Why SOFT_OFF resets instead of resuming: SOFT_OFF wakes only on the EWIC AON
+ * events (here LPTIMER0, via off_profile_soft_off) and NEVER on the MHU. On an
+ * MRAM boot (VTOR >= 0x80000000) the off profile re-enters through the reset
+ * vector, so the LPTIMER0 wake reboots HE.
+ *
+ * No state survives a cycle: a real dual-core SOFT_OFF does not retain SRAM1
+ * content (ALIF_SRAM1_MASK keeps SRAM1 powered while RUNNING, but retention in
+ * the OFF state would need ALIF_SRAM1_RET_MASK, which keeps a rail up and
+ * defeats the deep power-off this sample demonstrates). So each boot re-creates
+ * the cross-core heap and performs exactly one HE->HP exchange.
+ *
+ * NOTE: the systick driver only *arms* alarms on the idle-timer, it never
+ * starts the counter, so pm_start_idle_timer() must run before the first
+ * k_sleep() or the SUSPEND_TO_IDLE wake alarm never fires.
+ */
+static void pm_state_lock(enum pm_state state, bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(state, PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(state, PM_ALL_SUBSTATES);
+	}
+}
+
+/* Keep only SUSPEND_TO_IDLE available (MHU-wakeable) for the doorbell protocol;
+ * lock SUSPEND_TO_RAM and SOFT_OFF.
+ */
+static void pm_lock_for_protocol(void)
+{
+	pm_state_lock(PM_STATE_SUSPEND_TO_RAM, true);
+	pm_state_lock(PM_STATE_SOFT_OFF, true);
+}
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+/* Start the rtc0 LPM idle-timer. The cortex_m systick driver programs wake
+ * alarms on this counter while idle but never starts it, so it must be running
+ * before the first k_sleep() or the suspend-to-idle wake alarm never fires.
+ */
+static void pm_start_idle_timer(void)
+{
+	const struct device *const idle_timer = DEVICE_DT_GET(IDLE_TIMER_NODE);
+	int ret;
+
+	if (!device_is_ready(idle_timer)) {
+		printk("PM: idle timer not ready\n");
+		return;
+	}
+
+	ret = counter_start(idle_timer);
+	if (ret && ret != -EALREADY) {
+		printk("PM: counter_start failed (%d)\n", ret);
+	}
+}
+#endif /* CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(timer0), okay)
+/* Mandatory (no-op) alarm callback for LPTIMER0 -- the dw-timer counter driver
+ * rejects a NULL callback. SOFT_OFF resets the core before it would run.
+ */
+static void softoff_alarm_cb(const struct device *dev, uint8_t chan,
+			     uint32_t ticks, void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan);
+	ARG_UNUSED(ticks);
+	ARG_UNUSED(user_data);
+}
+
+/* LPTIMER0 TimerEOI register (DW APB timer): reading it clears the latched
+ * interrupt flag. Offset 0xC from the timer base.
+ */
+#define LPTIMER0_EOI_ADDR (DT_REG_ADDR(SOFT_OFF_WAKE_TIMER_NODE) + 0xCu)
+#define LPTIMER0_IRQ_NUM  DT_IRQN(SOFT_OFF_WAKE_TIMER_NODE)
+
+/* Clear any stale LPTIMER0 interrupt left over from the previous SOFT_OFF wake.
+ * LPTIMER0 is in the always-on VBAT domain, so it is NOT reset across the
+ * subsystem reset, and it fired with the core powered off -- the dw-timer ISR
+ * never ran, so its EOI was never read and the latched IRQ persists (the timer
+ * is also periodic and keeps reloading). Without clearing it, the next
+ * counter_set_channel_alarm() unmasks an already-pending IRQ that fires
+ * immediately, consuming that cycle's alarm -- so every other SOFT_OFF wakes
+ * instantly instead of staying off ~2 s. Read EOI to clear the peripheral
+ * latch, then drop any NVIC pending bit.
+ */
+static void lptimer0_clear_stale_irq(void)
+{
+	(void)sys_read32(LPTIMER0_EOI_ADDR);
+	NVIC_ClearPendingIRQ(LPTIMER0_IRQ_NUM);
+}
+#endif /* timer0 okay */
+
+/* Enter PM_STATE_SOFT_OFF until the LPTIMER0 wake. Make SOFT_OFF the only
+ * available deep state, arm LPTIMER0 (the off_profile_soft_off wake source --
+ * the rtc0 idle-timer is powered down in that profile), then sleep longer than
+ * the subsys_off min-residency so the idle policy commits to SOFT_OFF. On MRAM
+ * boot the LPTIMER0 wake resets the core.
+ */
+static void pm_enter_soft_off(void)
+{
+	pm_state_lock(PM_STATE_SUSPEND_TO_IDLE, true);
+	pm_state_lock(PM_STATE_SUSPEND_TO_RAM, true);
+	pm_state_lock(PM_STATE_SOFT_OFF, false);
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(timer0), okay)
+	const struct device *const lptimer =
+		DEVICE_DT_GET(SOFT_OFF_WAKE_TIMER_NODE);
+	struct counter_alarm_cfg alarm_cfg = {
+		.flags = 0,
+		.ticks = counter_us_to_ticks(lptimer, SOFT_OFF_PERIOD_USEC),
+		.callback = softoff_alarm_cb,
+		.user_data = NULL,
+	};
+
+	if (device_is_ready(lptimer)) {
+		int ret;
+
+		(void)counter_start(lptimer);
+		/* Drop the previous cycle's stale latched IRQ before arming, or
+		 * every other SOFT_OFF would wake instantly (see helper).
+		 */
+		lptimer0_clear_stale_irq();
+		ret = counter_set_channel_alarm(lptimer, 0, &alarm_cfg);
+		if (ret) {
+			printk("PM: failed to arm LPTIMER0 for SOFT_OFF (%d)\n",
+			       ret);
+		}
+	} else {
+		printk("PM: LPTIMER0 (timer0) not ready -- SOFT_OFF has no wake\n");
+	}
+#else
+	printk("PM: timer0 disabled -- SOFT_OFF has no LPTIMER0 wake "
+	       "(enable &timer0 in the build overlay)\n");
+#endif
+
+	printk("M55-HE: entering SOFT_OFF; LPTIMER0 wake in %u ms (core resets)\n",
+	       SOFT_OFF_PERIOD_USEC / 1000U);
+
+	/* Sleep longer than subsys_off min-residency so the policy enters
+	 * SOFT_OFF; LPTIMER0 fires first and resets the core.
+	 */
+	k_sleep(K_USEC(SOFT_OFF_PERIOD_USEC));
+}
+#endif /* CONFIG_PM */
+
+/* Perform one HE->HP allocate/send/ack exchange. Returns true on a fully
+ * successful round-trip, false on any error (each failure is logged). The
+ * doorbell waits run in PM_STATE_SUSPEND_TO_IDLE so the MHU IRQ can wake the
+ * core.
+ */
+static bool do_one_exchange(struct sys_heap *heap)
+{
+	/* Read the freshly initialised heap state from memory. */
+	CACHE_INVALIDATE(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+	volatile struct shared_msg *tx_msg =
+			sys_heap_alloc(heap, sizeof(struct shared_msg));
+
+	if (tx_msg == NULL) {
+		printk("ERROR: sys_heap_alloc failed\n");
+		return false;
+	}
+
+	uint32_t block_addr = (uint32_t)tx_msg;
+
+	/* Write test data into the allocated block. */
+	tx_msg->magic    = MAGIC_HE;
+	tx_msg->msg_id   = 0;
+	tx_msg->data_len = 16;
+	for (uint32_t j = 0; j < tx_msg->data_len; j++) {
+		tx_msg->data[j] = (uint8_t)j;
+	}
+	memset((void *)&tx_msg->data[tx_msg->data_len], 0,
+	       MAX_PAYLOAD - tx_msg->data_len);
+	tx_msg->checksum = calc_checksum((const uint8_t *)tx_msg->data,
+					 tx_msg->data_len);
+
+	/* Flush so HP sees the allocation metadata and payload. */
+	CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+	printk("HE->HP: alloc block @ 0x%08x msg_id=%u len=%u cksum=0x%x\n",
+	       block_addr, tx_msg->msg_id, tx_msg->data_len,
+	       tx_msg->checksum);
+
+	/* Ring doorbell to HP with the allocated block address. */
+	doorbell_tx_done = false;
+	doorbell_rx_received = false;
+	uint32_t doorbell_val = block_addr;
+
+	int send_ret = ipm_send(mhu_tx_dev, 0, 0, &doorbell_val, 4);
+
+	if (send_ret != 0) {
+		printk("ERROR: ipm_send failed: %d\n", send_ret);
+		/* HP never received the doorbell, so free the block here to
+		 * avoid leaking it and exhausting the shared heap over repeated
+		 * exchanges (CONFIG_PM-disabled path).
+		 */
+		sys_heap_free(heap, (void *)block_addr);
+		CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+		return false;
+	}
+
+	int waited = 0;
+
+	while (!doorbell_tx_done && waited < TX_TIMEOUT_MS) {
+		k_sleep(K_MSEC(1));
+		waited++;
+	}
+	if (!doorbell_tx_done) {
+		printk("ERROR: TX timeout (%d ms)\n", TX_TIMEOUT_MS);
+		return false;
+	}
+	printk("M55-HE: Doorbell TX (%s) done\n", MHU_NAME);
+
+	/* Wait for HP's acknowledgment doorbell. */
+	waited = 0;
+	while (!doorbell_rx_received && waited < RX_TIMEOUT_MS) {
+		k_sleep(K_MSEC(1));
+		waited++;
+	}
+	if (!doorbell_rx_received) {
+		printk("ERROR: Timeout waiting for HP ack (%d ms)\n",
+		       RX_TIMEOUT_MS);
+		return false;
+	}
+	printk("M55-HE: Doorbell RX (%s) addr=0x%08x\n", MHU_NAME,
+	       rx_doorbell_addr);
+
+	/* HP acknowledges the free by returning the block address. */
+	if (rx_doorbell_addr != block_addr) {
+		printk("HP->HE: FAIL ack addr 0x%08x != block 0x%08x\n",
+		       rx_doorbell_addr, block_addr);
+		return false;
+	}
+
+	printk("HP->HE: ack free of block @ 0x%08x PASS\n\n", block_addr);
+	return true;
+}
+
+int main(void)
+{
+	struct sys_heap *heap = (struct sys_heap *)SHARED_HEAP_CTRL;
+
+	mhu_rx_dev = DEVICE_DT_GET(DT_ALIAS(MHU_R_ALIAS));
+	mhu_tx_dev = DEVICE_DT_GET(DT_ALIAS(MHU_S_ALIAS));
+
+	if (!device_is_ready(mhu_rx_dev) || !device_is_ready(mhu_tx_dev)) {
+		printk("ERROR: %s devices not ready!\n", MHU_NAME);
+		return -1;
+	}
+
+	ipm_register_callback(mhu_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu_tx_dev, mhu_tx_callback, NULL);
+	ipm_set_enabled(mhu_rx_dev, true);
+
+#if defined(CONFIG_PM)
+	/* Lock the deep states (S2RAM/SOFT_OFF) and start the rtc0 idle-timer
+	 * BEFORE any k_sleep(). Otherwise the "wait for HP" sleep in
+	 * do_one_exchange() would run with SOFT_OFF still unlocked (min-residency
+	 * 0.5 s < 2 s) and no LPTIMER0 armed, so HE would power off with no wake
+	 * source and hang. With only SUSPEND_TO_IDLE available and the idle timer
+	 * running, that sleep is woken by rtc0 as intended.
+	 */
+	pm_lock_for_protocol();
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	pm_start_idle_timer();
+#endif
+#endif /* CONFIG_PM */
+
+	/* Each LPTIMER0 wake is a full reset and SRAM1 content is not retained
+	 * across the dual-core SOFT_OFF, so every boot starts fresh: print the
+	 * banner, (re)create the cross-core heap, and run one exchange.
+	 */
+	printk("\n==========================================\n");
+	printk("M55-HE -> M55-HP : %s Doorbell + Shared SRAM1 heap (initiator)\n", MHU_NAME);
+	printk("  Shared heap ctrl: 0x%08x\n", SHARED_HEAP_CTRL);
+	printk("  Shared heap mem : 0x%08x (size 0x%x)\n", SHARED_HEAP_MEM, SHARED_HEAP_SIZE);
+#if defined(CONFIG_PM)
+	printk("  PM: SOFT_OFF between exchanges, %u ms LPTIMER0 wake "
+	       "(each wake resets HE)\n", SOFT_OFF_PERIOD_USEC / 1000U);
+#else
+	printk("  PM: disabled -- exchanges run back-to-back "
+	       "(build with -S pm-system-off-he for SOFT_OFF)\n");
+#endif
+	printk("==========================================\n");
+
+	/* HE owns the cross-core heap; initialise it before the first alloc. The
+	 * doorbell can be sent right away: the MHU channel bit latches in hardware
+	 * until HP acknowledges it, and HP is woken by that very doorbell
+	 * (EWIC -> reset), so no readiness wait is needed.
+	 */
+	sys_heap_init(heap, (void *)SHARED_HEAP_MEM, SHARED_HEAP_SIZE);
+	CACHE_CLEAN(SHARED_HEAP_CTRL, SHARED_HEAP_SPAN);
+
+#if defined(CONFIG_PM)
+	(void)do_one_exchange(heap);
+
+	/* Back to SOFT_OFF until the LPTIMER0 wake resets HE for the next
+	 * exchange. The test runs indefinitely (one exchange per boot).
+	 */
+	pm_enter_soft_off();
+
+	/* Not reached on MRAM boot (SOFT_OFF resets the core). */
+	return 0;
+#else
+	/* No power management: SRAM1 stays powered and the core never resets, so
+	 * run NUM_EXCHANGES exchanges back-to-back on the same heap (HP frees each
+	 * block before the next alloc), then report the result and stop.
+	 */
+	unsigned int passed = 0;
+
+	for (unsigned int i = 0; i < NUM_EXCHANGES; i++) {
+		if (do_one_exchange(heap)) {
+			passed++;
+		}
+		if (i + 1 < NUM_EXCHANGES) {
+			k_sleep(K_MSEC(SOFT_OFF_PERIOD_USEC / 1000U));
+		}
+	}
+
+	printk("\n==========================================\n");
+	printk("M55-HE: done -- %u/%u exchanges PASSED\n", passed, NUM_EXCHANGES);
+	printk("==========================================\n");
+
+	return 0;
+#endif /* CONFIG_PM */
+}

--- a/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55hp_to_m55he_responder.c
+++ b/samples/drivers/ipm/ipm_arm_mhu_doorbell/src/m55hp_to_m55he_responder.c
@@ -1,0 +1,333 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ * MHU Doorbell + Shared SRAM1 heap test: M55-HP (responder) <-> M55-HE (initiator)
+ *
+ * Protocol:
+ *   - A struct sys_heap and the memory it manages both live in shared
+ *     SRAM1, so both cores operate on the same heap instance.
+ *   - HE (initiator) dynamically allocates a message block from the
+ *     shared heap and rings the MHU doorbell passing the block address.
+ *   - HP (responder) reads/validates the block, frees it back to the
+ *     shared heap, and rings back the freed address as an acknowledgment.
+ *
+ * IMPORTANT: D-cache coherency
+ *   Both M55-HE and M55-HP have D-cache enabled. Before reading shared
+ *   SRAM written by the other side, the reader must invalidate its D-cache.
+ *   After writing shared SRAM, the writer must clean (flush) its D-cache.
+ *   The strict doorbell ping-pong guarantees only one core touches the
+ *   shared heap at a time, so full-region maintenance is sufficient.
+ *
+ * Shared memory layout (struct shared_msg):
+ *   [0x00] magic      - 0xCAFE0E00 when written by HE, 0xCAFE0F00 by HP
+ *   [0x04] msg_id     - incrementing message counter
+ *   [0x08] data_len   - number of payload bytes (max 240)
+ *   [0x0C] data[240]  - payload
+ *   [0xFC] checksum   - sum of payload bytes
+ *
+ * Test flow (per iteration):
+ *   1. HP waits for doorbell from HE (MHU RX interrupt)
+ *   2. HP invalidates D-cache, reads and validates HE's block
+ *   3. HP frees the block back to the shared heap, flushes D-cache
+ *   4. HP rings doorbell to HE (MHU TX) with the freed block address
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/cache.h>
+#include <string.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+
+#include "mhu_doorbell_msg.h"
+#include "mhu_doorbell_heap.h"
+
+#define CACHE_INVALIDATE(addr, size) sys_cache_data_invd_range((void *)(addr), (size))
+#define CACHE_CLEAN(addr, size)      sys_cache_data_flush_range((void *)(addr), (size))
+
+#define TX_TIMEOUT_MS    1000
+
+/* Without CONFIG_PM (no pm-system-off-hp snippet) the core never resets, so
+ * handle a fixed number of doorbells and then stop with a summary.
+ */
+#define NUM_EXCHANGES    10
+
+/* Shared SRAM1 cross-core heaps for HE <-> HP inter-core communication.
+ * Each MHU channel has its own heap whose struct sys_heap control block
+ * and managed memory both live in shared SRAM. HE allocates blocks; HP
+ * frees them on the same heap instance. Addresses come from
+ * mhu_doorbell_heap.h.
+ */
+#define SHARED_HEAP_MHU0_CTRL  SHARED_HEAP_HEHP_MHU0_CTRL
+#define SHARED_HEAP_MHU1_CTRL  SHARED_HEAP_HEHP_MHU1_CTRL
+
+const struct device *mhu0_rx_dev;
+const struct device *mhu0_tx_dev;
+const struct device *mhu1_rx_dev;
+const struct device *mhu1_tx_dev;
+
+static volatile bool doorbell_tx_done;
+static volatile uint32_t rx_doorbell_addr;
+static const struct device *volatile active_tx_dev;
+
+/* Signalled from the MHU RX interrupt callback so the main loop can sleep
+ * (in low power, with CONFIG_PM) until a doorbell actually arrives instead
+ * of polling.
+ */
+static K_SEM_DEFINE(doorbell_rx_sem, 0, 1);
+
+static void mhu_rx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+
+	/* Keep the ISR minimal: no printk here (blocking/latency in interrupt
+	 * context). handle_doorbell() logs the doorbell in thread context.
+	 */
+	rx_doorbell_addr = *((uint32_t *)data);
+	active_tx_dev = (dev == mhu0_rx_dev) ? mhu0_tx_dev : mhu1_tx_dev;
+	k_sem_give(&doorbell_rx_sem);
+}
+
+static void mhu_tx_callback(const struct device *dev, void *user_data,
+			    uint32_t id, volatile void *data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(id);
+	ARG_UNUSED(data);
+
+	/* Keep the ISR minimal: no printk here. */
+	doorbell_tx_done = true;
+}
+
+static uint32_t calc_checksum(const uint8_t *buf, uint32_t len)
+{
+	uint32_t sum = 0;
+
+	for (uint32_t i = 0; i < len; i++) {
+		sum += buf[i];
+	}
+	return sum;
+}
+
+/*
+ * Power management is enabled only when this sample is built with the
+ * pm-system-off-hp snippet. The snippet configures the SE run/off power
+ * profiles in devicetree (applied automatically by se_service) and the deep
+ * off-state nodes.
+ *
+ * HP-goes-SOFT_OFF model: HP makes PM_STATE_SOFT_OFF the only available deep
+ * state and blocks waiting for a doorbell, so the idle thread powers the
+ * subsystem off. SOFT_OFF uses the M55 EWIC, which automatically monitors the
+ * core's enabled NVIC interrupt lines 0-63. The MHU RX IRQs (MHU0 = 41,
+ * MHU1 = 43) are within that range and are enabled by ipm_set_enabled(), so
+ * when HE rings the doorbell the EWIC wakes the subsystem. On this MRAM-boot
+ * image the wake re-enters through the reset vector, so HP REBOOTS on every
+ * doorbell; main() re-runs and the pending doorbell is delivered as soon as
+ * ipm_set_enabled() re-arms the RX IRQ.
+ *
+ * Each doorbell wake is a full reset, so no state survives between exchanges:
+ * main() simply re-arms the receivers and handles the one pending doorbell.
+ *
+ * Without CONFIG_PM (default build, no snippet) none of this applies: HP just
+ * blocks on the doorbell semaphore and handles each exchange in place.
+ */
+#if defined(CONFIG_PM)
+/* Make SOFT_OFF the only available deep state: lock the shallower states so the
+ * idle thread powers the subsystem off while HP blocks on the doorbell. The MHU
+ * RX IRQ then wakes it via the EWIC -> reset.
+ */
+static void pm_lock_for_soft_off(void)
+{
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	/* PM_STATE_SOFT_OFF left unlocked. */
+}
+#endif /* CONFIG_PM */
+
+/* Handle one incoming doorbell: validate HE's block, free it back to the shared
+ * heap, and ring the acknowledgment doorbell. Returns true on a clean PASS.
+ */
+static bool handle_doorbell(void)
+{
+	/* Capture ISR-written values under interrupt lock to prevent a second
+	 * doorbell from clobbering them before we use them.
+	 */
+	unsigned int key = irq_lock();
+	uint32_t local_rx_addr = rx_doorbell_addr;
+	const struct device *local_tx_dev = active_tx_dev;
+
+	irq_unlock(key);
+
+	/* Select the shared heap for the MHU channel that rang. */
+	struct sys_heap *heap = (struct sys_heap *)
+		((local_tx_dev == mhu0_tx_dev) ?
+		 SHARED_HEAP_MHU0_CTRL : SHARED_HEAP_MHU1_CTRL);
+	uint32_t heap_ctrl = (uint32_t)heap;
+
+	printk("M55-HP: Doorbell RX (%s) addr=0x%08x\n",
+	       (local_tx_dev == mhu0_tx_dev) ? "MHU0" : "MHU1", local_rx_addr);
+
+	/* --- Invalidate D-cache before reading HE's block --- */
+	CACHE_INVALIDATE(heap_ctrl, SHARED_HEAP_SPAN);
+	__DSB();
+
+	volatile struct shared_msg *incoming =
+			(volatile struct shared_msg *)local_rx_addr;
+
+	if (incoming->magic != MAGIC_HE) {
+		printk("ERROR: Bad magic 0x%08x (expected 0x%08x)\n",
+		       incoming->magic, MAGIC_HE);
+		return false;
+	}
+
+	if (incoming->msg_id != 0) {
+		printk("WARN: msg_id mismatch: got %u, expected 0\n",
+		       incoming->msg_id);
+	}
+
+	uint32_t rx_len = incoming->data_len;
+
+	if (rx_len > MAX_PAYLOAD) {
+		printk("ERROR: data_len %u exceeds MAX_PAYLOAD\n", rx_len);
+		return false;
+	}
+
+	uint32_t computed_cksum = calc_checksum((const uint8_t *)incoming->data,
+						rx_len);
+	bool ok = (computed_cksum == incoming->checksum);
+
+	printk("HE->HP: block @ 0x%08x msg_id=%u len=%u cksum=0x%x/0x%x %s\n",
+	       local_rx_addr, incoming->msg_id, rx_len, computed_cksum,
+	       incoming->checksum, ok ? "PASS" : "FAIL");
+
+	/* --- Free the block back to the shared heap --- */
+	sys_heap_free(heap, (void *)local_rx_addr);
+
+	/* --- Flush so HE sees the updated (freed) heap state --- */
+	CACHE_CLEAN(heap_ctrl, SHARED_HEAP_SPAN);
+	__DSB();
+
+	printk("HP: freed block @ 0x%08x\n", local_rx_addr);
+
+	/* --- Ring doorbell to HE acknowledging the free --- */
+	doorbell_tx_done = false;
+	uint32_t doorbell_val = local_rx_addr;
+
+	int send_ret = ipm_send(local_tx_dev, 0, 0, &doorbell_val, 4);
+
+	if (send_ret != 0) {
+		printk("ERROR: ipm_send failed: %d\n", send_ret);
+		return false;
+	}
+
+	int tx_waited = 0;
+
+	while (!doorbell_tx_done && tx_waited < TX_TIMEOUT_MS) {
+		k_sleep(K_MSEC(1));
+		tx_waited++;
+	}
+	if (!doorbell_tx_done) {
+		printk("ERROR: TX timeout (%d ms)\n", TX_TIMEOUT_MS);
+		return false;
+	}
+	printk("M55-HP: Doorbell TX (%s) done\n",
+	       (local_tx_dev == mhu0_tx_dev) ? "MHU0" : "MHU1");
+
+	return ok;
+}
+
+int main(void)
+{
+	printk("\n==========================================\n");
+	printk("M55-HP <-> M55-HE : MHU Doorbell + Shared SRAM1 heap (responder)\n");
+	printk("  MHU0 heap ctrl: 0x%08x\n", SHARED_HEAP_MHU0_CTRL);
+	printk("  MHU1 heap ctrl: 0x%08x\n", SHARED_HEAP_MHU1_CTRL);
+#if defined(CONFIG_PM)
+	printk("  PM: SOFT_OFF while waiting; MHU doorbell wakes via EWIC reset\n");
+#else
+	printk("  PM: disabled -- exchanges run back-to-back "
+	       "(build with -S pm-system-off-hp for SOFT_OFF)\n");
+#endif
+	printk("==========================================\n");
+
+	mhu0_rx_dev = DEVICE_DT_GET(DT_ALIAS(rtssmhu0r));
+	mhu0_tx_dev = DEVICE_DT_GET(DT_ALIAS(rtssmhu0s));
+	mhu1_rx_dev = DEVICE_DT_GET(DT_ALIAS(rtssmhu1r));
+	mhu1_tx_dev = DEVICE_DT_GET(DT_ALIAS(rtssmhu1s));
+
+	if (!device_is_ready(mhu0_rx_dev) || !device_is_ready(mhu0_tx_dev) ||
+	    !device_is_ready(mhu1_rx_dev) || !device_is_ready(mhu1_tx_dev)) {
+		printk("ERROR: MHU devices not ready!\n");
+		return -1;
+	}
+	printk("MHU devices ready\n");
+
+	ipm_register_callback(mhu0_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu0_tx_dev, mhu_tx_callback, NULL);
+	ipm_register_callback(mhu1_rx_dev, mhu_rx_callback, NULL);
+	ipm_register_callback(mhu1_tx_dev, mhu_tx_callback, NULL);
+
+	/* Re-arming the RX channels delivers any doorbell that woke us from
+	 * SOFT_OFF (the EWIC transfers the pending IRQ into the NVIC on reset).
+	 */
+	ipm_set_enabled(mhu0_rx_dev, true);
+	ipm_set_enabled(mhu1_rx_dev, true);
+
+#if defined(CONFIG_PM)
+	/* SOFT_OFF while waiting. The enabled MHU RX IRQs (MHU0=41, MHU1=43) are
+	 * within the EWIC's 0-63 range, so HE ringing the doorbell wakes HP --
+	 * via reset on this MRAM-boot image.
+	 */
+	pm_lock_for_soft_off();
+#endif /* CONFIG_PM */
+
+	/* HE owns and initialises the shared heaps; HP only frees blocks
+	 * from them, so nothing to clear here.
+	 */
+	printk("Waiting for HE doorbell...\n\n");
+
+#if defined(CONFIG_PM)
+	/* Reset-based responder: between doorbells the idle thread enters
+	 * SOFT_OFF; the next doorbell wakes HP via an EWIC reset, so on hardware
+	 * this loop body runs once per boot (the pending doorbell is delivered
+	 * right after ipm_set_enabled() above re-arms the RX IRQ).
+	 */
+	for (;;) {
+		k_sem_take(&doorbell_rx_sem, K_FOREVER);
+
+		if (handle_doorbell()) {
+			printk("Complete\n\n");
+		}
+	}
+#else
+	/* No power management: the core never resets, so handle NUM_EXCHANGES
+	 * doorbells back-to-back, then report the result and stop.
+	 */
+	unsigned int passed = 0;
+
+	for (unsigned int i = 0; i < NUM_EXCHANGES; i++) {
+		k_sem_take(&doorbell_rx_sem, K_FOREVER);
+
+		if (handle_doorbell()) {
+			passed++;
+			printk("Complete\n\n");
+		}
+	}
+
+	printk("\n==========================================\n");
+	printk("M55-HP: done -- %u/%u exchanges PASSED\n", passed, NUM_EXCHANGES);
+	printk("==========================================\n");
+
+	return 0;
+#endif /* CONFIG_PM */
+}


### PR DESCRIPTION
Add new ipm_arm_mhu_doorbell sample demonstrating inter-processor
communication using MHU doorbell interrupts on Alif Ensemble platforms,
across the A32 (APSS), M55-HE, and M55-HP cores, all running Zephyr.

The MHU channel is used as a doorbell whose 32-bit value carries the
physical address of a shared message block in SRAM1. Two core pairings
are demonstrated with the same shared-heap protocol:

  - M55-HE <-> M55-HP: the initiator allocates a message block from a
    struct sys_heap that lives in shared SRAM1, fills it with a payload,
    and rings the doorbell with the block address; the responder
    validates the block, frees it back to the same heap, and rings back
    the freed address as the ack. Both cores have D-cache enabled, so
    clean/invalidate maintenance keeps the shared region coherent.

  - M55-HE/HP <-> A32 (APSS): the M55 initiator drives the same protocol
    against an A32 responder, also running Zephyr. The A32 runs under an
    MMU and maps the shared SRAM1 heap page non-cacheable, so it needs no
    cache maintenance; the doorbell carries a physical address that the
     A32 translates into its mapping.    