### PR TITLE
manifest: update Zephyr version to ethos PM support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated Zephyr version to ethos PM support

This PR depends on: https://github.com/alifsemi/zephyr_alif/pull/555