### PR TITLE
Application: Ble test application idle profile fix

### DIFF
--- a/applications/bletestapp/src/appl_shell.c
+++ b/applications/bletestapp/src/appl_shell.c
@@ -211,7 +211,9 @@ static int cmd_set_offprofile(const struct shell *shell, size_t argc, char **arg
 		}
 		shell_print(shell, "Off profile set to STOP");
 	} else if (!strcmp(argv[1], "IDLE")) {
-		ret = set_off_profile(PM_STATE_MODE_IDLE_1);
+		set_off_profile_configuration(PM_STATE_MODE_IDLE_1);
+		current_offp.power_domains |= PD_SESS_MASK;
+		ret = set_current_off_profile();
 
 		if (ret) {
 			shell_error(shell, "Failed to set off profile: %d", ret);

--- a/applications/bletestapp/src/power_mgr.c
+++ b/applications/bletestapp/src/power_mgr.c
@@ -150,7 +150,7 @@ int set_current_off_profile(void)
 	return ret;
 }
 
-int set_off_profile(const enum pm_state_mode_type pm_mode)
+int set_off_profile_configuration(const enum pm_state_mode_type pm_mode)
 {
 	/* Set default for stop mode with RTC wakeup support */
 	current_offp.power_domains = PD_VBAT_AON_MASK;
@@ -209,6 +209,13 @@ int set_off_profile(const enum pm_state_mode_type pm_mode)
 	current_offp.vtor_address = SCB->VTOR;
 	current_offp.vtor_address_ns = SCB->VTOR;
 
+	return 0;
+}
+
+int set_off_profile(const enum pm_state_mode_type pm_mode)
+{
+
+	set_off_profile_configuration(pm_mode);
 	return set_current_off_profile();
 }
 

--- a/applications/bletestapp/src/power_mgr.h
+++ b/applications/bletestapp/src/power_mgr.h
@@ -27,6 +27,9 @@ enum pm_state_mode_type {
 	PM_STATE_MODE_STOP_4,
 	PM_STATE_MODE_STOP_5
 };
+extern run_profile_t current_runp;
+extern off_profile_t current_offp;
+extern int16_t power_profile;
 
 int select_timer_source(enum lp_counter_source source);
 void app_sleep_start(uint32_t time_s);
@@ -34,5 +37,6 @@ void get_default_run_cfg(run_profile_t *runp);
 void get_default_off_cfg(off_profile_t *offp);
 int set_current_off_profile(void);
 int set_off_profile(const enum pm_state_mode_type pm_mode);
+int set_off_profile_configuration(const enum pm_state_mode_type pm_mode);
 int app_set_run_params(void);
 void app_prevent_off(void);

--- a/applications/bletestapp/src/power_shell.c
+++ b/applications/bletestapp/src/power_shell.c
@@ -19,10 +19,6 @@
 #include "power_defines.h"
 #include "power_shell.h"
 
-extern run_profile_t current_runp;
-extern off_profile_t current_offp;
-extern int16_t power_profile;
-
 LOG_MODULE_REGISTER(power_shell, CONFIG_MAIN_LOG_LEVEL);
 
 static int16_t get_power_profile(const char *power_profile)


### PR DESCRIPTION
Idle profile to be differentiated from Standby profile by adding Secure Encalve power. This directly changes the behaviour of SE with BLE.

Signed-off-by: Mika Tervonen <mika.tervonen@alifsemi.com>