### PR TITLE
samples: bluetooth: le_multiprofile: add CGMS and GLPS, B1 StartKit support

### DIFF
--- a/samples/bluetooth/le_multiprofile/CMakeLists.txt
+++ b/samples/bluetooth/le_multiprofile/CMakeLists.txt
@@ -13,5 +13,6 @@ project(le_multiprofile)
 target_sources(app PRIVATE
     src/main.c
     src/prxp_rom_1_2.c
+    src/cgms_rom_1_2.c
 )
 

--- a/samples/bluetooth/le_multiprofile/README.rst
+++ b/samples/bluetooth/le_multiprofile/README.rst
@@ -16,6 +16,7 @@ The following services are included:
 * Blood Pressure (BLPS)
 * Health Thermometer (HTPT)
 * Glucose (GLPS)
+* Continuous Glucose Monitoring (CGMS)
 * Cycling Speed & Cadence (CSCPS)
 * Running Speed & Cadence (RSCPS)
 * Proximity (PRXP)
@@ -25,7 +26,7 @@ The following services are included:
 Requirements
 ************
 
-* Alif Balletto Development Kit
+* Alif Balletto Development Kit or Starter Kit
 * BLE-capable central (phone / BLE app)
 
 Building and Running
@@ -36,13 +37,13 @@ After connection, individual profiles begin operation once the corresponding CCC
 Dummy measurements are sent for supported profiles.
 The custom Blinky service allows LED control from the central device.
 
-Limitations
-********************
+Pairing
+*******
 
-* Glucose (GLPS) is advertised and the service is visible, but runtime
-  measurement values are not accessible due to incomplete RACP (Record Access
-  Control Point) handling.
-* For the same reason as above, Continuous Glucose Monitor Sample (CGMS) was not added as well.
-* The Proximity Profile (PRXP) includes Link Loss Service (LLS) only.
-  Immediate Alert (IAS) and TX Power (TPS) are excluded to stay within the profile task limit.
-* Measurements are dummy values and not sensor-backed.
+The Glucose (GLPS) and Continuous Glucose Monitoring (CGMS) profiles require a one-time
+Bluetooth pairing when first accessed. A pairing request will appear on the central device
+prompting for a passcode. Enter **000000** to complete pairing.
+
+This pairing only happens once — on all subsequent connections the link is automatically
+re-encrypted using the stored bond, so no passcode will be requested again.
+

--- a/samples/bluetooth/le_multiprofile/boards/alif_b1_sk_ab1c1f4m51820ph0_rtss_he.overlay
+++ b/samples/bluetooth/le_multiprofile/boards/alif_b1_sk_ab1c1f4m51820ph0_rtss_he.overlay
@@ -1,0 +1,75 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+
+
+&{/} {
+	aliases {
+		led0 = &aled0;
+		led1 = &aled1;
+		led2 = &aled2;
+		pwm-led0 = &pwm_ut2;
+		sw0 = &button0;
+	};
+	leds {
+		compatible = "gpio-leds";
+		aled0: led_0 {
+			gpios = <&gpio4 5 0>;
+			label = "LED0_G";
+		};
+
+		aled1: led_1 {
+			gpios = <&gpio4 7 0>;
+			label = "LED0_R";
+		};
+
+		aled2: led_2 {
+			gpios = <&gpio4 3 0>;
+			label = "LED0_B";
+		};
+	};
+
+	pwmleds {
+
+		compatible = "pwm-leds";
+		pwm_ut2: pwm_ut2 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "UT2 PWM";
+		};
+	};
+};
+
+&utimer2 {
+	status = "okay";
+	pwm2: pwm2 {
+		pinctrl-0 = < &pinctrl_ut2 >;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};
+
+/* for "buttons" node gpio5_7, enable software pull-up */
+&pinctrl_gpio5 {
+	group0 {
+		pinmux = < PIN_P5_0__GPIO >,
+			 < PIN_P5_1__GPIO >,
+			 < PIN_P5_2__GPIO >,
+			 < PIN_P5_3__GPIO >,
+			 < PIN_P5_4__GPIO >,
+			 < PIN_P5_5__GPIO >,
+			 < PIN_P5_6__GPIO >,
+			 < PIN_P5_7__GPIO >;
+		read-enable = < 0x1 >;
+	};
+
+	group1 {
+		pinmux = < PIN_P5_7__GPIO >;
+		driver-state-control = <1>;
+	};
+};

--- a/samples/bluetooth/le_multiprofile/src/cgms_app.h
+++ b/samples/bluetooth/le_multiprofile/src/cgms_app.h
@@ -1,0 +1,21 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef CGMS_APP_H
+#define CGMS_APP_H
+
+void server_configure(void);
+void disc_notify(uint16_t reason);
+
+/* Service specific functions */
+void service_conn_cgms(struct shared_control *ctrl);
+void cgms_process(uint16_t current_value);
+void addr_res_done(void);
+
+#endif /* CGMS_APP_H */

--- a/samples/bluetooth/le_multiprofile/src/cgms_rom_1_2.c
+++ b/samples/bluetooth/le_multiprofile/src/cgms_rom_1_2.c
@@ -1,0 +1,302 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include "prf_types.h"
+#include "cgmss.h"
+#include "shared_control.h"
+#include "co_time.h"
+
+LOG_MODULE_REGISTER(cgms, LOG_LEVEL_DBG);
+
+
+#define CGMS_RUN_TIME_HOURS (5)
+#define CGMS_CGM_TYPE CGMS_TYPE_CAPILLARY_WHOLE_BLOOD
+#define CGMS_SAMPLE_LOCATION CGMS_SAMPLE_LOCATION_FINGER
+
+typedef struct {
+	prf_date_time_t date_time;
+	int8_t time_zone;
+	uint8_t dst_offset;
+} app_start_time_t;
+
+typedef struct {
+	uint8_t cccd_state_bf;
+} app_bond_data_t;
+
+typedef struct {
+	app_bond_data_t bond_data;
+	app_start_time_t start_time;
+	bool ready_to_send;
+} app_env_t;
+
+/* Dummy starting values for glucose and time offset */
+uint16_t glucose = 0x00AA;
+uint16_t time_offset_minutes = 0x00BB;
+
+/* BLE definitions */
+#define local_sec_level GAP_SEC1_AUTH_PAIR_ENC
+
+struct shared_control *s_shared_ptr;
+
+const char cgms_char_name[CGMS_CHAR_TYPE_MAX][31] = {
+	"CGM Measurement",
+	"CGM Feature",
+	"Record Access Control Point",
+	"CGM Specific Ops Control Point",
+	"CGM Status",
+	"CGM Session Start Time",
+	"CGM Session Run Time",
+};
+
+static app_env_t app_env;
+
+/*
+ * CGMS callbacks
+ */
+static void on_set_session_start_time_req(uint8_t conidx, uint16_t token, co_buf_t *p_buf)
+{
+	/* for the sample application, a session is started during startup */
+	uint16_t status = PRF_ERR_REQ_DISALLOWED;
+
+	LOG_DBG("Sample application continuously running a sesison");
+	cgmss_set_value_cfm(conidx, status, token);
+}
+
+static void on_value_req(uint8_t conidx, uint8_t char_type, uint16_t token)
+{
+	co_buf_t *p_buf;
+	uint8_t *p_data;
+	uint16_t length;
+
+	switch (char_type) {
+	case CGMS_CHAR_TYPE_FEATURE:
+		length = CGMS_FEATURE_LEN;
+		break;
+
+	case CGMS_CHAR_TYPE_STATUS:
+		length = CGMS_STATUS_LEN;
+		break;
+
+	case CGMS_CHAR_TYPE_SESSION_START_TIME:
+		length = CGMS_SESSION_START_TIME_LEN;
+		break;
+
+	default:
+		length = CGMS_SESSION_RUN_TIME_LEN;
+		break;
+	}
+
+	cgms_buf_alloc(&p_buf, length);
+	p_data = co_buf_data(p_buf);
+
+	switch (char_type) {
+	case CGMS_CHAR_TYPE_FEATURE:
+		/* CGM Feature field */
+		*p_data++ = 0u;
+
+		/* CGMSS_E2E_CRC */
+		*p_data++ = 0u;
+		*p_data++ = 0u;
+
+		/* CGM Type-Sample Location field */
+		*p_data = CGMS_CGM_TYPE
+			| (CGMS_SAMPLE_LOCATION << 4);
+		break;
+
+	case CGMS_CHAR_TYPE_STATUS:
+		/* Time offset field */
+		co_write16(p_data, co_htole16(time_offset_minutes));
+		p_data += 2u;
+		/* CGM Status field */
+		*p_data++ = 0u;
+		*p_data++ = 0u;
+		*p_data = 0u;
+		break;
+
+	case CGMS_CHAR_TYPE_SESSION_START_TIME:
+		/* Session Start Time field */
+		co_write16(p_data, co_htole16(app_env.start_time.date_time.year));
+		p_data += 2u;
+		*p_data++ = app_env.start_time.date_time.month;
+		*p_data++ = app_env.start_time.date_time.day;
+		*p_data++ = app_env.start_time.date_time.hour;
+		*p_data++ = app_env.start_time.date_time.min;
+		*p_data++ = app_env.start_time.date_time.sec;
+		/* Time Zone field */
+		*p_data++ = app_env.start_time.time_zone;
+		/* DST Offset field */
+		*p_data = app_env.start_time.dst_offset;
+		break;
+
+	default:
+		uint16_t time = CGMS_RUN_TIME_HOURS;
+
+		co_write16(p_data, co_htole16(time));
+		break;
+	}
+
+	cgmss_value_cfm(conidx, token, char_type, p_buf);
+	co_buf_release(p_buf);
+
+	LOG_DBG("Read request for %s characteristic", cgms_char_name[char_type]);
+}
+
+static void on_control_req(uint8_t conidx, uint8_t char_type, uint16_t token, co_buf_t *p_buf)
+{
+	/* No records stored for this sample application */
+	uint16_t status = PRF_ERR_REQ_DISALLOWED;
+
+	LOG_DBG("No records available");
+	cgmss_set_value_cfm(conidx, status, token);
+}
+
+static void on_get_cccd_req(uint8_t conidx, uint8_t char_type, uint16_t token)
+{
+	co_buf_t *p_buf;
+	uint16_t value;
+
+	value = PRF_CLI_STOP_NTFIND;
+
+	if ((app_env.bond_data.cccd_state_bf & CO_BIT(char_type)) != 0) {
+		value = (char_type == CGMS_CHAR_TYPE_MEASUREMENT) ? PRF_CLI_START_NTF
+		: PRF_CLI_START_IND;
+	}
+
+	cgms_buf_alloc(&p_buf, PRF_CCC_DESC_LEN);
+	co_write16(co_buf_data(p_buf), co_htole16(value));
+	cgmss_get_cccd_cfm(conidx, token, p_buf);
+	co_buf_release(p_buf);
+
+	LOG_DBG("Get CCCD request for %s characteristic", cgms_char_name[char_type]);
+}
+
+static void on_set_cccd_req(uint8_t conidx, uint8_t char_type, uint16_t token, co_buf_t *p_buf)
+{
+	uint16_t status = GAP_ERR_NO_ERROR;
+	uint16_t value;
+
+	value = co_letoh16(co_read16(co_buf_data(p_buf)));
+
+	if (value != PRF_CLI_STOP_NTFIND) {
+		if (((char_type == CGMS_CHAR_TYPE_MEASUREMENT) && (value == PRF_CLI_START_NTF))
+			|| ((char_type != CGMS_CHAR_TYPE_MEASUREMENT)
+			&& (value == PRF_CLI_START_IND))) {
+			app_env.bond_data.cccd_state_bf |= CO_BIT(char_type);
+			app_env.ready_to_send = true;
+		} else {
+			status = ATT_ERR_VALUE_NOT_ALLOWED;
+		}
+	} else {
+		app_env.bond_data.cccd_state_bf &= ~CO_BIT(char_type);
+		app_env.ready_to_send = false;
+	}
+	cgmss_set_value_cfm(conidx, status, token);
+}
+
+static void on_sent(uint8_t conidx, uint8_t char_type, uint16_t status)
+{
+	app_env.ready_to_send = true;
+}
+
+static const cgmss_cbs_t cgms_cb = {
+	.cb_set_session_start_time_req = on_set_session_start_time_req,
+	.cb_value_req = on_value_req,
+	.cb_control_req = on_control_req,
+	.cb_get_cccd_req = on_get_cccd_req,
+	.cb_set_cccd_req = on_set_cccd_req,
+	.cb_sent = on_sent,
+};
+
+static void set_start_time(void)
+{
+	/* dummy session start date and time */
+	app_env.start_time.date_time.year = 2025;
+	app_env.start_time.date_time.month = 1;
+	app_env.start_time.date_time.day = 1;
+	app_env.start_time.date_time.hour = 0;
+	app_env.start_time.date_time.min = 0;
+	app_env.start_time.date_time.sec = 0;
+	app_env.start_time.time_zone = 10;
+	app_env.start_time.dst_offset = 0;
+}
+
+void server_configure(void)
+{
+	uint16_t err;
+	uint16_t start_hdl = 0;
+	uint8_t cgmss_cfg_bf = 0;
+
+	err = prf_add_profile(TASK_ID_CGMSS, local_sec_level, 0, &cgmss_cfg_bf,
+			&cgms_cb, &start_hdl);
+
+	if (err) {
+		LOG_ERR("Error %u adding profile", err);
+	}
+
+	/* Set sample start time for CGMS session */
+	set_start_time();
+}
+
+/*  Generate and send dummy data*/
+static void send_measurement(uint16_t current_value)
+{
+	uint16_t err;
+
+	co_buf_t *p_buf;
+	uint8_t *p_data;
+
+	cgms_buf_alloc(&p_buf, CGMS_MEASUREMENT_MIN_LEN);
+	p_data = co_buf_data(p_buf);
+
+	/* Size field */
+	*p_data++ = CGMS_MEASUREMENT_MIN_LEN;
+	/* Flags field */
+	*p_data++ = 0u;
+	/* CGM Glucose Concentration field */
+	co_write16(p_data, co_htole16(glucose));
+	p_data += 2;
+	/* Time Offset field */
+	co_write16(p_data, co_htole16(time_offset_minutes));
+
+	err = cgmss_send_measurement(0, p_buf);
+	co_buf_release(p_buf);
+
+	if (err) {
+		LOG_ERR("Error %u sending measurement", err);
+	}
+}
+
+void cgms_process(uint16_t measurement)
+{
+	/* Dummy measurement data */
+	glucose = (glucose >= 0x00DD ? 0x00A9 : glucose) + 1;
+	time_offset_minutes = (time_offset_minutes >= 0x00EE ? 0x00BA : time_offset_minutes) + 1;
+
+	if (s_shared_ptr->connected && app_env.ready_to_send) {
+		send_measurement(measurement);
+		app_env.ready_to_send = false;
+	}
+}
+
+void addr_res_done(void)
+{
+}
+
+void service_conn_cgms(struct shared_control *ctrl)
+{
+	s_shared_ptr = ctrl;
+}
+
+void disc_notify(uint16_t reason)
+{
+	app_env.ready_to_send = false;
+	app_env.bond_data.cccd_state_bf = 0;
+}

--- a/samples/bluetooth/le_multiprofile/src/main.c
+++ b/samples/bluetooth/le_multiprofile/src/main.c
@@ -75,6 +75,9 @@
 /* Proximity Profile (Link Loss only - IASS and TPSS removed to stay within profile task limit) */
 #include "prxp_app.h"
 
+/* Continuous Glucose Monitoring Profile Server */
+#include "cgms_app.h"
+
 /* Custom Blinky GATT service */
 #include "gatt_db.h"
 #include "gatt_srv.h"
@@ -93,6 +96,7 @@ static const struct gpio_dt_spec led2 = GPIO_DT_SPEC_GET(LED2_NODE, gpios);
 void LedWorkerHandler(struct k_work *work);
 
 static K_WORK_DELAYABLE_DEFINE(ledWork, LedWorkerHandler);
+
 /* HRPS feature flags */
 enum hrps_feat_bf {
 	HRPS_BODY_SENSOR_LOC_CHAR_SUP_POS = 0,
@@ -129,11 +133,15 @@ static bool hr_ready_to_send;
 static bool bp_ready_to_send;
 static bool ht_ready_to_send;
 static bool gl_ready_to_send;
-static bool gl_sent_once;
 static bool cs_ready_to_send;
 static bool rsc_ready_to_send;
 
-static void send_glucose_once(void);
+/* Saved RACP request context — needed to send the response after measurement completes */
+static uint8_t gl_racp_conidx;
+static uint8_t gl_racp_op_code;
+static uint16_t gl_seq_num;
+
+static void send_glucose_measurement(void);
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
@@ -195,7 +203,7 @@ static const gatt_att_desc_t blinky_att_db[BLINKY_IDX_NB] = {
 /* Bluetooth stack configuration */
 static gapm_config_t gapm_cfg = {
 	.role = GAP_ROLE_LE_PERIPHERAL,
-	.pairing_mode = GAPM_PAIRING_DISABLE,
+	.pairing_mode = GAPM_PAIRING_LEGACY,
 	.privacy_cfg = 0,
 	.renew_dur = 1500,
 	.private_identity.addr = {0},
@@ -235,16 +243,18 @@ static void on_disconnection(uint8_t conidx, uint16_t reason)
 {
 	/* Notify PRXP (triggers link loss alert if disconnection was not user-initiated) */
 	prxp_disc_notify(reason);
+	disc_notify(reason);
 
-	/* Turn off BLE-controlled LED on disconnect */
+	/* Turn off BLE-controlled LED on disconnect, restart advertising blink */
 	ble_gpio_led_set(&led0, false);
+	k_work_reschedule(&ledWork, K_MSEC(1));
 
 	/* Reset all service send gates - phone must re-enable CCCDs after reconnect */
 	hr_ready_to_send = false;
 	bp_ready_to_send = false;
 	ht_ready_to_send = false;
 	gl_ready_to_send = false;
-	gl_sent_once = false;
+	gl_racp_op_code = 0;
 	cs_ready_to_send = false;
 	rsc_ready_to_send = false;
 }
@@ -358,7 +368,6 @@ static void on_glps_bond_data_upd(uint8_t conidx, uint8_t evt_cfg)
 
 	if (evt_cfg == PRF_CLI_START_NTF) {
 		gl_ready_to_send = true;
-		gl_sent_once = false;
 	} else {
 		gl_ready_to_send = false;
 	}
@@ -366,20 +375,23 @@ static void on_glps_bond_data_upd(uint8_t conidx, uint8_t evt_cfg)
 
 static void on_glps_meas_send_complete(uint8_t conidx, uint16_t status)
 {
-	ARG_UNUSED(conidx);
 	ARG_UNUSED(status);
+	gl_ready_to_send = true;
+
+	if (gl_racp_op_code) {
+		glps_racp_rsp_send(conidx, gl_racp_op_code, GLP_RSP_SUCCESS, 1);
+		gl_racp_op_code = 0;
+	}
 }
 
-/* Called when the app sends a RACP request (e.g. user taps reload button).
- * Send the dummy measurement first, then report 1 record so the app shows a value.
- */
 static void on_glps_racp_req(uint8_t conidx, uint8_t op_code,
 			     uint8_t func_operator,
 			     uint8_t filter_type,
 			     const union glp_filter *p_filter)
 {
-	send_glucose_once();
-	glps_racp_rsp_send(conidx, op_code, GLP_RSP_SUCCESS, 1);
+	gl_racp_conidx = conidx;
+	gl_racp_op_code = op_code;
+	send_glucose_measurement();
 }
 
 static void on_glps_racp_rsp_send_cmp(uint8_t conidx, uint16_t status)
@@ -407,7 +419,7 @@ static prf_sfloat glucose_to_sfloat(float mg_dl)
 }
 
 /* Send a single dummy glucose record (95 mg/dL, capillary whole blood, finger) */
-static void send_glucose_once(void)
+static void send_glucose_measurement(void)
 {
 	glp_meas_t meas = {
 		.flags = GLP_MEAS_GL_CTR_TYPE_AND_SPL_LOC_PRES_BIT,
@@ -424,7 +436,7 @@ static void send_glucose_once(void)
 		},
 	};
 
-	uint16_t err = glps_meas_send(0, 1, &meas, NULL);
+	uint16_t err = glps_meas_send(0, gl_seq_num++, &meas, NULL);
 
 	if (err) {
 		LOG_ERR("GLPS send error %u", err);
@@ -550,6 +562,7 @@ static uint16_t set_advertising_data(uint8_t actv_idx)
 		GATT_SVC_BLOOD_PRESSURE,
 		GATT_SVC_HEALTH_THERMOM,
 		GATT_SVC_GLUCOSE,
+		GATT_SVC_CONTINUOUS_GLUCOSE_MONITORING,
 		GATT_SVC_CYCLING_SPEED_CADENCE,
 		GATT_SVC_RUNNING_SPEED_CADENCE,
 		GATT_SVC_LINK_LOSS,
@@ -965,11 +978,12 @@ static void combined_process(void)
 		ht_ready_to_send = false;
 	}
 
-	/* Glucose sends one record per connection (it's a historical log, not a stream) */
-	if (gl_ready_to_send && !gl_sent_once) {
-		send_glucose_once();
-		gl_sent_once = true;
+	if (gl_ready_to_send) {
+		send_glucose_measurement();
+		gl_ready_to_send = false;
 	}
+
+	cgms_process(0);
 
 	/* CSCPS gated by CCCD enable + send complete */
 	if (cs_ready_to_send) {
@@ -1041,12 +1055,14 @@ int main(void)
 
 	/* Share connection state with battery and other sub-services */
 	service_conn(&ctrl);
+	service_conn_cgms(&ctrl);
 
 	config_battery_service();
 	blinky_init();
 
 	/* Add all standard BLE profiles (share the profile framework GATT user) */
 	bundle_server_configure();
+	server_configure();
 	prxp_server_configure(); /* Registers LLSS only */
 
 	/* Create and start advertising */

--- a/samples/bluetooth/le_multiprofile/src/prxp_app.h
+++ b/samples/bluetooth/le_multiprofile/src/prxp_app.h
@@ -37,15 +37,5 @@ void ias_process(void);
  */
 void prxp_disc_notify(uint16_t reason);
 
-/**
- * @brief Append PRXP advertising parameters to an existing param struct.
- *
- * Sets the TX power parameter for advertising and returns the
- * updated advertising creation parameter struct.
- *
- * @param adv_append_params  Pointer to the base advertising parameter struct.
- * @return Updated gapm_le_adv_create_param_t with PRXP parameters merged in.
- */
-gapm_le_adv_create_param_t append_adv_param(gapm_le_adv_create_param_t *adv_append_params);
 
 #endif /* PRXP_APP_H */

--- a/subsys/bluetooth/common/gapm_sec.c
+++ b/subsys/bluetooth/common/gapm_sec.c
@@ -105,8 +105,14 @@ static void on_le_encrypt_req(uint8_t conidx, uint32_t metainfo, uint16_t ediv,
 {
 	uint16_t err;
 
-	err = gapc_le_encrypt_req_reply(conidx, true, &stored_keys.ltk.key,
-					stored_keys.ltk.key_size);
+	/* Legacy pairing: use locally generated LTK.
+	 * SC pairing: on_ltk_req never called, fall back to stored peer key.
+	 */
+	bool use_generated = (generated_keys.valid_key_bf & GAP_KDIST_ENCKEY) != 0;
+	const gap_sec_key_t *ltk = use_generated ? &generated_keys.ltk.key : &stored_keys.ltk.key;
+	uint8_t key_size = use_generated ? generated_keys.ltk.key_size : stored_keys.ltk.key_size;
+
+	err = gapc_le_encrypt_req_reply(conidx, true, ltk, key_size);
 
 	if (err) {
 		LOG_ERR("Error during encrypt request reply %u", err);


### PR DESCRIPTION
Add B1 SK board overlay, CGMS profile, fix GLPS RACP ordering and sequence number, enable GAPM_PAIRING_LEGACY for GLPS/CGMS one-time pairing (passcode 000000), fix gapm_sec.c LTK selection for legacy pairing bonded reconnection, fix CGMS CCCD state not cleared on disconnect, fix LED blink on disconnect, update README.