### PR TITLE
samples: drivers: pm: add SPI DW power management demo

### DIFF
--- a/samples/drivers/pm/spi_dw/CMakeLists.txt
+++ b/samples/drivers/pm/spi_dw/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(spi_dw)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/pm/spi_dw/Kconfig
+++ b/samples/drivers/pm/spi_dw/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+mainmenu "Alif SPI DW Power Management Demo"
+
+source "Kconfig.zephyr"

--- a/samples/drivers/pm/spi_dw/README.rst
+++ b/samples/drivers/pm/spi_dw/README.rst
@@ -1,0 +1,150 @@
+.. _spi-dw-pm-sample:
+
+SPI DW Power Management Demo
+#############################
+
+Overview
+********
+
+This sample demonstrates Zephyr power management states combined with SPI DW
+loopback transfers on Alif RTSS cores. The application cycles through PM states
+and performs an SPI master/slave loopback after each wake, verifying that the
+SPI peripheral resumes correctly.
+
+PM states exercised (determined at runtime by capability predicates):
+
+- **S2RAM path** (TCM or SRAM0 retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  S2RAM STANDBY → S2RAM STOP → idle loop
+- **SOFT_OFF path** (MRAM boot, no retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  SOFT_OFF (system resets on wakeup)
+
+.. note::
+
+   Use LPUART port for console logs on E1C and B1 DevKits.
+
+Building and Running
+********************
+
+HE Core — TCM boot S2RAM (E7/E8/E1C/B1)
+=========================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/spi_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: spi-dw-pm-s2ram-tcm
+   :gen-args: -DCONFIG_FLASH_BASE_ADDRESS=0x0 -DCONFIG_FLASH_LOAD_OFFSET=0x0 -DCONFIG_FLASH_SIZE=256
+
+HE Core — MRAM boot SOFT_OFF (E7/E8/E1C/B1)
+=============================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/spi_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: spi-dw-pm-mram
+
+HP Core — MRAM boot SOFT_OFF (E7/E8)
+======================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/spi_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
+   :goals: build
+   :west-args: -p auto
+   :snippets: spi-dw-pm-mram
+
+HE Core — SRAM0 S2RAM (E8 only)
+================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/spi_dw
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: spi-dw-pm-s2ram-sram0
+
+HP Core — SRAM0 S2RAM (E8 only)
+================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/spi_dw
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p auto
+   :snippets: spi-dw-pm-s2ram-sram0
+
+Sample Output (S2RAM path)
+**************************
+
+The output below is from an E7 DK HE core TCM-boot run (``APP_PM_WAKEUP_DEBUG 0``,
+the default). Setting ``APP_PM_WAKEUP_DEBUG 1`` in ``main.c`` additionally prints
+``PM wakeup: NVIC ISPR[x] = 0x...`` lines on each resume.
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v4.1.0-607-g7fafce9cf3ee ***
+   [00:00:00.000,000] <inf> pm_spi_dw: alif_e7_dk (S2RAM): SPI DW PM demo (RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM STANDBY, S2RAM STOP)
+   [00:00:00.000,000] <inf> pm_spi_dw: POWER STATE SEQUENCE:
+   [00:00:00.000,000] <inf> pm_spi_dw:   1. PM_STATE_RUNTIME_IDLE
+   [00:00:00.000,000] <inf> pm_spi_dw:   2. PM_STATE_SUSPEND_TO_IDLE
+   [00:00:00.000,000] <inf> pm_spi_dw:   3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)
+   [00:00:00.000,000] <inf> pm_spi_dw:   4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)
+   [00:00:00.000,000] <inf> pm_spi_dw: [SPI Demo] before RUNTIME_IDLE
+   [00:00:00.000,000] <inf> pm_spi_dw: Slave Transceive Iter= 1
+   [00:00:00.101,000] <inf> pm_spi_dw: Master Transceive Iter= 1
+   [00:00:00.107,000] <inf> pm_spi_dw: Master wrote:   a5a50000 a5a50001 a5a50002 a5a50003 a5a50004
+   [00:00:00.107,000] <inf> pm_spi_dw: Master receive: 5a5a0000 5a5a0001 5a5a0002 5a5a0003 5a5a0004
+   [00:00:00.107,000] <inf> pm_spi_dw: SUCCESS: SPI Master RX & Slave TX DATA IS MATCHING: 0
+   [00:00:00.107,000] <inf> pm_spi_dw: slave wrote: 5a5a0000 5a5a0001 5a5a0002 5a5a0003 5a5a0004
+   [00:00:00.107,000] <inf> pm_spi_dw: slave read:  a5a50000 a5a50001 a5a50002 a5a50003 a5a50004
+   [00:00:00.107,000] <inf> pm_spi_dw: SUCCESS: SPI Master TX & Slave RX DATA IS MATCHING: 0
+   ... (iterations 2-10, one per second) ...
+   [00:00:09.170,000] <inf> pm_spi_dw: Slave Transfer Successfully Completed
+   [00:00:10.171,000] <inf> pm_spi_dw: Master Transfer Successfully Completed
+   [00:00:10.171,000] <inf> pm_spi_dw: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+   [00:00:28.172,000] <inf> pm_spi_dw: Exited from RUNTIME_IDLE sleep
+   [00:00:28.172,000] <inf> pm_spi_dw: Enter PM_STATE_SUSPEND_TO_IDLE for (10000 microseconds)
+   [00:00:28.173,000] <inf> pm_spi_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:28.173,000] <inf> pm_spi_dw: PM wakeup: SUSPEND_TO_IDLE (substate 0)
+   [00:00:28.173,000] <inf> pm_spi_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:28.183,000] <inf> pm_spi_dw: Exited from PM_STATE_SUSPEND_TO_IDLE
+   [00:00:28.183,000] <inf> pm_spi_dw: [SPI Demo] after SUSPEND_TO_IDLE
+   [00:00:28.183,000] <inf> pm_spi_dw: Slave Transceive Iter= 1
+   [00:00:28.284,000] <inf> pm_spi_dw: Master Transceive Iter= 1
+   [00:00:28.290,000] <inf> pm_spi_dw: Master wrote:   a5a50000 a5a50001 a5a50002 a5a50003 a5a50004
+   [00:00:28.290,000] <inf> pm_spi_dw: Master receive: 5a5a0000 5a5a0001 5a5a0002 5a5a0003 5a5a0004
+   [00:00:28.290,000] <inf> pm_spi_dw: SUCCESS: SPI Master RX & Slave TX DATA IS MATCHING: 0
+   [00:00:28.290,000] <inf> pm_spi_dw: slave wrote: 5a5a0000 5a5a0001 5a5a0002 5a5a0003 5a5a0004
+   [00:00:28.290,000] <inf> pm_spi_dw: slave read:  a5a50000 a5a50001 a5a50002 a5a50003 a5a50004
+   [00:00:28.290,000] <inf> pm_spi_dw: SUCCESS: SPI Master TX & Slave RX DATA IS MATCHING: 0
+   ... (iterations 2-10, one per second) ...
+   [00:00:37.353,000] <inf> pm_spi_dw: Slave Transfer Successfully Completed
+   [00:00:38.354,000] <inf> pm_spi_dw: Master Transfer Successfully Completed
+   [00:00:38.354,000] <inf> pm_spi_dw: Enter PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) for (6000000 microseconds)
+   [00:00:38.355,000] <inf> pm_spi_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:38.355,000] <inf> pm_spi_dw: PM wakeup: SUSPEND_TO_IDLE (substate 0)
+   [00:00:38.355,000] <inf> pm_spi_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:38.452,000] <inf> pm_spi_dw: PM enter: SUSPEND_TO_RAM (substate 0)
+   [00:00:38.452,000] <inf> pm_spi_dw: PM wakeup: SUSPEND_TO_RAM (substate 0)
+   [00:00:38.452,000] <inf> pm_spi_dw: PM exit:  SUSPEND_TO_RAM (substate 0)
+   [00:00:44.405,000] <inf> pm_spi_dw: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) ===
+   [00:00:44.405,000] <inf> pm_spi_dw: [SPI Demo] after S2RAM STANDBY
+   ... (10 transfer iterations, one per second) ...
+   [00:00:53.575,000] <inf> pm_spi_dw: Slave Transfer Successfully Completed
+   [00:00:54.576,000] <inf> pm_spi_dw: Master Transfer Successfully Completed
+   [00:00:54.576,000] <inf> pm_spi_dw: Enter PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) for (9000000 microseconds)
+   [00:00:54.577,000] <inf> pm_spi_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:54.577,000] <inf> pm_spi_dw: PM wakeup: SUSPEND_TO_IDLE (substate 0)
+   [00:00:54.577,000] <inf> pm_spi_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:54.674,000] <inf> pm_spi_dw: PM enter: SUSPEND_TO_RAM (substate 1)
+   [00:00:54.674,000] <inf> pm_spi_dw: PM wakeup: SUSPEND_TO_RAM (substate 1)
+   [00:00:54.674,000] <inf> pm_spi_dw: PM exit:  SUSPEND_TO_RAM (substate 1)
+   [00:01:03.622,000] <inf> pm_spi_dw: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) ===
+   [00:01:03.622,000] <inf> pm_spi_dw: [SPI Demo] after S2RAM STOP
+   ... (10 transfer iterations, one per second) ...
+   [00:01:12.792,000] <inf> pm_spi_dw: Slave Transfer Successfully Completed
+   [00:01:13.793,000] <inf> pm_spi_dw: Master Transfer Successfully Completed
+   [00:01:13.793,000] <inf> pm_spi_dw: === SPI DW PM SEQUENCE COMPLETED ===

--- a/samples/drivers/pm/spi_dw/prj.conf
+++ b/samples/drivers/pm/spi_dw/prj.conf
@@ -1,0 +1,34 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_SPI=y
+CONFIG_SPI_DW=y
+CONFIG_SPI_SLAVE=y
+CONFIG_SPI_LOG_LEVEL_INF=n
+CONFIG_SPI_LOG_LEVEL_DBG=n
+CONFIG_DMA=y
+CONFIG_SPI_DW_USE_DMA=y
+CONFIG_DMA_LOG_LEVEL_INF=n
+
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_IDLE_STACK_SIZE=1024
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_COUNTER=y
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_ASSERT=y
+
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=0
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=5
+CONFIG_LOG_BACKEND_UART=y

--- a/samples/drivers/pm/spi_dw/sample.yaml
+++ b/samples/drivers/pm/spi_dw/sample.yaml
@@ -1,0 +1,63 @@
+sample:
+  name: Alif SPI DW Power Management Demo
+  description: >
+    Demonstrates Zephyr power management states (PM_STATE_RUNTIME_IDLE,
+    PM_STATE_SUSPEND_TO_IDLE, PM_STATE_SUSPEND_TO_RAM, PM_STATE_SOFT_OFF)
+    for Alif RTSS cores with SPI DW loopback between PM state transitions.
+    PM states exercised are selected via build snippets: spi-dw-pm-s2ram-tcm
+    (HE TCM retention), spi-dw-pm-mram (MRAM boot SOFT_OFF, HE or HP), and
+    spi-dw-pm-s2ram-sram0 (SRAM0 retention S2RAM, E8 only, HE or HP).
+common:
+  tags:
+    - power
+    - pm
+    - spi
+    - dma
+    - counter
+    - rtc
+    - drivers
+  filter: SOC_FAMILY_ENSEMBLE or SOC_FAMILY_BALLETTO
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "SPI DW PM demo"
+      - "POWER STATE SEQUENCE"
+tests:
+  sample.drivers.spi.dw.pm.s2ram_tcm:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e8_dk_rtss_he
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=spi-dw-pm-s2ram-tcm
+  sample.drivers.spi.dw.pm.mram:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+      - alif_e8_dk_rtss_he
+      - alif_e8_dk_rtss_hp
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=spi-dw-pm-mram
+  sample.drivers.spi.dw.pm.s2ram_sram0:
+    platform_allow:
+      - alif_e8_dk_rtss_he
+      - alif_e8_dk_rtss_hp
+    integration_platforms:
+      - alif_e8_dk_rtss_he
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=spi-dw-pm-s2ram-sram0

--- a/samples/drivers/pm/spi_dw/snippets/pm_s2ram_common.conf
+++ b/samples/drivers/pm/spi_dw/snippets/pm_s2ram_common.conf
@@ -1,0 +1,3 @@
+# Common Kconfig for all S2RAM-capable snippets (TCM and SRAM0 retention paths)
+CONFIG_PM_S2RAM=y
+CONFIG_PM_SAU_SAVE_RESTORE=y

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_common.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_common.overlay
@@ -1,0 +1,46 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <9000000>;
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	status = "okay";
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+};
+
+/ {
+	chosen {
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_he.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HE core booting from MRAM.
+ * Uses RTC as wakeup source and idle timer.
+ */
+
+#include "pm_mram_common.overlay"
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+	};
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_hp.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/pm_mram_hp.overlay
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HP core booting from MRAM.
+ * Uses LPTIMER0 as wakeup source.
+ */
+
+#include "pm_mram_common.overlay"
+
+&timer0 {
+	status = "okay";
+};
+
+&utimer5 {
+	status = "disabled";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPTIMER0>;
+	ewic-cfg      = <ALIF_EWIC_VBAT_TIMER>;
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/prj.conf
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/prj.conf
@@ -1,0 +1,2 @@
+# PM MRAM boot - SOFT_OFF configuration (HE and HP)
+# MRAM boot uses SOFT_OFF; S2RAM (PM_S2RAM) is not enabled for this path.

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/snippet.yml
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/snippet.yml
@@ -1,0 +1,22 @@
+name: spi-dw-pm-mram
+append:
+  EXTRA_CONF_FILE: prj.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e7_he.overlay
+  /alif_e7.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e7_hp.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e8_he.overlay
+  /alif_e8.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e8_hp.overlay

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_b1.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_b1.overlay
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: LPSPI0 (master) + SPI1 (slave), DMA2, evtrtr2.
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &lpspi0;
+		slave-spi = &spi1;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&lpspi0 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 1, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 1, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi1 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e1c.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e1c.overlay
@@ -1,0 +1,61 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: LPSPI0 (master) + SPI0 (slave), DMA2, evtrtr2.
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ * Console: lpuart (overrides uart2 set by pm_mram_common.overlay).
+ */
+
+#include "pm_mram_he.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	chosen {
+		zephyr,console    = &lpuart;
+		zephyr,shell-uart = &lpuart;
+	};
+	aliases {
+		master-spi = &lpspi0;
+		slave-spi = &spi0;
+	};
+};
+
+&uart2 {
+	status = "disabled";
+};
+
+&lpuart {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&lpspi0 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 1, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 1, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e7_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e7_he.overlay
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: SPI4 (master) + SPI0 (slave), DMA2 + DMA0, evtrtr2 + evtrtr0.
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi4;
+		slave-spi = &spi0;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi4 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e7_hp.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e7_hp.overlay
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HP: SPI1 (master) + SPI0 (slave), DMA0, evtrtr0.
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi1;
+		slave-spi = &spi0;
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "okay";
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(0, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(1, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e8_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e8_he.overlay
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: SPI4 (master) + SPI1 (slave), DMA2 + DMA0, evtrtr2 + evtrtr0.
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi4;
+		slave-spi = &spi1;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi4 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi1 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e8_hp.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-mram/spi_dw_e8_hp.overlay
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HP: SPI1 (master) + SPI0 (slave), DMA0, evtrtr0.
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi1;
+		slave-spi = &spi0;
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "okay";
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(0, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(1, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_common.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_common.overlay
@@ -1,0 +1,88 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * Common PM S2RAM overlay for SRAM0 retention builds (HE and HP cores).
+ *
+ * Both cores require a first-stage loader (placed at MRAM before the Zephyr
+ * app image) to power up SRAM0 before execution reaches the application.
+ * SRAM0 retention masks (ALIF_SRAM0_*_RET_MASK) are Ensemble Gen2 specific.
+ */
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&standby_s2ram {
+	min-residency-us = <5000000>;
+	status = "okay";
+};
+
+&stop_s2ram {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&suspend_idle {
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+				ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
+};
+
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	memory-blocks = <(ALIF_SRAM0_MASK | ALIF_SRAM1_MASK |
+			  ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+			  ALIF_SRAM0_1_RET_MASK | ALIF_SRAM0_2_RET_MASK |
+			  ALIF_SRAM0_3_RET_MASK | ALIF_SRAM0_4_RET_MASK |
+			  ALIF_SRAM1_RET_MASK)>;
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	memory-blocks = <(ALIF_SRAM0_MASK | ALIF_SRAM1_MASK |
+			  ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+			  ALIF_SRAM0_1_RET_MASK | ALIF_SRAM0_2_RET_MASK |
+			  ALIF_SRAM0_3_RET_MASK | ALIF_SRAM0_4_RET_MASK |
+			  ALIF_SRAM1_RET_MASK)>;
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,sram                = &sram0;
+		zephyr,cortex-m-idle-timer = &rtc0;
+		zephyr,console             = &uart2;
+	};
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_he.overlay
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM S2RAM overlay for HE core with SRAM0 as data RAM.
+ * The aipm_off vtor-address points to the first-stage loader at MRAM
+ * 0x80000000 so the SE restores execution there on wakeup.
+ */
+
+#include "pm_sram0_common.overlay"

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_hp.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/pm_sram0_hp.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM S2RAM overlay for HP core with SRAM0 as data RAM.
+ *
+ * The aipm_off vtor-address points to the first-stage loader at MRAM
+ * 0x80100000 so the SE restores execution there on wakeup.
+ *
+ */
+
+#include "pm_sram0_common.overlay"
+
+&timer0 {
+	status = "disabled";
+};
+
+&utimer5 {
+	status = "disabled";
+};
+
+&aipm_off {
+	vtor-address = <0x80100000>;
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/snippet.yml
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/snippet.yml
@@ -1,0 +1,10 @@
+name: spi-dw-pm-s2ram-sram0
+append:
+  EXTRA_CONF_FILE: ../pm_s2ram_common.conf
+boards:
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e8_he.overlay
+  /alif_e8.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e8_hp.overlay

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/spi_dw_e8_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/spi_dw_e8_he.overlay
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: SPI4 (master) + SPI1 (slave), DMA2 + DMA0, evtrtr2 + evtrtr0.
+ * PM: SRAM0 retention S2RAM (HE, RTC wakeup).
+ */
+
+#include "pm_sram0_he.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi4;
+		slave-spi = &spi1;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi4 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi1 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/spi_dw_e8_hp.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-sram0/spi_dw_e8_hp.overlay
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HP: SPI1 (master) + SPI0 (slave), DMA0, evtrtr0.
+ * PM: SRAM0 retention S2RAM (HP, RTC wakeup).
+ */
+
+#include "pm_sram0_hp.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi1;
+		slave-spi = &spi0;
+	};
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "okay";
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(0, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(1, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_common.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_common.overlay
@@ -1,0 +1,74 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <9000000>;
+	status = "okay";
+};
+
+&standby_s2ram {
+	min-residency-us = <5000000>;
+	status = "okay";
+};
+
+&stop_s2ram {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&suspend_idle {
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	vtor-address = <0x00000000>;
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
@@ -1,0 +1,33 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble E1C and Balletto B1 SoCs.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
@@ -1,0 +1,28 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble and Ensemble Gen2
+ * SoCs - HE core TCM boot S2RAM.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/snippet.yml
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/snippet.yml
@@ -1,0 +1,16 @@
+name: spi-dw-pm-s2ram-tcm
+append:
+  EXTRA_CONF_FILE: ../pm_s2ram_common.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e7_he.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: spi_dw_e8_he.overlay

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_b1.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_b1.overlay
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: LPSPI0 (master) + SPI1 (slave), DMA2, evtrtr2.
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &lpspi0;
+		slave-spi = &spi1;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&lpspi0 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 1, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 1, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi1 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e1c.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e1c.overlay
@@ -1,0 +1,61 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: LPSPI0 (master) + SPI0 (slave), DMA2, evtrtr2.
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ * Console: lpuart (overrides uart2 set by pm_tcm_e1c_b1.overlay).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	chosen {
+		zephyr,console    = &lpuart;
+		zephyr,shell-uart = &lpuart;
+	};
+	aliases {
+		master-spi = &lpspi0;
+		slave-spi = &spi0;
+	};
+};
+
+&uart2 {
+	status = "disabled";
+};
+
+&lpuart {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&lpspi0 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 1, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 1, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e7_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e7_he.overlay
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: SPI4 (master) + SPI0 (slave), DMA2 + DMA0, evtrtr2 + evtrtr0.
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi4;
+		slave-spi = &spi0;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi4 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi0 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 20>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 16>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e8_he.overlay
+++ b/samples/drivers/pm/spi_dw/snippets/spi-dw-pm-s2ram-tcm/spi_dw_e8_he.overlay
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: SPI4 (master) + SPI1 (slave), DMA2 + DMA0, evtrtr2 + evtrtr0.
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+#include <zephyr/dt-bindings/dma/alif_dma_event_router.h>
+
+/ {
+	aliases {
+		master-spi = &spi4;
+		slave-spi = &spi1;
+	};
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&evtrtr2 {
+	status = "okay";
+};
+
+&evtrtr0 {
+	status = "okay";
+};
+
+&spi4 {
+	status = "okay";
+	dmas = <&evtrtr2 ALIF_DMA_ENCODE(0, 0, 1) 13>,
+	       <&evtrtr2 ALIF_DMA_ENCODE(1, 0, 1) 12>;
+	dma-names = "txdma", "rxdma";
+};
+
+&spi1 {
+	status = "okay";
+	serial-target;
+	dmas = <&evtrtr0 ALIF_DMA_ENCODE(2, 2, 1) 21>,
+	       <&evtrtr0 ALIF_DMA_ENCODE(3, 2, 1) 17>;
+	dma-names = "txdma", "rxdma";
+};

--- a/samples/drivers/pm/spi_dw/src/main.c
+++ b/samples/drivers/pm/spi_dw/src/main.c
@@ -1,0 +1,640 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/spi.h>
+#include <string.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(pm_spi_dw, LOG_LEVEL_INF);
+
+/* Set to 1 to dump full NVIC ISPR state on wakeup */
+#define APP_PM_WAKEUP_DEBUG 0
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
+#else
+#error "Wakeup Device not enabled in the dts"
+#endif
+
+/*
+ * Sleep duration constants for each PM state.
+ *
+ * Upper bound: at 400 MHz, ticks to cycles calculation in PM driver
+ * overflows uint32 max for values > 10.7s (2^32 / 400). All deep-sleep
+ * durations and overlay min-residency-us values must stay below this ceiling.
+ */
+/* Sleep duration for PM_STATE_RUNTIME_IDLE */
+#define RUNTIME_IDLE_SLEEP_USEC (18 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_IDLE */
+#define SUSPEND_IDLE_SLEEP_USEC (10 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 0 (STANDBY) */
+#define S2RAM_STANDBY_SLEEP_USEC (6 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 1 (STOP) */
+#define S2RAM_STOP_SLEEP_USEC (9 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SOFT_OFF */
+#define SOFT_OFF_SLEEP_USEC (10 * 1000 * 1000)
+
+/*
+ * MRAM base address - used to determine boot location
+ * TCM boot: VTOR = 0x0
+ * MRAM boot: VTOR >= 0x80000000
+ */
+#define MRAM_BASE_ADDRESS 0x80000000
+
+#define IS_BOOTING_FROM_MRAM() (SCB->VTOR >= MRAM_BASE_ADDRESS)
+
+/*
+ * True when the DTS chosen zephyr,sram points at sram0. The snippet overlay
+ * is responsible for ensuring SRAM0 has retention support on the target board.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(sram0))
+#define IS_SRAM0_CONFIGURED_AS_RAM() \
+	DT_SAME_NODE(DT_CHOSEN(zephyr_sram), DT_NODELABEL(sram0))
+#else
+#define IS_SRAM0_CONFIGURED_AS_RAM() 0
+#endif
+
+/*
+ * S2RAM_SUPPORTED — retention-capable sleep is possible when:
+ *   - SRAM0 is the configured data RAM (HE or HP, E8 only), OR
+ *   - HE core booting from TCM (TCM has hardware retention)
+ *
+ * SOFT_OFF_SUPPORTED — mutually exclusive with S2RAM: used when no
+ * retained RAM is available (HP-TCM, HE-MRAM boot without SRAM0).
+ */
+#define S2RAM_SUPPORTED \
+	(IS_SRAM0_CONFIGURED_AS_RAM() || \
+	 (IS_ENABLED(CONFIG_RTSS_HE) && !IS_BOOTING_FROM_MRAM()))
+
+#define SOFT_OFF_SUPPORTED (!S2RAM_SUPPORTED)
+
+/* Validate ordering of deep-sleep durations at compile time */
+BUILD_ASSERT(S2RAM_STOP_SLEEP_USEC > S2RAM_STANDBY_SLEEP_USEC,
+	"STOP sleep duration must be greater than STANDBY sleep duration");
+BUILD_ASSERT(SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC,
+	"SOFT_OFF sleep duration must be greater than STOP sleep duration");
+
+/**
+ * Helper function to lock/unlock deeper power states.
+ * @param lock true → lock all deep states (allow RUNTIME_IDLE only)
+ *             false → unlock the applicable state; keep the other locked
+ */
+static void app_pm_lock_deeper_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
+}
+
+/*
+ * Lock every PM sleep state deeper than RUNTIME_IDLE. Intended for use around
+ * peripheral transfers (see spi_loopback_run()) and around any sleep call the
+ * app makes where an accidental upgrade to a deeper state must be prevented.
+ */
+static void app_pm_lock_sleep_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+#if !defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+static volatile uint32_t alarm_cb_status;
+static void alarm_callback_fn(const struct device *wakeup_dev,
+				uint8_t chan_id, uint32_t ticks,
+				void *user_data)
+{
+	LOG_DBG("%s: Alarm triggered", wakeup_dev->name);
+	alarm_cb_status = 1;
+}
+#endif
+
+static int app_enter_normal_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg;
+	int ret;
+
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Could not set the alarm");
+		return ret;
+	}
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+
+	k_sleep(K_USEC(sleep_usec));
+
+	if (!alarm_cb_status) {
+		return -1;
+	}
+	alarm_cb_status = 0;
+
+#endif
+	return 0;
+}
+
+static int app_enter_deep_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	/*
+	 * Set a delay more than the min-residency-us configured so that
+	 * the sub-system will go to OFF state.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg;
+	int ret;
+	/*
+	 * Set the alarm and delay so that idle thread can run
+	 */
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set the alarm (err %d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+	/*
+	 * Wait for the alarm to trigger. The idle thread will
+	 * take care of entering the deep sleep state via PM framework.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#endif
+
+	return 0;
+}
+
+/* master_spi and slave_spi aliases are defined in
+ * overlay files to use different SPI instance if needed.
+ */
+#define SPIDW_NODE   DT_ALIAS(master_spi)
+#define S_SPIDW_NODE DT_ALIAS(slave_spi)
+
+/* size of stack area used by each thread */
+#define STACKSIZE 1024
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
+/* scheduling priority used by each thread,
+ * as we are testing Loopback on the same board,
+ * make sure master priority is higher than slave priority.
+ */
+#define MASTER_PRIORITY 6
+#define SLAVE_PRIORITY  7
+
+/* Master and Slave buffer size */
+#define BUFF_SIZE  200
+
+/* Master and Slave buffer word size */
+#define SPI_WORD_SIZE 8
+
+/* Master and Slave buffer frequency */
+#define Mhz 1000000
+#define SPI_FREQUENCY (1 * Mhz)
+
+/* Master and Slave buffer transfers */
+#define SPI_NUM_TRANSFERS  10
+
+/*
+ * Signaling semaphores: main gives start sems to kick off a transfer round;
+ * threads give done sems when the round finishes. Both sets survive S2RAM in
+ * retained RAM so threads resume from k_sem_take() without re-creation.
+ */
+static struct k_sem slave_start_sem;
+static struct k_sem master_start_sem;
+static struct k_sem slave_done_sem;
+static struct k_sem master_done_sem;
+
+/* Master and Slave buffers */
+static uint32_t master_txdata[BUFF_SIZE];
+static uint32_t master_rxdata[BUFF_SIZE];
+static uint32_t slave_txdata[BUFF_SIZE];
+static uint32_t slave_rxdata[BUFF_SIZE];
+
+K_THREAD_STACK_DEFINE(MasterT_stack, STACKSIZE);
+static struct k_thread MasterT_data;
+
+K_THREAD_STACK_DEFINE(SlaveT_stack, STACKSIZE);
+static struct k_thread SlaveT_data;
+
+/*
+ * Send/Receive data through slave spi
+ */
+int slave_spi_transceive(const struct device *dev)
+{
+	struct spi_config cnfg;
+	int ret;
+
+	cnfg.frequency = SPI_FREQUENCY;
+	cnfg.operation = SPI_OP_MODE_SLAVE | SPI_WORD_SET(SPI_WORD_SIZE);
+	cnfg.slave = 0;
+
+	int length = (BUFF_SIZE) * sizeof(slave_rxdata[0]);
+
+	struct spi_buf rx_buf = {
+		.buf = slave_rxdata,
+		.len = length
+	};
+	struct spi_buf_set rx_bufset = {
+		.buffers = &rx_buf,
+		.count = 1
+	};
+	struct spi_buf tx_buf = {
+		.buf = slave_txdata,
+		.len = length
+	};
+	struct spi_buf_set tx_bufset = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+
+	ret = spi_transceive(dev, &cnfg, &tx_bufset, &rx_bufset);
+	if (ret < 0) {
+		LOG_ERR("Slave SPI transceive error: %d", ret);
+	}
+
+	LOG_INF("slave wrote: %08x %08x %08x %08x %08x",
+		slave_txdata[0], slave_txdata[1], slave_txdata[2],
+		slave_txdata[3], slave_txdata[4]);
+
+	LOG_INF("slave read:  %08x %08x %08x %08x %08x",
+		slave_rxdata[0], slave_rxdata[1], slave_rxdata[2],
+		slave_rxdata[3], slave_rxdata[4]);
+
+	ret = memcmp(master_txdata, slave_rxdata, length);
+	if (ret) {
+		LOG_ERR("SPI master TX & slave RX data mismatch: %d", ret);
+	} else {
+		LOG_INF("SUCCESS: SPI Master TX & Slave RX DATA IS MATCHING: 0");
+	}
+
+	return ret;
+}
+
+/*
+ * Send/Receive data through master spi
+ */
+int master_spi_transceive(const struct device *dev, struct spi_cs_control *cs)
+{
+	struct spi_config cnfg;
+	int ret;
+
+	cnfg.frequency = SPI_FREQUENCY;
+	cnfg.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(SPI_WORD_SIZE);
+	cnfg.slave = 0;
+	cnfg.cs = *cs;
+
+	int length = (BUFF_SIZE) * sizeof(master_txdata[0]);
+
+	struct spi_buf tx_buf = {
+		.buf = master_txdata,
+		.len = length
+	};
+
+	struct spi_buf_set tx_bufset = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+
+	struct spi_buf rx_buf = {
+		.buf = master_rxdata,
+		.len = length
+	};
+	struct spi_buf_set rx_bufset = {
+		.buffers = &rx_buf,
+		.count = 1
+	};
+
+	ret = spi_transceive(dev, &cnfg, &tx_bufset, &rx_bufset);
+	if (ret) {
+		LOG_ERR("SPI=%s transceive error: %d", dev->name, ret);
+	}
+	LOG_INF("Master wrote:   %08x %08x %08x %08x %08x",
+		master_txdata[0], master_txdata[1], master_txdata[2],
+		master_txdata[3], master_txdata[4]);
+	LOG_INF("Master receive: %08x %08x %08x %08x %08x",
+		master_rxdata[0], master_rxdata[1], master_rxdata[2],
+		master_rxdata[3], master_rxdata[4]);
+
+	ret = memcmp(master_rxdata, slave_txdata, length);
+	if (ret) {
+		LOG_ERR("SPI master RX & slave TX data mismatch: %d", ret);
+	} else {
+		LOG_INF("SUCCESS: SPI Master RX & Slave TX DATA IS MATCHING: 0");
+	}
+
+	return ret;
+}
+
+static void prepare_data(uint32_t *data, uint16_t def_mask)
+{
+	for (uint32_t cnt = 0; cnt < BUFF_SIZE; cnt++) {
+		data[cnt] = (def_mask << 16) | cnt;
+	}
+}
+
+/*
+ * Master SPI thread. Blocks on master_start_sem between rounds.
+ * After S2RAM wakeup, retained RAM keeps the thread context intact and it
+ * resumes from k_sem_take() — no re-creation required.
+ */
+static void master_spi_thread(void *p1, void *p2, void *p3)
+{
+	const struct device *const dev = DEVICE_DT_GET(SPIDW_NODE);
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: Master device not ready", dev->name);
+		return;
+	}
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	struct spi_cs_control cs_ctrl = (struct spi_cs_control){
+		.gpio  = GPIO_DT_SPEC_GET(SPIDW_NODE, cs_gpios),
+		.delay = 100u,
+	};
+#else
+	struct spi_cs_control cs_ctrl = {0};
+#endif
+
+	while (true) {
+		k_sem_take(&master_start_sem, K_FOREVER);
+		for (uint32_t i = 0; i < SPI_NUM_TRANSFERS; i++) {
+			LOG_INF("Master Transceive Iter= %u", i + 1);
+			if (master_spi_transceive(dev, &cs_ctrl) < 0) {
+				LOG_ERR("Stopping the Master Thread due to error");
+				break;
+			}
+			k_msleep(1000);
+		}
+		LOG_INF("Master Transfer Successfully Completed");
+		k_sem_give(&master_done_sem);
+	}
+}
+
+/*
+ * Slave SPI thread. Blocks on slave_start_sem between rounds.
+ * After S2RAM wakeup, retained RAM keeps the thread context intact and it
+ * resumes from k_sem_take() — no re-creation required.
+ */
+static void slave_spi_thread(void *p1, void *p2, void *p3)
+{
+	const struct device *const slave_dev = DEVICE_DT_GET(S_SPIDW_NODE);
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	if (!device_is_ready(slave_dev)) {
+		LOG_ERR("%s: Slave device not ready", slave_dev->name);
+		return;
+	}
+
+	while (true) {
+		k_sem_take(&slave_start_sem, K_FOREVER);
+		for (uint32_t i = 0; i < SPI_NUM_TRANSFERS; i++) {
+			LOG_INF("Slave Transceive Iter= %u", i + 1);
+			if (slave_spi_transceive(slave_dev) < 0) {
+				LOG_ERR("Stopping the Slave Thread due to error");
+				break;
+			}
+		}
+		LOG_INF("Slave Transfer Successfully Completed");
+		k_sem_give(&slave_done_sem);
+	}
+}
+
+/*
+ * Signal both SPI threads to run one round of transfers and wait for
+ * completion. Slave is armed 100 ms before master to ensure the slave SPI
+ * peripheral is ready to receive before the master starts the transaction.
+ */
+static void spi_loopback_run(const char *phase_label)
+{
+	app_pm_lock_sleep_states(true);
+	LOG_INF("[SPI Demo] %s", phase_label);
+	prepare_data(master_txdata, 0xA5A5);
+	prepare_data(slave_txdata, 0x5A5A);
+	k_sem_give(&slave_start_sem);
+	k_msleep(100);
+	k_sem_give(&master_start_sem);
+	k_sem_take(&slave_done_sem, K_FOREVER);
+	k_sem_take(&master_done_sem, K_FOREVER);
+	app_pm_lock_sleep_states(false);
+}
+
+/* PM state name lookup for notifier logging */
+static const char * const pm_state_names[] = {
+	[PM_STATE_ACTIVE]          = "ACTIVE",
+	[PM_STATE_RUNTIME_IDLE]    = "RUNTIME_IDLE",
+	[PM_STATE_SUSPEND_TO_IDLE] = "SUSPEND_TO_IDLE",
+	[PM_STATE_STANDBY]         = "STANDBY",
+	[PM_STATE_SUSPEND_TO_RAM]  = "SUSPEND_TO_RAM",
+	[PM_STATE_SUSPEND_TO_DISK] = "SUSPEND_TO_DISK",
+	[PM_STATE_SOFT_OFF]        = "SOFT_OFF",
+};
+
+#define PM_STATE_STR(s) \
+	((s) < ARRAY_SIZE(pm_state_names) ? pm_state_names[(s)] : "UNKNOWN")
+
+static void pm_notify_entry(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+
+	LOG_INF("PM enter: %s (substate %u)", PM_STATE_STR(state), info->substate_id);
+}
+
+/*
+ * With CONFIG_LOG_MODE_DEFERRED, LOG_INF here only writes to the ring buffer
+ * — no UART access — so this is safe even before devices are resumed.
+ */
+static void pm_notify_pre_resume(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint32_t active_exc = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
+
+	if (active_exc >= 16U) {
+		LOG_INF("PM wakeup: %s (substate %u) IRQ %u",
+			PM_STATE_STR(state), info->substate_id, active_exc - 16U);
+	} else if (active_exc != 0U) {
+		LOG_INF("PM wakeup: %s (substate %u) exception %u",
+			PM_STATE_STR(state), info->substate_id, active_exc);
+	} else {
+		LOG_INF("PM wakeup: %s (substate %u)",
+			PM_STATE_STR(state), info->substate_id);
+	}
+#if APP_PM_WAKEUP_DEBUG
+	for (int i = 0; i < 16; i++) {
+		if (NVIC->ISPR[i]) {
+			LOG_INF("PM wakeup: NVIC ISPR[%d] = 0x%08x", i, NVIC->ISPR[i]);
+		}
+	}
+#endif
+}
+
+static void pm_notify_exit(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+
+	LOG_INF("PM exit:  %s (substate %u)", PM_STATE_STR(state), info->substate_id);
+}
+
+static struct pm_notifier app_pm_notifier = {
+	.state_entry       = pm_notify_entry,
+	.pre_device_resume = pm_notify_pre_resume,
+	.state_exit        = pm_notify_exit,
+};
+
+int main(void)
+{
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	int ret;
+
+	__ASSERT(device_is_ready(cons), "%s: device not ready", cons->name);
+	__ASSERT(device_is_ready(wakeup_dev), "%s: device not ready", wakeup_dev->name);
+
+	pm_notifier_register(&app_pm_notifier);
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("%s (S2RAM): SPI DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM STANDBY, S2RAM STOP)",
+			CONFIG_BOARD);
+	} else {
+		LOG_INF("%s (SOFT_OFF): SPI DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)",
+			CONFIG_BOARD);
+	}
+
+	ret = counter_start(wakeup_dev);
+	__ASSERT(!ret || ret == -EALREADY, "Failed to start counter (err %d)", ret);
+
+	k_sem_init(&slave_start_sem, 0, 1);
+	k_sem_init(&master_start_sem, 0, 1);
+	k_sem_init(&slave_done_sem, 0, 1);
+	k_sem_init(&master_done_sem, 0, 1);
+
+	/*
+	 * Create SPI threads once. They loop on their start semaphores so after
+	 * S2RAM wakeup they resume from k_sem_take() without re-creation.
+	 */
+	k_thread_create(&SlaveT_data, SlaveT_stack, STACKSIZE,
+			slave_spi_thread, NULL, NULL, NULL,
+			SLAVE_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&MasterT_data, MasterT_stack, STACKSIZE,
+			master_spi_thread, NULL, NULL, NULL,
+			MASTER_PRIORITY, 0, K_NO_WAIT);
+
+	LOG_INF("POWER STATE SEQUENCE:");
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("  3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)");
+		LOG_INF("  4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)");
+	} else {
+		LOG_INF("  3. PM_STATE_SOFT_OFF");
+	}
+
+	spi_loopback_run("before RUNTIME_IDLE");
+
+	LOG_INF("Enter RUNTIME_IDLE sleep for (%d microseconds)", RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(true);
+	ret = app_enter_normal_sleep(RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(false);
+	__ASSERT(ret == 0, "Could not enter RUNTIME_IDLE sleep (err %d)", ret);
+
+	LOG_INF("Exited from RUNTIME_IDLE sleep");
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	LOG_INF("Request SUSPEND_TO_IDLE for %d us", SUSPEND_IDLE_SLEEP_USEC);
+	app_pm_lock_deeper_states(true);
+	k_sleep(K_USEC(SUSPEND_IDLE_SLEEP_USEC));
+	app_pm_lock_deeper_states(false);
+	spi_loopback_run("after SUSPEND_TO_IDLE");
+#else
+	/* Lock SUSPEND_TO_IDLE when LPM timer support is not configured */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("PM_STATE_SUSPEND_TO_IDLE (skipped - LPM timer not enabled)");
+#endif
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("Request S2RAM STANDBY for %d us", S2RAM_STANDBY_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STANDBY_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		spi_loopback_run("after S2RAM STANDBY");
+
+		LOG_INF("Request S2RAM STOP for %d us", S2RAM_STOP_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STOP_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		spi_loopback_run("after S2RAM STOP");
+	}
+
+	if (SOFT_OFF_SUPPORTED) {
+		LOG_INF("Request SOFT_OFF for %d us (no retention - system resets on wakeup)",
+			SOFT_OFF_SLEEP_USEC);
+		ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+		/* Should never reach here - SOFT_OFF causes full reset on wakeup */
+		LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+		__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+	}
+
+	LOG_INF("=== SPI DW PM SEQUENCE COMPLETED ===");
+
+	app_pm_lock_deeper_states(true);
+	/* Demo complete — prevent SUSPEND_TO_IDLE so the idle spin stays in RUNTIME_IDLE */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+	while (true) {
+		/* spin here */
+		k_sleep(K_SECONDS(1));
+	}
+
+	return 0;
+}

--- a/samples/drivers/pm/spi_dw/src/main.c
+++ b/samples/drivers/pm/spi_dw/src/main.c
@@ -1,0 +1,664 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/spi.h>
+#include <string.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(pm_spi_dw, LOG_LEVEL_INF);
+
+/* Set to 1 to dump full NVIC ISPR state on wakeup */
+#define APP_PM_WAKEUP_DEBUG 0
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
+#else
+#error "Wakeup Device not enabled in the dts"
+#endif
+
+/*
+ * Sleep duration constants for each PM state.
+ *
+ * Upper bound: at 400 MHz, ticks-to-cycles calculation in the PM driver
+ * overflows uint32 max for values > 10.7s (2^32 / 400). Deep-sleep durations
+ * (S2RAM, SOFT_OFF) and overlay min-residency-us values must stay below this
+ * ceiling. RUNTIME_IDLE may exceed it because deeper states are locked out
+ * during that sleep (see app_pm_lock_sleep_states()).
+ */
+/* Sleep duration for PM_STATE_RUNTIME_IDLE */
+#define RUNTIME_IDLE_SLEEP_USEC (18 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_IDLE */
+#define SUSPEND_IDLE_SLEEP_USEC (10 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 0 (STANDBY) */
+#define S2RAM_STANDBY_SLEEP_USEC (6 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 1 (STOP) */
+#define S2RAM_STOP_SLEEP_USEC (9 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SOFT_OFF */
+#define SOFT_OFF_SLEEP_USEC (10 * 1000 * 1000)
+
+/*
+ * MRAM base address - used to determine boot location
+ * TCM boot: VTOR = 0x0
+ * MRAM boot: VTOR >= 0x80000000
+ */
+#define MRAM_BASE_ADDRESS 0x80000000
+
+#define IS_BOOTING_FROM_MRAM() (SCB->VTOR >= MRAM_BASE_ADDRESS)
+
+/*
+ * True when the DTS chosen zephyr,sram points at sram0. The snippet overlay
+ * is responsible for ensuring SRAM0 has retention support on the target board.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(sram0)) && DT_HAS_CHOSEN(zephyr_sram)
+#define IS_SRAM0_CONFIGURED_AS_RAM() \
+	DT_SAME_NODE(DT_CHOSEN(zephyr_sram), DT_NODELABEL(sram0))
+#else
+#define IS_SRAM0_CONFIGURED_AS_RAM() 0
+#endif
+
+/*
+ * S2RAM_SUPPORTED — retention-capable sleep is possible when:
+ *   - SRAM0 is the configured data RAM (HE or HP, E8 only), OR
+ *   - HE core booting from TCM (TCM has hardware retention)
+ *
+ * SOFT_OFF_SUPPORTED — mutually exclusive with S2RAM: used when no
+ * retained RAM is available (HP-TCM, HE-MRAM boot without SRAM0).
+ */
+#define S2RAM_SUPPORTED \
+	(IS_SRAM0_CONFIGURED_AS_RAM() || \
+	 (IS_ENABLED(CONFIG_RTSS_HE) && !IS_BOOTING_FROM_MRAM()))
+
+#define SOFT_OFF_SUPPORTED (!S2RAM_SUPPORTED)
+
+/* Validate ordering of deep-sleep durations at compile time */
+BUILD_ASSERT(S2RAM_STOP_SLEEP_USEC > S2RAM_STANDBY_SLEEP_USEC,
+	"STOP sleep duration must be greater than STANDBY sleep duration");
+BUILD_ASSERT(SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC,
+	"SOFT_OFF sleep duration must be greater than STOP sleep duration");
+
+/**
+ * Helper function to lock/unlock deeper power states.
+ * @param lock true  → lock both deep states (S2RAM and SOFT_OFF)
+ *             false → unlock both deep states
+ */
+static void app_pm_lock_deeper_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
+}
+
+/*
+ * Lock every PM sleep state deeper than RUNTIME_IDLE. Intended for use around
+ * peripheral transfers (see spi_loopback_run()) and around any sleep call the
+ * app makes where an accidental upgrade to a deeper state must be prevented.
+ */
+static void app_pm_lock_sleep_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+#if !defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+static volatile uint32_t alarm_cb_status;
+static void alarm_callback_fn(const struct device *wakeup_dev,
+				uint8_t chan_id, uint32_t ticks,
+				void *user_data)
+{
+	LOG_DBG("%s: Alarm triggered", wakeup_dev->name);
+	alarm_cb_status = 1;
+}
+#endif
+
+static int app_enter_normal_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Could not set the alarm");
+		return ret;
+	}
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+
+	k_sleep(K_USEC(sleep_usec));
+
+	if (!alarm_cb_status) {
+		return -1;
+	}
+	alarm_cb_status = 0;
+
+#endif
+	return 0;
+}
+
+static int app_enter_deep_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	/*
+	 * Set a delay more than the min-residency-us configured so that
+	 * the sub-system will go to OFF state.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+	/*
+	 * Set the alarm and delay so that idle thread can run
+	 */
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set the alarm (err %d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+	/*
+	 * Wait for the alarm to trigger. The idle thread will
+	 * take care of entering the deep sleep state via PM framework.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#endif
+
+	return 0;
+}
+
+/* master_spi and slave_spi aliases are defined in
+ * overlay files to use different SPI instance if needed.
+ */
+#define SPIDW_NODE   DT_ALIAS(master_spi)
+#define S_SPIDW_NODE DT_ALIAS(slave_spi)
+
+/* size of stack area used by each thread */
+#define STACKSIZE 1024
+
+/* default SPI master SS(slave select) is H/W controlled,
+ * enable this to use as S/W controlled using gpio.
+ */
+#define SPI_MASTER_SS_SW_CONTROLLED_GPIO   0
+
+/* scheduling priority used by each thread,
+ * as we are testing Loopback on the same board,
+ * make sure master priority is higher than slave priority.
+ */
+#define MASTER_PRIORITY 6
+#define SLAVE_PRIORITY  7
+
+/* Master and Slave buffer size */
+#define BUFF_SIZE  200
+
+/* Master and Slave buffer word size */
+#define SPI_WORD_SIZE 8
+
+/* Master and Slave buffer frequency */
+#define Mhz 1000000
+#define SPI_FREQUENCY (1 * Mhz)
+
+/* Master and Slave buffer transfers */
+#define SPI_NUM_TRANSFERS  10
+
+/*
+ * Signaling semaphores: main gives start sems to kick off a transfer round;
+ * threads give done sems when the round finishes. Both sets survive S2RAM in
+ * retained RAM so threads resume from k_sem_take() without re-creation.
+ */
+static struct k_sem slave_start_sem;
+static struct k_sem master_start_sem;
+static struct k_sem slave_done_sem;
+static struct k_sem master_done_sem;
+
+/* Master and Slave buffers */
+static uint32_t master_txdata[BUFF_SIZE];
+static uint32_t master_rxdata[BUFF_SIZE];
+static uint32_t slave_txdata[BUFF_SIZE];
+static uint32_t slave_rxdata[BUFF_SIZE];
+
+K_THREAD_STACK_DEFINE(MasterT_stack, STACKSIZE);
+static struct k_thread MasterT_data;
+
+K_THREAD_STACK_DEFINE(SlaveT_stack, STACKSIZE);
+static struct k_thread SlaveT_data;
+
+/*
+ * Send/Receive data through slave spi
+ */
+int slave_spi_transceive(const struct device *dev)
+{
+	struct spi_config cnfg = {0};
+	int ret;
+
+	cnfg.frequency = SPI_FREQUENCY;
+	cnfg.operation = SPI_OP_MODE_SLAVE | SPI_WORD_SET(SPI_WORD_SIZE);
+	cnfg.slave = 0;
+
+	int length = (BUFF_SIZE) * sizeof(slave_rxdata[0]);
+
+	struct spi_buf rx_buf = {
+		.buf = slave_rxdata,
+		.len = length
+	};
+	struct spi_buf_set rx_bufset = {
+		.buffers = &rx_buf,
+		.count = 1
+	};
+	struct spi_buf tx_buf = {
+		.buf = slave_txdata,
+		.len = length
+	};
+	struct spi_buf_set tx_bufset = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+
+	ret = spi_transceive(dev, &cnfg, &tx_bufset, &rx_bufset);
+	if (ret < 0) {
+		LOG_ERR("Slave SPI transceive error: %d", ret);
+	}
+
+	LOG_INF("slave wrote: %08x %08x %08x %08x %08x",
+		slave_txdata[0], slave_txdata[1], slave_txdata[2],
+		slave_txdata[3], slave_txdata[4]);
+
+	LOG_INF("slave read:  %08x %08x %08x %08x %08x",
+		slave_rxdata[0], slave_rxdata[1], slave_rxdata[2],
+		slave_rxdata[3], slave_rxdata[4]);
+
+	/* Propagate transceive error first; RX buffer contents are unreliable. */
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (memcmp(master_txdata, slave_rxdata, length) != 0) {
+		LOG_ERR("SPI master TX & slave RX data mismatch");
+		return -EIO;
+	}
+
+	LOG_INF("SUCCESS: SPI Master TX & Slave RX DATA IS MATCHING");
+	return 0;
+}
+
+/*
+ * Send/Receive data through master spi
+ */
+int master_spi_transceive(const struct device *dev, struct spi_cs_control *cs)
+{
+	struct spi_config cnfg = {0};
+	int ret;
+
+	cnfg.frequency = SPI_FREQUENCY;
+	cnfg.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(SPI_WORD_SIZE);
+	cnfg.slave = 0;
+	cnfg.cs = *cs;
+
+	int length = (BUFF_SIZE) * sizeof(master_txdata[0]);
+
+	struct spi_buf tx_buf = {
+		.buf = master_txdata,
+		.len = length
+	};
+
+	struct spi_buf_set tx_bufset = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+
+	struct spi_buf rx_buf = {
+		.buf = master_rxdata,
+		.len = length
+	};
+	struct spi_buf_set rx_bufset = {
+		.buffers = &rx_buf,
+		.count = 1
+	};
+
+	ret = spi_transceive(dev, &cnfg, &tx_bufset, &rx_bufset);
+	if (ret < 0) {
+		LOG_ERR("SPI=%s transceive error: %d", dev->name, ret);
+	}
+
+	LOG_INF("Master wrote:   %08x %08x %08x %08x %08x",
+		master_txdata[0], master_txdata[1], master_txdata[2],
+		master_txdata[3], master_txdata[4]);
+	LOG_INF("Master receive: %08x %08x %08x %08x %08x",
+		master_rxdata[0], master_rxdata[1], master_rxdata[2],
+		master_rxdata[3], master_rxdata[4]);
+
+	/* Propagate transceive error first; RX buffer contents are unreliable. */
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (memcmp(master_rxdata, slave_txdata, length) != 0) {
+		LOG_ERR("SPI master RX & slave TX data mismatch");
+		return -EIO;
+	}
+
+	LOG_INF("SUCCESS: SPI Master RX & Slave TX DATA IS MATCHING");
+	return 0;
+}
+
+static void prepare_data(uint32_t *data, uint16_t def_mask)
+{
+	for (uint32_t cnt = 0; cnt < BUFF_SIZE; cnt++) {
+		data[cnt] = (def_mask << 16) | cnt;
+	}
+}
+
+/*
+ * Master SPI thread. Blocks on master_start_sem between rounds.
+ * After S2RAM wakeup, retained RAM keeps the thread context intact and it
+ * resumes from k_sem_take() — no re-creation required.
+ */
+static void master_spi_thread(void *p1, void *p2, void *p3)
+{
+	const struct device *const dev = DEVICE_DT_GET(SPIDW_NODE);
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: Master device not ready", dev->name);
+		return;
+	}
+
+#if SPI_MASTER_SS_SW_CONTROLLED_GPIO
+	struct spi_cs_control cs_ctrl = (struct spi_cs_control){
+		.gpio  = GPIO_DT_SPEC_GET(SPIDW_NODE, cs_gpios),
+		.delay = 100u,
+	};
+#else
+	struct spi_cs_control cs_ctrl = {0};
+#endif
+
+	while (true) {
+		bool success = true;
+
+		k_sem_take(&master_start_sem, K_FOREVER);
+		for (uint32_t i = 0; i < SPI_NUM_TRANSFERS; i++) {
+			LOG_INF("Master Transceive Iter= %u", i + 1);
+			if (master_spi_transceive(dev, &cs_ctrl) < 0) {
+				LOG_ERR("Stopping the Master Thread due to error");
+				success = false;
+				break;
+			}
+			k_msleep(1000);
+		}
+		if (success) {
+			LOG_INF("Master Transfer Successfully Completed");
+		}
+		k_sem_give(&master_done_sem);
+	}
+}
+
+/*
+ * Slave SPI thread. Blocks on slave_start_sem between rounds.
+ * After S2RAM wakeup, retained RAM keeps the thread context intact and it
+ * resumes from k_sem_take() — no re-creation required.
+ */
+static void slave_spi_thread(void *p1, void *p2, void *p3)
+{
+	const struct device *const slave_dev = DEVICE_DT_GET(S_SPIDW_NODE);
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	if (!device_is_ready(slave_dev)) {
+		LOG_ERR("%s: Slave device not ready", slave_dev->name);
+		return;
+	}
+
+	while (true) {
+		bool success = true;
+
+		k_sem_take(&slave_start_sem, K_FOREVER);
+		for (uint32_t i = 0; i < SPI_NUM_TRANSFERS; i++) {
+			LOG_INF("Slave Transceive Iter= %u", i + 1);
+			if (slave_spi_transceive(slave_dev) < 0) {
+				LOG_ERR("Stopping the Slave Thread due to error");
+				success = false;
+				break;
+			}
+		}
+		if (success) {
+			LOG_INF("Slave Transfer Successfully Completed");
+		}
+		k_sem_give(&slave_done_sem);
+	}
+}
+
+/*
+ * Signal both SPI threads to run one round of transfers and wait for
+ * completion. Slave is armed 100 ms before master to ensure the slave SPI
+ * peripheral is ready to receive before the master starts the transaction.
+ */
+static void spi_loopback_run(const char *phase_label)
+{
+	app_pm_lock_sleep_states(true);
+	LOG_INF("[SPI Demo] %s", phase_label);
+	prepare_data(master_txdata, 0xA5A5);
+	prepare_data(slave_txdata, 0x5A5A);
+	k_sem_give(&slave_start_sem);
+	k_msleep(100);
+	k_sem_give(&master_start_sem);
+	k_sem_take(&slave_done_sem, K_FOREVER);
+	k_sem_take(&master_done_sem, K_FOREVER);
+	app_pm_lock_sleep_states(false);
+}
+
+/* PM state name lookup for notifier logging */
+static const char * const pm_state_names[] = {
+	[PM_STATE_ACTIVE]          = "ACTIVE",
+	[PM_STATE_RUNTIME_IDLE]    = "RUNTIME_IDLE",
+	[PM_STATE_SUSPEND_TO_IDLE] = "SUSPEND_TO_IDLE",
+	[PM_STATE_STANDBY]         = "STANDBY",
+	[PM_STATE_SUSPEND_TO_RAM]  = "SUSPEND_TO_RAM",
+	[PM_STATE_SUSPEND_TO_DISK] = "SUSPEND_TO_DISK",
+	[PM_STATE_SOFT_OFF]        = "SOFT_OFF",
+};
+
+#define PM_STATE_STR(s) \
+	((s) < ARRAY_SIZE(pm_state_names) ? pm_state_names[(s)] : "UNKNOWN")
+
+static void pm_notify_entry(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+
+	LOG_INF("PM enter: %s (substate %u)", PM_STATE_STR(state), substate_id);
+}
+
+/*
+ * With CONFIG_LOG_MODE_DEFERRED, LOG_INF here only writes to the ring buffer
+ * — no UART access — so this is safe even before devices are resumed.
+ */
+static void pm_notify_pre_resume(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+	uint32_t active_exc = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
+
+	if (active_exc >= 16U) {
+		LOG_INF("PM wakeup: %s (substate %u) IRQ %u",
+			PM_STATE_STR(state), substate_id, active_exc - 16U);
+	} else if (active_exc != 0U) {
+		LOG_INF("PM wakeup: %s (substate %u) exception %u",
+			PM_STATE_STR(state), substate_id, active_exc);
+	} else {
+		LOG_INF("PM wakeup: %s (substate %u)",
+			PM_STATE_STR(state), substate_id);
+	}
+#if APP_PM_WAKEUP_DEBUG
+	for (int i = 0; i < 16; i++) {
+		if (NVIC->ISPR[i]) {
+			LOG_INF("PM wakeup: NVIC ISPR[%d] = 0x%08x", i, NVIC->ISPR[i]);
+		}
+	}
+#endif
+}
+
+static void pm_notify_exit(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+
+	LOG_INF("PM exit:  %s (substate %u)", PM_STATE_STR(state), substate_id);
+}
+
+static struct pm_notifier app_pm_notifier = {
+	.state_entry       = pm_notify_entry,
+	.pre_device_resume = pm_notify_pre_resume,
+	.state_exit        = pm_notify_exit,
+};
+
+int main(void)
+{
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	int ret;
+
+	__ASSERT(device_is_ready(cons), "%s: device not ready", cons->name);
+	__ASSERT(device_is_ready(wakeup_dev), "%s: device not ready", wakeup_dev->name);
+
+	pm_notifier_register(&app_pm_notifier);
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("%s (S2RAM): SPI DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM STANDBY, S2RAM STOP)",
+			CONFIG_BOARD);
+	} else {
+		LOG_INF("%s (SOFT_OFF): SPI DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)",
+			CONFIG_BOARD);
+	}
+
+	ret = counter_start(wakeup_dev);
+	__ASSERT(!ret || ret == -EALREADY, "Failed to start counter (err %d)", ret);
+
+	k_sem_init(&slave_start_sem, 0, 1);
+	k_sem_init(&master_start_sem, 0, 1);
+	k_sem_init(&slave_done_sem, 0, 1);
+	k_sem_init(&master_done_sem, 0, 1);
+
+	/*
+	 * Create SPI threads once. They loop on their start semaphores so after
+	 * S2RAM wakeup they resume from k_sem_take() without re-creation.
+	 */
+	k_thread_create(&SlaveT_data, SlaveT_stack, STACKSIZE,
+			slave_spi_thread, NULL, NULL, NULL,
+			SLAVE_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&MasterT_data, MasterT_stack, STACKSIZE,
+			master_spi_thread, NULL, NULL, NULL,
+			MASTER_PRIORITY, 0, K_NO_WAIT);
+
+	LOG_INF("POWER STATE SEQUENCE:");
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("  3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)");
+		LOG_INF("  4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)");
+	} else {
+		LOG_INF("  3. PM_STATE_SOFT_OFF");
+	}
+
+	spi_loopback_run("before RUNTIME_IDLE");
+
+	LOG_INF("Enter RUNTIME_IDLE sleep for (%d microseconds)", RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(true);
+	ret = app_enter_normal_sleep(RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(false);
+	__ASSERT(ret == 0, "Could not enter RUNTIME_IDLE sleep (err %d)", ret);
+
+	LOG_INF("Exited from RUNTIME_IDLE sleep");
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	LOG_INF("Request SUSPEND_TO_IDLE for %d us", SUSPEND_IDLE_SLEEP_USEC);
+	app_pm_lock_deeper_states(true);
+	k_sleep(K_USEC(SUSPEND_IDLE_SLEEP_USEC));
+	app_pm_lock_deeper_states(false);
+	spi_loopback_run("after SUSPEND_TO_IDLE");
+#else
+	/* Lock SUSPEND_TO_IDLE when LPM timer support is not configured */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("PM_STATE_SUSPEND_TO_IDLE (skipped - LPM timer not enabled)");
+#endif
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("Request S2RAM STANDBY for %d us", S2RAM_STANDBY_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STANDBY_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		spi_loopback_run("after S2RAM STANDBY");
+
+		LOG_INF("Request S2RAM STOP for %d us", S2RAM_STOP_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STOP_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		spi_loopback_run("after S2RAM STOP");
+	}
+
+	if (SOFT_OFF_SUPPORTED) {
+		LOG_INF("Request SOFT_OFF for %d us (no retention - system resets on wakeup)",
+			SOFT_OFF_SLEEP_USEC);
+		ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+		/* Should never reach here - SOFT_OFF causes full reset on wakeup */
+		LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+		__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+	}
+
+	LOG_INF("=== SPI DW PM SEQUENCE COMPLETED ===");
+
+	app_pm_lock_deeper_states(true);
+	/* Demo complete — prevent SUSPEND_TO_IDLE so the idle spin stays in RUNTIME_IDLE */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+	while (true) {
+		/* spin here */
+		k_sleep(K_SECONDS(1));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Demonstrate SPI DW operation across the full PM state sequence: RUNTIME_IDLE, SUSPEND_TO_IDLE, SUSPEND_TO_RAM (STANDBY and STOP substates), and SOFT_OFF (on targets without retained RAM).

SPI master and slave threads run loopback transfers before each deep sleep phase to verify correct device resume. Transfers use DMA and are guarded with pm_policy_state_lock to prevent SUSPEND_TO_IDLE entry while DMA is active, since SPI and DMA IRQs fall outside the IWIC wakeup range.

Snippet overlays cover TCM, SRAM0, and MRAM boot configurations across B1, E1C, E7, and E8 variants.