### PR TITLE
manifest: Update Zephyr version to Binning support change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 162e865ca29e29e2c3734de0c137b84b2501a6e6
+      revision: pull/550/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 01c3b051a63d5c97edad047a198f0b446145f7b2
+      revision: 6f4d17e8b09527a89968c74c5d75bf20d68a8f82
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the Zephyr version to binning support change.
This PR depends on: alifsemi/zephyr_alif/pull/550
This PR depends on: alifsemi/hal_alif/pull/127