### PR TITLE
manifest: update Zephyr version to OSPI XIP memory region handling

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: c3727a63885227b97902c263df76881960ae7f06
+      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update Zephyr version to OSPI XIP memory region handling.

This PR depends on: https://github.com/alifsemi/zephyr_alif/pull/554
