### PR TITLE
manifest: update Zephyr version to move heap to sram support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0c8c78c5094c47a826d65ca934efcdaa5f734350
+      revision: 1b73a3025f75c647f1368ab51d4a9dd3ce393c76
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated Zephyr version to move heap to sram support

This PR depends on: https://github.com/alifsemi/zephyr_alif/pull/562