### PR TITLE
manifest: Take LPA defaults into use

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0337305734427e130746e9b4022298afd06ac8ea
+      revision: d580761e6e423edb6fe0593d878ee34f995a1005
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
B1 DK defaults for LPA mode has been updated in hal_alif. Take it into use

Depends on: https://github.com/alifsemi/zephyr_alif/pull/564