### PR TITLE
manifest: Update Zephyr version to DW I2S restructure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 162e865ca29e29e2c3734de0c137b84b2501a6e6
+      revision: pull/551/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated the Zephyr version to DW I2S restructure
This PR depends on: https://github.com/alifsemi/zephyr_alif/pull/551