### PR TITLE
bluetooth: common: gate pm on CONFIG_PM, not just snippet name

### DIFF
--- a/subsys/bluetooth/common/CMakeLists.txt
+++ b/subsys/bluetooth/common/CMakeLists.txt
@@ -17,7 +17,7 @@ zephyr_library_sources(central_itf.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO ble_gpio.c)
 zephyr_library_sources_ifdef(CONFIG_SETTINGS ble_storage.c)
 
-if(pm-ble IN_LIST SNIPPET)
+if(pm-ble IN_LIST SNIPPET AND CONFIG_PM)
     message("BLE PM is enabled, including power_mgr.c in common sources.")
     zephyr_library_sources(power_mgr.c)
     zephyr_library_compile_options(-DSNIPPET_PM_BLE_USED=1)


### PR DESCRIPTION
Samples force the pm-ble snippet into the SNIPPET list unconditionally, but its overlay/conf (CONFIG_PM=y, RTC/stop_s2ram nodes) is board-scoped. On boards where the snippet content is filtered out, the name stays in the list while CONFIG_PM is n, so power_mgr.c was compiled without the DT nodes it requires and failed with #error on the missing RTC / stop_s2ram nodes.

Also require CONFIG_PM so power_mgr.c is only built when PM is actually configured. Builds where the snippet applies are unaffected.

This came up when I wanted to get BLE samples running with our FPGA test environment.