### PR TITLE
tests: drivers: video: Add ARX3A0 sensor support and ISP pipeline

### DIFF
--- a/tests/drivers/video/README.rst
+++ b/tests/drivers/video/README.rst
@@ -1,12 +1,12 @@
-.. _alif-cpi-sample:
+.. _alif-video-tests:
 
-Alif CPI Sample
-###############
+Alif Video Tests
+################
 
 Overview
 ********
 
-This test exercises the Alif Camera Parallel Interface (CPI) / MIPI Camera
+This test exercises the Alif Camera Parallel Interface (CPI) and MIPI Camera
 Serial Interface (CSI-2) video capture pipeline via the Zephyr
 :dtcompatible:`alif,cam` driver. It validates the generic Zephyr ``video``
 API (``video_get_caps``, ``video_set_format``, ``video_get_format``,
@@ -39,10 +39,12 @@ The pipeline format is selected at compile time from the device tree:
 +================================+===========================+================+
 | ``aptina,mt9m114``             | Parallel CPI              | ``GREY``       |
 +--------------------------------+---------------------------+----------------+
+| ``onnn,arx3a0``                | MIPI CSI-2                | ``RAW10``      |
++--------------------------------+---------------------------+----------------+
 
 When ``CONFIG_USE_ALIF_ISP_LIB=y`` is enabled (see ``boards/isp.conf``),
-the output format is forced to ``RGB888_PLANAR_PRIVATE`` and frames flow
-through the ISP (``vsi,isp-pico``).
+the ARX3A0 RAW10 output is processed by the ISP (``vsi,isp-pico``) and
+converted to ``RGB888_PLANAR_PRIVATE`` format.
 
 Building and Running
 ********************
@@ -50,32 +52,48 @@ Building and Running
 The application only builds for targets whose device tree enables a
 :dtcompatible:`alif,cam` node.
 
-Parallel CPI + MT9M114 (RTSS-HP, E8 DK)
+Replace ``<board>`` with your target board (e.g., ``alif_e8_dk/ae822fa0e5597xx0/rtss_hp``)
+and ``<test_path>`` with the path to the test directory.
+
+CPI + MT9M114 Parallel
+======================
+
+.. code-block:: console
+
+   west build -p -b <board> \
+       <test_path> \
+       -- -DDTC_OVERLAY_FILE=boards/cpi_mt9m114.overlay
+
+LP-CPI + MT9M114 Parallel (RTSS-HE only)
+=========================================
+
+.. note::
+   LP-CPI is only supported on RTSS-HE targets.
+
+.. code-block:: console
+
+   west build -p -b <board> \
+       <test_path> \
+       -- -DDTC_OVERLAY_FILE=boards/lpcpi_mt9m114.overlay
+
+MIPI CSI-2 + ARX3A0 + ISP (Selfie Camera)
+==========================================
+
+.. code-block:: console
+
+   west build -p -b <board> \
+       <test_path> \
+       -- -DDTC_OVERLAY_FILE=boards/serial_camera_arx3a0_selfie.overlay \
+          -DEXTRA_CONF_FILE=boards/isp.conf
+
+MIPI CSI-2 + ARX3A0 (Standard Camera)
 =======================================
 
 .. code-block:: console
 
-   west build -p -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
-       ../alif/tests/drivers/video/ \
-       -- -DDTC_OVERLAY_FILE="$PWD/../alif/tests/drivers/video/boards/cpi_mt9m114.overlay"
-
-Parallel CPI + MT9M114 (RTSS-HE)
-================================
-
-.. code-block:: console
-
-   west build -p -b alif_e8_dk/ae822fa0e5597xx0/rtss_he \
-       ../alif/tests/drivers/video/ \
-       -- -DDTC_OVERLAY_FILE="$PWD/../alif/tests/drivers/video/boards/cpi_mt9m114.overlay"
-
-LP-CPI + MT9M114 (RTSS-HE)
-==========================
-
-.. code-block:: console
-
-   west build -p -b alif_e8_dk/ae822fa0e5597xx0/rtss_he \
-       ../alif/tests/drivers/video/ \
-       -- -DDTC_OVERLAY_FILE="$PWD/../alif/tests/drivers/video/boards/lpcpi_mt9m114.overlay"
+   west build -p -b <board> \
+       <test_path> \
+       -- -DDTC_OVERLAY_FILE=boards/serial_camera_arx3a0_standard.overlay
 
 Flash and open a serial console at 115200 8N1 to observe the test output.
 

--- a/tests/drivers/video/boards/serial_camera_arx3a0.overlay
+++ b/tests/drivers/video/boards/serial_camera_arx3a0.overlay
@@ -1,0 +1,103 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code are permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement.
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/video/video-interfaces.h>
+
+&gpio7 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+
+	arx3a0: arx3a0@36 {
+		compatible = "onnn,arx3a0";
+		reg = <0x36>;
+		pinctrl-0 = < &pinctrl_cam_xvclk >;
+		pinctrl-names = "default";
+		reset-gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+		power-gpios = <&gpio7 5 GPIO_ACTIVE_HIGH>;
+
+		status = "okay";
+
+		port {
+			arx3a0_csi2_ep_out: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				link-frequencies = < 400000000 >;
+				data-lanes = <1 2>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "csi2_ep_in";
+			};
+		};
+	};
+};
+
+&cam {
+	status = "okay";
+
+	pinctrl-0 = <&pinctrl_cam_xvclk>;
+	pinctrl-names = "default";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* MIPI CSI-2 bus endpoint. */
+		port@0 {
+			reg = <0>;
+			cam_csi2_ep_in: endpoint {
+				remote-endpoint-label = "csi2_ep_out";
+			};
+		};
+
+		/* Video buffer output endpoint. */
+		port@1 {
+			reg = <1>;
+			cam_mem_ep_out: endpoint {
+				remote-endpoint-label = "application";
+			};
+		};
+	};
+};
+
+&csi {
+	status = "okay";
+
+	/* RX-DPHY */
+	phy-if = <&dphy 0>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			csi2_ep_in: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				data-lanes = <1 2>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "arx3a0_csi2_ep_out";
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csi2_ep_out: endpoint {
+				remote-endpoint-label = "cam_csi2_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			};
+		};
+	};
+};

--- a/tests/drivers/video/boards/serial_camera_arx3a0_selfie.overlay
+++ b/tests/drivers/video/boards/serial_camera_arx3a0_selfie.overlay
@@ -1,0 +1,133 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code are permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement.
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/video/video-interfaces.h>
+
+&i2c1 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&gpio14 {
+	status = "okay";
+};
+
+/{
+	i2c_mux: i2c-mux {
+		compatible = "gpio-i2c-mux";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-inst = <&i2c1>;
+
+		ctrl-gpios = <&gpio14 3 GPIO_ACTIVE_HIGH>;
+
+		mux_i2c@0 {
+			compatible = "gpio-i2c-mux-channel";
+			reg = <0>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			arx3a0_selfie: arx3a0_selfie@36 {
+				compatible = "onnn,arx3a0";
+				reg = <0x36>;
+
+				reset-gpios = <&gpio14 4 GPIO_ACTIVE_HIGH>;
+				power-gpios = <&gpio7 5 GPIO_ACTIVE_HIGH>;
+
+				status = "okay";
+
+				port {
+					arx3a0_csi2_ep_out0: endpoint {
+						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+						link-frequencies = < 400000000 >;
+						data-lanes = <1 2>;
+						clock-lane = <0>;
+
+						remote-endpoint-label = "csi2_ep_in0";
+					};
+				};
+			};
+		};
+	};
+};
+
+&isp {
+	status = "okay";
+
+	port {
+		isp_ep_in: endpoint {
+			remote-endpoint-label = "cam_isp_ep_out";
+		};
+	};
+};
+
+&cam {
+	status = "okay";
+
+	pinctrl-0 = <&pinctrl_cam_xvclk>;
+	pinctrl-names = "default";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* MIPI CSI-2 bus endpoint. */
+		port@0 {
+			reg = <0>;
+			cam_csi2_ep_in: endpoint {
+				remote-endpoint-label = "csi2_ep_out";
+			};
+		};
+
+		/* ISP Interface. */
+		port@2 {
+			reg = <2>;
+			cam_isp_ep_out: endpoint {
+				remote-endpoint-label = "isp_ep_in";
+			};
+		};
+	};
+};
+
+&csi {
+	status = "okay";
+
+	/* Selfie camera D-PHY*/
+	phy-if = <&dphy 0>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			csi2_ep_in0: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				data-lanes = <1 2>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "arx3a0_csi2_ep_out0";
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csi2_ep_out: endpoint {
+				remote-endpoint-label = "cam_csi2_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			};
+		};
+	};
+};

--- a/tests/drivers/video/boards/serial_camera_arx3a0_standard.overlay
+++ b/tests/drivers/video/boards/serial_camera_arx3a0_standard.overlay
@@ -1,0 +1,134 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code are permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement.
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/video/video-interfaces.h>
+
+&i2c1 {
+	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&gpio13 {
+	status = "okay";
+};
+
+&gpio14 {
+	status = "okay";
+};
+
+/{
+	i2c_mux: i2c-mux {
+		compatible = "gpio-i2c-mux";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-inst = <&i2c1>;
+
+		ctrl-gpios = <&gpio14 3 GPIO_ACTIVE_HIGH>;
+
+		mux_i2c@1 {
+			compatible = "gpio-i2c-mux-channel";
+			reg = <1>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			arx3a0_standard: arx3a0_standard@36 {
+				compatible = "onnn,arx3a0";
+				reg = <0x36>;
+
+				reset-gpios = <&gpio13 0 GPIO_ACTIVE_HIGH>;
+				power-gpios = <&gpio7 5 GPIO_ACTIVE_HIGH>;
+
+				status = "okay";
+
+				port {
+					arx3a0_csi2_ep_out1: endpoint {
+						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+						link-frequencies = < 400000000 >;
+						data-lanes = <1 2>;
+						clock-lane = <0>;
+
+						remote-endpoint-label = "csi2_ep_in1";
+					};
+				};
+			};
+		};
+	};
+};
+
+&cam {
+	status = "okay";
+
+	pinctrl-0 = <&pinctrl_cam_xvclk>;
+	pinctrl-names = "default";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* MIPI CSI-2 bus endpoint. */
+		port@0 {
+			reg = <0>;
+			cam_csi2_ep_in: endpoint {
+				remote-endpoint-label = "csi2_ep_out";
+			};
+		};
+
+		/* Video buffer output endpoint. */
+		port@1 {
+			reg = <1>;
+			cam_mem_ep_out: endpoint {
+				remote-endpoint-label = "application";
+			};
+		};
+	};
+};
+
+&csi {
+	status = "okay";
+
+	/* Standard camera D-PHY*/
+	phy-if = <&dphy 1>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@1 {
+			reg = <1>;
+			csi2_ep_in1: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				data-lanes = <1 2>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "arx3a0_csi2_ep_out1";
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csi2_ep_out: endpoint {
+				remote-endpoint-label = "cam_csi2_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			};
+		};
+	};
+};
+
+&mipi_dsi {
+	status = "okay";
+};
+&mw405 {
+	status = "disabled";
+};

--- a/tests/drivers/video/src/main.c
+++ b/tests/drivers/video/src/main.c
@@ -30,6 +30,28 @@ K_THREAD_STACK_DEFINE(thread_stack, 1024);
 LOG_MODULE_REGISTER(video_app, LOG_LEVEL_INF);
 const struct device *video;
 
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+uint8_t current_sensor_main;
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+
+#if ISP_ENABLED
+enum logging_level {
+	LOGGING_LEVEL_NONE = 0,
+	LOGGING_LEVEL_ERR,
+	LOGGING_LEVEL_WARN,
+	LOGGING_LEVEL_INFO,
+	LOGGING_LEVEL_DEBUG,
+	LOGGING_LEVEL_VERBOSE,
+};
+
+#define LIB_LOG_LEVEL LOGGING_LEVEL_NONE
+
+int log_level(void)
+{
+	return LIB_LOG_LEVEL;
+}
+#endif
+
 /*
  * Test Case to Capture Image
  */
@@ -45,9 +67,7 @@ ZTEST(cpi_manual_testcase, video_test_image_capture)
 	int i;
 	int ret;
 	int loop_ctr;
-	#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
-		uint8_t current_sensor;
-	#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+
 	/* `video` is acquired and validated by manual_suite_before(). */
 	TC_PRINT("- Device name: %s\n", video->name);
 	for (loop_ctr = NUM_CAMS - 1; loop_ctr >= 0; loop_ctr--) {
@@ -57,16 +77,12 @@ ZTEST(cpi_manual_testcase, video_test_image_capture)
 		 */
 		i = 0;
 		memset(&fmt, 0, sizeof(fmt));
-	#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
-		ret = video_get_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM, &current_sensor);
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		ret = video_get_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM, &current_sensor_main);
 		zassert_equal(ret, 0, "Failed to get current camera: %d", ret);
-		LOG_INF("Selected camera: %s", (current_sensor) ? "Standard" : "Selfie");
-	#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
-		if (IS_ENABLED(ISP_ENABLED)) {
-			ep = VIDEO_EP_IN;
-		} else {
-			ep = VIDEO_EP_OUT;
-		}
+		LOG_INF("Selected camera: %s", (current_sensor_main) ? "Standard" : "Selfie");
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+		ep = CAPTURE_EP;
 	/* Get capabilities error check*/
 	zassert_false(video_get_caps(video, ep, &caps[loop_ctr]),
 					"Unable to retrieve video capabilities");
@@ -94,34 +110,19 @@ ZTEST(cpi_manual_testcase, video_test_image_capture)
 	}
 
 	zassert_not_equal(fmt.pixelformat, 0, "Desired Pixel format is not supported.");
-	ret = video_set_format(video, ep, &fmt);
-	zassert_equal(ret, 0, "video_set_format on ep=%d failed: %d", ep, ret);
-	#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+	ret = video_set_capture_format(video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
 		if (NUM_CAMS > 1) {
-			current_sensor ^= 1;
+			current_sensor_main ^= 1;
 			ret = video_set_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM,
-					&current_sensor);
+					&current_sensor_main);
 			if (ret) {
 				LOG_ERR("Unable to switch camera!");
 			}
 		}
-	#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
 	}
-		#if (ISP_ENABLED)
-		/*
-		 * Set Output Endpoint format. Ensure that ISP EP-out
-		 * format is set while allocating the buffers used to
-		 * capture images.
-		 */
-		fmt.pixelformat = OUTPUT_FORMAT;
-		fmt.width = 480;
-		fmt.height = 480;
-		fmt.pitch = fourcc_to_pitch(fmt.pixelformat, fmt.width);
-
-		ret = video_set_format(video, VIDEO_EP_OUT, &fmt);
-		zassert_equal(ret, 0,
-			"ISP EP_OUT video_set_format failed: %d", ret);
-	#endif /*ISP_ENABLED */
 #if (ISP_ENABLED)
 	zassert_false(fmt.pixelformat != OUTPUT_FORMAT, "Unsupported pixel format. fmt - %c%c%c%c",
 		(char)fmt.pixelformat,
@@ -148,24 +149,22 @@ ZTEST(cpi_manual_testcase, video_test_image_capture)
 	TC_PRINT("Width - %d, Pitch - %d, Height - %d, Buff size - %d\n",
 			fmt.width, fmt.pitch, fmt.height, bsize);
 
-	#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
 		if (NUM_CAMS > 1) {
-			current_sensor = 0;
+			current_sensor_main = 0;
 			ret = video_set_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM,
-					&current_sensor);
+					&current_sensor_main);
 			if (ret) {
 				LOG_ERR("Unable to switch camera!");
 			}
 		}
-	#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
 	/* Alloc video buffers and enqueue for capture */
 
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
 		buffers[i] = video_buffer_alloc(bsize, K_NO_WAIT);
-		if (buffers[i] == NULL) {
-			LOG_ERR("Unable to alloc video buffer");
-			return;
-		}
+		zassert_not_null(buffers[i],
+				"Unable to alloc video buffer %d", i);
 
 		/* Allocated Buffer Information */
 
@@ -218,16 +217,16 @@ ZTEST(cpi_manual_testcase, video_test_image_capture)
 	 * synchronously so the K_NO_WAIT dequeue loop below sees every
 	 * buffer.
 	 */
-	video_flush(video, VIDEO_EP_OUT, false);
-	LOG_INF("Calling video flush done.");
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
 		struct video_buffer *drained = NULL;
 
-		video_dequeue(video, VIDEO_EP_OUT, &drained, K_NO_WAIT);
+		ret = video_dequeue(video, VIDEO_EP_OUT, &drained, K_NO_WAIT);
+		zassert_equal(ret, 0, "video_dequeue failed: %d", ret);
 		if (drained) {
 			video_buffer_release(drained);
 		}
 	}
+	k_msleep(500);
 }
 
 #ifdef CONFIG_POLL
@@ -290,7 +289,7 @@ ZTEST(cpi_manual_testcase, video_api_set_signal)
  */
 ZTEST(cpi_manual_testcase, video_z_capture_n_frames)
 {
-	struct video_buffer *buffers[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX], *vbuf;
+	struct video_buffer *buffers_z[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX], *vbuf;
 	struct video_format fmt = { 0 };
 	struct video_caps caps;
 	enum video_endpoint_id ep;
@@ -301,12 +300,15 @@ ZTEST(cpi_manual_testcase, video_z_capture_n_frames)
 	unsigned int frame = 0;
 
 	/* `video` is acquired and validated by manual_suite_before(). */
+	TC_PRINT("- Device name: %s\n", video->name);
+	ep = CAPTURE_EP;
 
-	if (IS_ENABLED(ISP_ENABLED)) {
-		ep = VIDEO_EP_IN;
-	} else {
-		ep = VIDEO_EP_OUT;
-	}
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		ret = video_get_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM, &current_sensor_main);
+		zassert_equal(ret, 0,
+				"video_get_ctrl(VIDEO_CID_ALIF_CSI_CURR_CAM) failed: %d", ret);
+		LOG_INF("Selected camera: %s", (current_sensor_main) ? "Standard" : "Selfie");
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
 
 	zassert_false(video_get_caps(video, ep, &caps),
 		"Unable to retrieve video capabilities");
@@ -324,25 +326,69 @@ ZTEST(cpi_manual_testcase, video_z_capture_n_frames)
 	}
 	zassert_not_equal(fmt.pixelformat, 0, "Desired pixel format not supported.");
 
-	ret = video_set_format(video, ep, &fmt);
-	zassert_equal(ret, 0, "video_set_format failed: %d", ret);
+	ret = video_set_capture_format(video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
 
-#if ISP_ENABLED
-	fmt.pixelformat = OUTPUT_FORMAT;
-	fmt.width = 480;
-	fmt.height = 480;
-	fmt.pitch = fourcc_to_pitch(fmt.pixelformat, fmt.width);
-	ret = video_set_format(video, VIDEO_EP_OUT, &fmt);
-	zassert_equal(ret, 0, "ISP EP_OUT set_format failed: %d", ret);
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		if (NUM_CAMS > 1) {
+			current_sensor_main ^= 1;
+			ret = video_set_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM,
+					&current_sensor_main);
+			if (ret) {
+				LOG_ERR("Unable to switch camera!");
+			}
+		}
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+#if (ISP_ENABLED)
+	zassert_false(fmt.pixelformat != OUTPUT_FORMAT, "Unsupported pixel format. fmt - %c%c%c%c",
+		(char)fmt.pixelformat,
+		(char)(fmt.pixelformat >> 8),
+		(char)(fmt.pixelformat >> 16),
+		(char)(fmt.pixelformat >> 24));
+#else
+	zassert_false(fmt.pixelformat != PIPELINE_FORMAT, "Unsupported pixel format. fmt "
+		" - %c%c%c%c",
+		(char)fmt.pixelformat,
+		(char)(fmt.pixelformat >> 8),
+		(char)(fmt.pixelformat >> 16),
+		(char)(fmt.pixelformat >> 24));
 #endif
+	TC_PRINT("- format: %c%c%c%c %ux%u\n", (char)fmt.pixelformat,
+	       (char)(fmt.pixelformat >> 8),
+	       (char)(fmt.pixelformat >> 16),
+	       (char)(fmt.pixelformat >> 24),
+	       fmt.width, fmt.height);
+
+	/* Size to allocate for each buffer */
 
 	bsize = fmt.pitch * fmt.height;
+	TC_PRINT("Width - %d, Pitch - %d, Height - %d, Buff size - %d\n",
+			fmt.width, fmt.pitch, fmt.height, bsize);
 
-	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-		buffers[i] = video_buffer_alloc(bsize, K_NO_WAIT);
-		zassert_not_null(buffers[i], "Unable to alloc video buffer %d", i);
-		memset(buffers[i]->buffer, 0, bsize);
-		ret = video_enqueue(video, VIDEO_EP_OUT, buffers[i]);
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		if (NUM_CAMS > 1) {
+			current_sensor_main = 0;
+			ret = video_set_ctrl(video, VIDEO_CID_ALIF_CSI_CURR_CAM,
+					&current_sensor_main);
+			if (ret) {
+				LOG_ERR("Unable to switch camera!");
+			}
+		}
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+	/* Alloc video buffers and enqueue for capture */
+
+	for (i = 0; i < ARRAY_SIZE(buffers_z); i++) {
+		buffers_z[i] = video_buffer_alloc(bsize, K_NO_WAIT);
+		zassert_not_null(buffers_z[i], "Unable to alloc video buffer %d", i);
+
+		/* Allocated Buffer Information */
+		LOG_INF("- addr - 0x%x, size - %d, bytesused - %d",
+			(uint32_t)buffers_z[i]->buffer,
+			bsize,
+			buffers_z[i]->bytesused);
+
+		memset(buffers_z[i]->buffer, 0, bsize);
+		ret = video_enqueue(video, VIDEO_EP_OUT, buffers_z[i]);
 		zassert_equal(ret, 0, "Enqueue failed for buffer %d: %d", i, ret);
 	}
 
@@ -378,7 +424,7 @@ ZTEST(cpi_manual_testcase, video_z_capture_n_frames)
 	ret = video_flush(video, VIDEO_EP_OUT, false);
 	zassert_equal(ret, 0, "video_flush failed: %d", ret);
 
-	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
+	for (i = 0; i < ARRAY_SIZE(buffers_z); i++) {
 		struct video_buffer *drained = NULL;
 
 		ret = video_dequeue(video, VIDEO_EP_OUT, &drained, K_NO_WAIT);
@@ -395,17 +441,18 @@ ZTEST(cpi_manual_testcase, video_z_capture_n_frames)
  */
 static int app_set_parameters(void)
 {
-#if (CONFIG_VIDEO_MIPI_CSI2_DW)
 	run_profile_t runp;
 	int ret;
 
+#if (CONFIG_VIDEO_MIPI_CSI2_DW)
 #if (DT_NODE_HAS_STATUS(DT_NODELABEL(camera_select), okay))
 	const struct gpio_dt_spec sel =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(camera_select), select_gpios);
 
 	gpio_pin_configure_dt(&sel, GPIO_OUTPUT);
 	gpio_pin_set_dt(&sel, 1);
-#endif /* (DT_NODE_HAS_STATUS(DT_NODELABEL(camera_sensor), okay)) */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(camera_sensor), okay) */
+#endif
 
 	/* Enable HFOSC (38.4 MHz) and CFG (100 MHz) clock. */
 #if defined(CONFIG_SOC_SERIES_E8)
@@ -414,7 +461,7 @@ static int app_set_parameters(void)
 	sys_set_bits(CGU_CLK_ENA, BIT(23) | BIT(21));
 #endif /* defined (CONFIG_SOC_SERIES_E7) */
 
-	runp.power_domains = PD_SYST_MASK | PD_SSE700_AON_MASK;
+	runp.power_domains = PD_SYST_MASK | PD_SSE700_AON_MASK | PD_DBSS_MASK;
 	runp.dcdc_voltage  = 825;
 	runp.dcdc_mode     = DCDC_MODE_PWM;
 	runp.aon_clk_src   = CLK_SRC_LFXO;
@@ -443,6 +490,7 @@ static int app_set_parameters(void)
 	 * TODO: parse this clock from DTS and set on board from camera
 	 * controller driver.
 	 */
+#if defined(CONFIG_VIDEO_MIPI_CSI2_DW)
 	sys_write32(0x140001, CLKCTRL_PER_MST_CAMERA_PIXCLK_CTRL);
 #endif
 

--- a/tests/drivers/video/src/video_api.c
+++ b/tests/drivers/video/src/video_api.c
@@ -25,6 +25,10 @@
 
 static const struct device *api_video;
 
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+	uint8_t current_sensor;
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+
 /*
  * Probe VIDEO_EP_IN and VIDEO_EP_OUT at runtime to find an endpoint that the
  * driver does not support (video_get_caps returns -EINVAL). This keeps the
@@ -171,24 +175,12 @@ ZTEST(cpi_api_testcase, api_set_format_valid)
 	ret = api_get_default_fmt(&fmt);
 	zassert_equal(ret, 0, "api_get_default_fmt failed: %d", ret);
 
-	ret = video_set_format(api_video, CAPTURE_EP, &fmt);
-	zassert_equal(ret, 0, "video_set_format on CAPTURE_EP with valid fmt failed: %d", ret);
+	ret = video_set_capture_format(api_video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
 	TC_PRINT("api_set_format_valid: fmt=%c%c%c%c %ux%u pitch=%u ret=%d\n",
 		(char)fmt.pixelformat, (char)(fmt.pixelformat >> 8),
 		(char)(fmt.pixelformat >> 16), (char)(fmt.pixelformat >> 24),
 		fmt.width, fmt.height, fmt.pitch, ret);
-
-#if ISP_ENABLED
-	/* ISP also requires an output-side format (OUTPUT_FORMAT on EP_OUT). */
-	struct video_format out_fmt = {
-		.pixelformat = OUTPUT_FORMAT,
-		.width       = 480,
-		.height      = 480,
-		.pitch       = fourcc_to_pitch(OUTPUT_FORMAT, 480),
-	};
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &out_fmt);
-	zassert_equal(ret, 0, "ISP EP_OUT set_format failed: %d", ret);
-#endif
 }
 
 /* -------------------------------------------------------------------------
@@ -206,7 +198,7 @@ ZTEST(cpi_api_testcase, api_set_format_invalid_pixelformat)
 	uintptr_t regs = DEVICE_MMIO_GET(api_video);
 	int ret;
 
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &fmt);
+	ret = video_set_format(api_video, CAPTURE_EP, &fmt);
 	TC_PRINT("api_set_format_invalid_pixelformat: ret=%d\n", ret);
 	zassert_true(ret == -EINVAL || ret == -ENOTSUP,
 		"Expected -EINVAL or -ENOTSUP for bad pixelformat, got %d", ret);
@@ -315,10 +307,14 @@ ZTEST(cpi_api_testcase, api_enqueue_valid)
 
 	ret = api_get_default_fmt(&fmt);
 	zassert_equal(ret, 0, "api_get_default_fmt failed: %d", ret);
-	bsize = fmt.pitch * fmt.height;
 
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &fmt);
-	zassert_equal(ret, 0, "set_format failed: %d", ret);
+	ret = video_set_capture_format(api_video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
+
+	/* fmt now describes what EP_OUT expects (PIPELINE on direct-CAM,
+	 * OUTPUT_FORMAT on ISP), so the buffer-size math is correct on both.
+	 */
+	bsize = fmt.pitch * fmt.height;
 
 	vbuf = video_buffer_alloc(bsize, K_NO_WAIT);
 	zassert_not_null(vbuf, "video_buffer_alloc returned NULL");
@@ -457,10 +453,11 @@ ZTEST(cpi_api_testcase, api_flush_cancel)
 
 	ret = api_get_default_fmt(&fmt);
 	zassert_equal(ret, 0, "api_get_default_fmt failed: %d", ret);
-	bsize = fmt.pitch * fmt.height;
 
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &fmt);
-	zassert_equal(ret, 0, "set_format failed: %d", ret);
+	ret = video_set_capture_format(api_video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
+
+	bsize = fmt.pitch * fmt.height;
 
 	for (i = 0; i < 2; i++) {
 		bufs[i] = video_buffer_alloc(bsize, K_NO_WAIT);
@@ -497,10 +494,11 @@ ZTEST(cpi_api_testcase, api_flush_no_cancel_stopped)
 
 	ret = api_get_default_fmt(&fmt);
 	zassert_equal(ret, 0, "api_get_default_fmt failed: %d", ret);
-	bsize = fmt.pitch * fmt.height;
 
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &fmt);
-	zassert_equal(ret, 0, "set_format failed: %d", ret);
+	ret = video_set_capture_format(api_video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
+
+	bsize = fmt.pitch * fmt.height;
 
 	vbuf = video_buffer_alloc(bsize, K_NO_WAIT);
 	zassert_not_null(vbuf, "video_buffer_alloc returned NULL");
@@ -568,10 +566,45 @@ ZTEST(cpi_api_testcase, api_stream_start_stop_roundtrip)
 
 	ret = api_get_default_fmt(&fmt);
 	zassert_equal(ret, 0, "api_get_default_fmt failed: %d", ret);
+
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		ret = video_get_ctrl(api_video, VIDEO_CID_ALIF_CSI_CURR_CAM, &current_sensor);
+		zassert_equal(ret, 0,
+				"video_get_ctrl(VIDEO_CID_ALIF_CSI_CURR_CAM) failed: %d", ret);
+		TC_PRINT("Selected camera: %s\n", (current_sensor) ? "Standard" : "Selfie");
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+
+	ret = video_set_capture_format(api_video, &fmt);
+	zassert_equal(ret, 0, "video_set_capture_format failed: %d", ret);
+
 	bsize = fmt.pitch * fmt.height;
 
-	ret = video_set_format(api_video, VIDEO_EP_OUT, &fmt);
-	zassert_equal(ret, 0, "set_format failed: %d", ret);
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		if (NUM_CAMS > 1) {
+			current_sensor ^= 1;
+			ret = video_set_ctrl(api_video, VIDEO_CID_ALIF_CSI_CURR_CAM,
+					&current_sensor);
+			if (ret) {
+				TC_PRINT("Unable to switch camera!");
+			}
+		}
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
+
+	/* video_set_capture_format() above already handled the ISP EP_OUT
+	 * configuration when ISP_ENABLED, so no extra set_format is needed
+	 * here regardless of build variant.
+	 */
+
+#if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
+		if (NUM_CAMS > 1) {
+			current_sensor = 0;
+			ret = video_set_ctrl(api_video, VIDEO_CID_ALIF_CSI_CURR_CAM,
+					&current_sensor);
+			if (ret) {
+				TC_PRINT("Unable to switch camera!");
+			}
+		}
+#endif /* CONFIG_VIDEO_ALIF_CAM_EXTENDED */
 
 	vbuf = video_buffer_alloc(bsize, K_NO_WAIT);
 	zassert_not_null(vbuf, "video_buffer_alloc returned NULL");
@@ -602,7 +635,7 @@ ZTEST(cpi_api_testcase, api_stream_start_stop_roundtrip)
 	TC_PRINT("api_stream_start_stop_roundtrip: stream stopped\n");
 
 	/* Drain any remaining buffers before release. */
-	video_flush(api_video, VIDEO_EP_OUT, true);
+	video_flush(api_video, VIDEO_EP_OUT, false);
 
 	struct video_buffer *out = NULL;
 

--- a/tests/drivers/video/src/video_common.c
+++ b/tests/drivers/video/src/video_common.c
@@ -70,6 +70,38 @@ int fourcc_to_pitch(uint32_t fourcc, uint32_t width)
 	return pitch;
 }
 
+int video_set_capture_format(const struct device *dev, struct video_format *fmt)
+{
+	int ret;
+
+	ret = video_set_format(dev, CAPTURE_EP, fmt);
+	if (ret) {
+		LOG_ERR("video_set_format on CAPTURE_EP (ep=%d) failed: %d",
+			CAPTURE_EP, ret);
+		return ret;
+	}
+
+#if ISP_ENABLED
+	/* On ISP-enabled builds the application sees OUTPUT_FORMAT on EP_OUT,
+	 * not the raw sensor format on EP_IN. Rewrite *fmt so the caller's
+	 * buffer-size math (pitch * height) targets the ISP output, then set
+	 * that format on EP_OUT.
+	 */
+	fmt->pixelformat = OUTPUT_FORMAT;
+	fmt->width       = ISP_OUTPUT_WIDTH;
+	fmt->height      = ISP_OUTPUT_HEIGHT;
+	fmt->pitch       = fourcc_to_pitch(fmt->pixelformat, fmt->width);
+
+	ret = video_set_format(dev, VIDEO_EP_OUT, fmt);
+	if (ret) {
+		LOG_ERR("video_set_format on VIDEO_EP_OUT failed: %d", ret);
+		return ret;
+	}
+#endif /* ISP_ENABLED */
+
+	return 0;
+}
+
 void manual_suite_before(void *fixture)
 {
 	ARG_UNUSED(fixture);

--- a/tests/drivers/video/src/video_common.h
+++ b/tests/drivers/video/src/video_common.h
@@ -49,7 +49,14 @@
 #endif
 
 #if ISP_ENABLED
-#define OUTPUT_FORMAT		VIDEO_PIX_FMT_RGB888_PLANAR_PRIVATE
+#define OUTPUT_FORMAT           VIDEO_PIX_FMT_RGB888_PLANAR_PRIVATE
+/* Resolution presented to the application on VIDEO_EP_OUT when the ISP is in
+ * the path. The ISP scaler down-samples the sensor frame to this size before
+ * conversion to OUTPUT_FORMAT, so buffers enqueued on EP_OUT must be sized
+ * for OUTPUT_FORMAT @ ISP_OUTPUT_WIDTH x ISP_OUTPUT_HEIGHT.
+ */
+#define ISP_OUTPUT_WIDTH        480
+#define ISP_OUTPUT_HEIGHT       480
 #endif
 
 #if (CONFIG_VIDEO_ALIF_CAM_EXTENDED && CONFIG_VIDEO_MIPI_CSI2_DW)
@@ -63,6 +70,36 @@ extern const struct device *video;
 
 /* Convert a fourcc pixel format to the pitch (bytes per row) for a given width. */
 int fourcc_to_pitch(uint32_t fourcc, uint32_t width);
+
+
+/**
+ * Configure the capture pipeline format on the appropriate endpoint(s).
+ *
+ * On a direct-CAM build (ISP disabled), this calls
+ *     video_set_format(dev, VIDEO_EP_OUT, fmt)
+ * exactly once and leaves *fmt untouched.
+ *
+ * On an ISP-enabled build (e.g. arx3a0 + vsi,isp-pico), this:
+ *   1. Sets the sensor / pipeline format on VIDEO_EP_IN (CAPTURE_EP),
+ *   2. Rewrites *fmt in place to OUTPUT_FORMAT @ ISP_OUTPUT_WIDTH x
+ *      ISP_OUTPUT_HEIGHT (with matching pitch),
+ *   3. Sets that output format on VIDEO_EP_OUT.
+ *
+ * The in-place rewrite means callers can keep their existing
+ * `bsize = fmt.pitch * fmt.height;` buffer-size math regardless of build
+ * variant — `fmt` after the call always describes what EP_OUT expects.
+ *
+ * @param dev   video device handle (alif,cam on direct-CAM, vsi,isp-pico
+ *              when the ISP is in the path).
+ * @param fmt   on entry: pipeline format (PIPELINE_FORMAT, sensor-side
+ *              w/h). On exit: identical on direct-CAM; OUTPUT_FORMAT
+ *              dimensions on ISP-enabled builds.
+ *
+ * @return 0 on success, or the first non-zero return code from
+ *         video_set_format().
+ */
+int video_set_capture_format(const struct device *dev,
+			     struct video_format *fmt);
 
 /* Suite "before" hook shared by manual + api test suites. */
 void manual_suite_before(void *fixture);

--- a/tests/drivers/video/testcase.yaml
+++ b/tests/drivers/video/testcase.yaml
@@ -65,3 +65,14 @@ tests:
       - cpi
       - isp
       - csi2
+
+  # ARX3A0 standard camera (no ISP, direct memory output)
+  drivers.video.cpi.arx3a0_standard:
+    extra_args:
+      - "DTC_OVERLAY_FILE=boards/serial_camera_arx3a0_standard.overlay"
+    filter: dt_compat_enabled("alif,cam") and dt_compat_enabled("onnn,arx3a0")
+    tags:
+      - drivers
+      - video
+      - cpi
+      - csi2


### PR DESCRIPTION
tests: drivers: video: Add ARX3A0 sensor support and ISP pipeline handdling

Update video test to support both MT9M114 (CPI) and ARX3A0 (CSI-2) sensors with ISP pipeline integration and improved test coverage.

- Add video_set_capture_format() for ISP pipeline config Sets sensor format on CAPTURE_EP (EP_IN for ISP, EP_OUT for direct-CAM). Rewrites format to OUTPUT_FORMAT @ 480x480 for ISP-enabled builds. Sets output format on VIDEO_EP_OUT when ISP is in pipeline.

- Add drivers.video.cpi.arx3a0_standard test case Validates RAW10 pixel format capture via MIPI CSI-2. Tests direct memory output path.

- Add ARX3A0 device tree overlays (selfie, standard, generic) Selfie camera with ISP integration. Standard camera with direct memory output.

- Add board-specific overlays for ARX3A0 on E8/E7 ISP config for RAW10 to RGB888_PLANAR_PRIVATE.

- Update documentation for ARX3A0 sensor support Add ARX3A0 to supported sensors (RAW10 via CSI-2). Generic build commands with placeholders.