### PR TITLE
samples: bluetooth: le_throughput: Small improvements

### DIFF
--- a/samples/bluetooth/le_throughput/Kconfig
+++ b/samples/bluetooth/le_throughput/Kconfig
@@ -25,10 +25,6 @@ config BLE_TP_DEVICE_NAME
 	string "Default BLE throughput device name"
 	default "ALIF-TP"
 
-config BLE_TP_BIDIRECTIONAL_TEST
-	bool "Bidirectional throughput test"
-	default y
-
 config ALIF_TP_SHELL_THREAD_PRIORITY
 	int "Priority for thread running the throughput"
 	default 0

--- a/samples/bluetooth/le_throughput/README.rst
+++ b/samples/bluetooth/le_throughput/README.rst
@@ -19,10 +19,103 @@ Building and Running
 This sample can be found under :zephyr_file:`samples/bluetooth/le_throughput` in the
 sdk-alif tree.
 
-For testing throughput you need both, central and peripheral devices. That can be configured in
-shell by typing either 'tp central' or 'tp peripheral'. After devices have been connected, start test with command
-'tp run' in central device shell.
+For testing throughput you need both, central and peripheral devices.
 
-By default, test measures throughput in both directions. First from central to peripheral and then
-from peripheral to central. To measure only from central to peripheral, set config
-'CONFIG_BLE_TP_BIDIRECTIONAL_TEST' to 'n'.
+Shell Command User Guide
+************************
+
+The throughput sample provides the ``tp`` shell command with the following subcommands.
+
+``tp info``
+===========
+
+Show throughput device information.
+
+Usage::
+
+	tp info
+
+``tp connection``
+=================
+
+Set BLE connection parameters.
+
+Usage::
+
+	tp connection --min <min> --max <max> --supervision <supervision>
+
+Where:
+
+* ``<min>``: Minimum connection interval
+* ``<max>``: Maximum connection interval
+* ``<supervision>``: Supervision timeout
+
+``tp interval``
+==============
+
+Set data acket send interval in milliseconds. If not set, the default interval is 0 ms, which means that the device will send packets as fast as possible.
+If set, the device will wait for the specified interval between sending packets. This can be used to simulate different traffic patterns and to test how the throughput changes with different send intervals.
+
+Usage::
+
+	tp interval <interval_ms>
+
+``tp peripheral``
+=================
+
+Configure device as BLE peripheral.
+
+Usage::
+
+	tp peripheral
+
+``tp central``
+==============
+
+Configure device as BLE central.
+
+Usage::
+
+	tp central
+
+``tp run``
+==========
+
+Run throughput test.
+
+Usage::
+
+	tp run
+	tp run <duration_s>
+
+If ``<duration_s>`` is provided, the test runs for that duration in seconds. Minimum duration is 2 seconds and maximum duration is 3 hours.
+If not provided, duration is set with config BLE_THROUGHPUT_DURATION and is by default 20 seconds.
+
+``tp data-sender``
+==================
+
+Select which side sends throughput data. Default is both.
+
+Usage::
+
+	tp data-sender central
+	tp data-sender peripheral
+	tp data-sender both
+
+Typical Flow
+============
+
+1. On one board, run ``tp peripheral``.
+2. On the other board, run ``tp central``.
+3. Optionally configure connection, send interval and data sender with the following commands:
+
+	 * ``tp connection --min <min> --max <max> --supervision <supervision>``
+	 * ``tp interval <interval_ms>``
+	 * ``tp data-sender central|peripheral|both``
+
+4. Start test from central side with ``tp run`` or ``tp run <duration_s>``.
+5. After test is done, throughput results are printed.
+
+
+
+

--- a/samples/bluetooth/le_throughput/shell/central.c
+++ b/samples/bluetooth/le_throughput/shell/central.c
@@ -67,6 +67,8 @@ struct service_env {
 	uint8_t init_actv_idx;
 	/* Connection index */
 	uint8_t conidx;
+	/* Data sender */
+	enum tp_data_send_direction data_sender;
 	/* Used to know if peripheral found */
 	bool periph_found;
 };
@@ -77,6 +79,7 @@ static struct service_env env = {
 	.supervision_to = SUPERVISION_TIMEOUT_DEFAULT,
 	.scan_actv_idx = GAP_INVALID_ACTV_IDX,
 	.init_actv_idx = GAP_INVALID_ACTV_IDX,
+	.data_sender = TP_DATA_SENDER_BOTH,
 };
 
 struct tp_data transmit_throughput_results;
@@ -613,7 +616,8 @@ int central_app_exec(uint32_t const app_state)
 		printk(" >>> TRASMIT RESULT: ");
 		pretty_print_result(&transmit_throughput_results);
 
-		if (IS_ENABLED(CONFIG_BLE_TP_BIDIRECTIONAL_TEST)) {
+		if (env.data_sender == TP_DATA_SENDER_BOTH ||
+			env.data_sender == TP_DATA_SENDER_PERIPHERAL) {
 			printk("\r\n <<< Reception test starts\r\n");
 		}
 
@@ -637,6 +641,7 @@ int central_app_exec(uint32_t const app_state)
 			.type = TP_CLIENT_CTRL_TYPE_RESET,
 			.test_duration_ms = env.test_duration_ms,
 			.send_interval_ms = env.send_interval_ms,
+			.data_sender = env.data_sender,
 		};
 
 		memset(&tp_stats, 0, sizeof(tp_stats));
@@ -644,9 +649,14 @@ int central_app_exec(uint32_t const app_state)
 		gatt_client_write_noack(service_handle, (void *)&command, sizeof(command));
 
 		last_tp_read = current_ms;
-
-		app_transition_to(APP_STATE_DATA_TRANSMIT);
-		printk(" >>> Transmit test starts\r\n");
+		if (env.data_sender == TP_DATA_SENDER_BOTH ||
+			env.data_sender == TP_DATA_SENDER_CENTRAL) {
+			app_transition_to(APP_STATE_DATA_TRANSMIT);
+			printk(" >>> Transmit test starts\r\n");
+		} else {
+			printk("\r\n <<< Reception test starts\r\n");
+			app_transition_to(APP_STATE_CENTRAL_READY);
+		}
 		break;
 	}
 
@@ -684,6 +694,13 @@ int central_get_service_uuid_str(char *p_uuid, uint8_t max_len)
 int central_set_send_interval(uint32_t const interval)
 {
 	env.send_interval_ms = interval;
+
+	return 0;
+}
+
+int central_set_data_sender(enum tp_data_send_direction dir)
+{
+	env.data_sender = dir;
 
 	return 0;
 }
@@ -759,8 +776,8 @@ int central_connection_params_set(struct central_conn_params const *const p_para
 
 int central_set_test_duration(uint32_t const duration_s)
 {
-	if (duration_s < 2 || duration_s > (60 * 60)) {
-		LOG_ERR("Test duration maximum is an hour!");
+	if (duration_s < 2 || duration_s > (60 * 60 * 3)) {
+		LOG_ERR("Test duration must be between 2 seconds and 3 hours!");
 		return -EINVAL;
 	}
 

--- a/samples/bluetooth/le_throughput/shell/central.h
+++ b/samples/bluetooth/le_throughput/shell/central.h
@@ -51,6 +51,15 @@ int central_get_service_uuid_str(char *p_uuid, uint8_t max_len);
 int central_set_send_interval(uint32_t interval);
 
 /**
+ * Set data sender
+ *
+ * @param[in] dir Data sender direction
+ *
+ * @return 0 in case of success, otherwise -1
+ */
+int central_set_data_sender(enum tp_data_send_direction dir);
+
+/**
  * Get connection parameters
  *
  * @param[out] p_params Connection parameters

--- a/samples/bluetooth/le_throughput/shell/common.h
+++ b/samples/bluetooth/le_throughput/shell/common.h
@@ -45,6 +45,13 @@ enum app_state {
 	APP_STATE_DISCONNECTED,
 };
 
+enum tp_data_send_direction {
+	TP_DATA_SENDER_CENTRAL = 1,
+	TP_DATA_SENDER_PERIPHERAL,
+	TP_DATA_SENDER_BOTH,
+};
+
+
 enum tp_client_ctrl_type {
 	TP_CLIENT_CTRL_TYPE_RESET = 1,
 };
@@ -53,6 +60,7 @@ struct tp_client_ctrl {
 	enum tp_client_ctrl_type type;
 	uint32_t test_duration_ms;
 	uint32_t send_interval_ms;
+	enum tp_data_send_direction data_sender;
 };
 
 void app_transition_to(enum app_state state);

--- a/samples/bluetooth/le_throughput/shell/peripheral.c
+++ b/samples/bluetooth/le_throughput/shell/peripheral.c
@@ -82,6 +82,7 @@ static struct service_env {
 	uint16_t mtu;
 	uint32_t total_len;
 	uint16_t cnt;
+	enum tp_data_send_direction data_sender;
 } env;
 
 static uint8_t service_uuid[] = SERVICE_UUID;
@@ -126,7 +127,9 @@ static void on_att_read_get(uint8_t const conidx, uint8_t const user_lid, uint16
 		}
 
 		memcpy(p_buf->buf + p_buf->head_len, &env.resp_data, att_val_len);
-		if (IS_ENABLED(CONFIG_BLE_TP_BIDIRECTIONAL_TEST)) {
+
+		if (env.data_sender == TP_DATA_SENDER_BOTH ||
+			env.data_sender == TP_DATA_SENDER_PERIPHERAL) {
 			app_transition_to(APP_STATE_PERIPHERAL_PREPARE_SENDING);
 		} else {
 			app_transition_to(APP_STATE_STANDBY);
@@ -228,14 +231,15 @@ static void on_att_val_set(uint8_t const conidx, uint8_t const user_lid, uint16_
 
 		/* Check if the control message was received */
 		if (data_len == sizeof(struct tp_client_ctrl)) {
-			struct tp_client_ctrl *p_ctrl =
-				(struct tp_client_ctrl *)co_buf_data(p_data);
+			/* Copy into an aligned local struct to avoid unaligned access fault */
+			struct tp_client_ctrl p_ctrl;
 
-			if (p_ctrl->type == TP_CLIENT_CTRL_TYPE_RESET) {
-				printk(" >>> Reception starts\r\n");
+			memcpy(&p_ctrl, co_buf_data(p_data), sizeof(p_ctrl));
 
-				env.test_duration_ms = p_ctrl->test_duration_ms;
-				env.send_interval_ms = p_ctrl->send_interval_ms;
+			if (p_ctrl.type == TP_CLIENT_CTRL_TYPE_RESET) {
+				env.test_duration_ms = p_ctrl.test_duration_ms;
+				env.send_interval_ms = p_ctrl.send_interval_ms;
+				env.data_sender = p_ctrl.data_sender;
 
 				env.accumulated_time_ns = 0;
 				env.resp_data.write_count = 0;
@@ -243,7 +247,14 @@ static void on_att_val_set(uint8_t const conidx, uint8_t const user_lid, uint16_
 				env.resp_data.write_rate = 0;
 
 				clock_cycles_last = cycle_now;
-				app_transition_to(APP_STATE_PERIPHERAL_RECEIVING);
+
+				if (env.data_sender == TP_DATA_SENDER_BOTH ||
+					env.data_sender == TP_DATA_SENDER_CENTRAL) {
+					printk(" >>> Reception starts\r\n");
+					app_transition_to(APP_STATE_PERIPHERAL_RECEIVING);
+				} else {
+					app_transition_to(APP_STATE_PERIPHERAL_PREPARE_SENDING);
+				}
 				break;
 			}
 		}
@@ -494,6 +505,10 @@ int peripheral_app_exec(uint32_t const app_state)
 		break;
 	}
 	case APP_STATE_PERIPHERAL_SENDING: {
+		if (env.send_interval_ms) {
+			k_sleep(K_MSEC(env.send_interval_ms));
+		}
+
 		notification_send();
 		break;
 	}

--- a/samples/bluetooth/le_throughput/shell/shell_throughput.c
+++ b/samples/bluetooth/le_throughput/shell/shell_throughput.c
@@ -158,6 +158,32 @@ static int32_t param_get_int(size_t const argc, char **argv, char *p_param, int 
 	return def_value;
 }
 
+static int cmd_set_data_sender(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		LOG_ERR("Invalid number of arguments");
+		return -EINVAL;
+	}
+
+	if (get_device_role() != GAP_ROLE_LE_CENTRAL) {
+		LOG_ERR("Only central device could define data sender");
+		return -EINVAL;
+	}
+
+	if (strcmp(argv[1], "central") == 0) {
+		(void)central_set_data_sender(TP_DATA_SENDER_CENTRAL);
+	} else if (strcmp(argv[1], "peripheral") == 0) {
+		(void)central_set_data_sender(TP_DATA_SENDER_PERIPHERAL);
+	} else if (strcmp(argv[1], "both") == 0) {
+		(void)central_set_data_sender(TP_DATA_SENDER_BOTH);
+	} else {
+		LOG_ERR("Invalid data sender: %s (use central, peripheral or both)", argv[1]);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int cmd_set_conn_interval(const struct shell *shell, size_t const argc, char **argv)
 {
 	if (argc < 2) {
@@ -204,6 +230,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(peripheral, NULL, "Peripheral config", cmd_peripheral_start, 1, 10),
 	SHELL_CMD_ARG(central, NULL, "Central config", cmd_central_start, 1, 10),
 	SHELL_CMD_ARG(run, NULL, "Run throughput test: <duration_s>", cmd_tp_test_start, 1, 10),
+	SHELL_CMD_ARG(data-sender, NULL, "Set data sender: central|peripheral|both",
+		      cmd_set_data_sender, 2, 1),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 


### PR DESCRIPTION
- add sleep to peripheral data send, if sending interval is set
- new shall command to set data sender, either central only, peripheral only or both directions
- increase maximum test time to 3 hours for regression testing