### PR TITLE
tests: drivers: jpeg: Add JPEG encoder test suite

### DIFF
--- a/tests/drivers/jpeg/CMakeLists.txt
+++ b/tests/drivers/jpeg/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(jpeg_hantro_vc9000e_test)
+
+target_sources(app PRIVATE
+	src/main.c
+	src/jpeg_common.c
+	src/incbin.c
+	src/jpeg_perf.c
+)
+target_compile_definitions(app PRIVATE INCBIN_BASE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/drivers/jpeg/README.rst
+++ b/tests/drivers/jpeg/README.rst
@@ -1,0 +1,165 @@
+.. _jpeg_hantro_vc9000e_test:
+
+JPEG Driver Test
+################
+
+Overview
+********
+
+ZTest suite for the VeriSilicon Hantro VC9000E JPEG hardware encoder
+driver (``verisilicon,hantro-vc9000e-jpeg``).
+
+Each test exercises a distinct slice of the driver API; redundant or
+fully-subsumed cases have been removed. Device-readiness is enforced
+unconditionally by the suite-before hook and is therefore not a
+separate test.
+
+The suite is split into two groups: the **baseline** tests (which all
+pass on the current driver) and the **newly added** tests, kept in a
+dedicated section at the bottom of this document so they can be
+identified at a glance.
+
+Baseline tests
+**************
+
+#. Capabilities reporting (NV12 / NV21 presence, dimension / step
+   bounds, EP_IN rejection).
+#. ``video_set_format`` / ``video_get_format`` round-trip parametrized
+   over both supported pixel formats (NV12 and NV21).
+#. ``video_set_format`` rejection paths (too small, too large,
+   unsupported pixel format, wrong endpoint).
+#. ``VIDEO_CID_JPEG_COMPRESSION_QUALITY`` set/get round-trip and
+   unsupported-CID rejection.
+#. ``video_stream_start`` / ``video_stream_stop`` ``-EALREADY`` paths.
+#. ``video_enqueue`` ``-EBUSY`` (single in-flight buffer constraint).
+#. ``video_dequeue`` ``-EAGAIN`` on timeout (no enqueue performed).
+#. Quality-level encode (q=10 + q=90): covers basic-encode sanity
+   (SOI/EOI markers, ``bytesused > header_size``, ``bytesused < input``,
+   compression ratio) and asserts the quality knob has the documented
+   monotonic effect on output size. Uses the 1280x720 NV12 reference
+   image shared with ``samples/drivers/jpeg``.
+#. Multi-resolution encode (32x32, 320x240, 640x480 synthetic
+   gradient) -- validates dimension handling and 16-px alignment.
+#. Back-to-back encodes (5 iterations of the same buffer pair) --
+   asserts byte-identical output size across iterations, proving the
+   driver fully re-arms HW state between encodes.
+
+Exporting encoded images
+************************
+
+The encode tests print **two** export hints per buffer: one for gdb
+and one for J-Link Commander. Each line carries the buffer's start
+address and ``bytesused`` so the captured file is a complete JPEG.
+
+Example (output line wrapped for readability):
+
+.. code-block:: console
+
+   EXPORT[q=90] gdb   : dump binary memory "q90.jpg" 0x02151870 0x02181f88
+   EXPORT[q=90] J-Link: savebin q90.jpg 0x02151870 0x30718
+
+``dump binary memory`` (gdb) takes start + end addresses; ``savebin``
+(J-Link Commander) takes start + size in bytes. Either command
+produces a viewable ``.jpg`` file.
+
+Requirements
+************
+
+* Alif Ensemble E8 Development/Application Kit (or any board exposing
+  the ``jpeg0`` node with compatible
+  ``verisilicon,hantro-vc9000e-jpeg``).
+* Fixture: ``fixture_jpeg``.
+
+Building and Running
+********************
+
+.. code-block:: console
+
+   west build -b <board> <path>
+
+The reference NV12 image used by the encoder tests is shared with the
+JPEG sample:
+``src/testing_images/1280x720.bin -> ../../../samples/drivers/jpeg/src/testing_images/1280x720.bin``.
+
+Expected output (excerpt)
+*************************
+
+.. code-block:: console
+
+   PASS - jpeg_hantro::test_jpeg_get_caps
+   PASS - jpeg_hantro::test_jpeg_set_format_valid
+   PASS - jpeg_hantro::test_jpeg_set_format_invalid
+   PASS - jpeg_hantro::test_jpeg_set_get_ctrl_quality
+   PASS - jpeg_hantro::test_jpeg_stream_already_started_stopped
+   PASS - jpeg_hantro::test_jpeg_enqueue_busy
+   PASS - jpeg_hantro::test_jpeg_dequeue_timeout
+   PASS - jpeg_hantro::test_jpeg_encode_quality_levels
+   PASS - jpeg_hantro::test_jpeg_encode_multi_resolutions
+   PASS - jpeg_hantro::test_jpeg_back_to_back_encodes
+
+----
+
+Unique scenarios (expected to PASS)
+===================================
+
+* ``test_jpeg_pitch_with_padding`` -- NV12 with ``pitch (384) > width
+  (320)``. Validates that the driver programs ROWLENGTH /
+  LUMA_STRIDE / CHROMA_STRIDE from ``fmt.pitch`` (not ``fmt.width``).
+* ``test_jpeg_non_aligned_dimensions`` -- 300x200 NV12 (``xfill=2``,
+  ``yfill=8``). Exercises the MCU-padding paths in ``set_format``.
+* ``test_jpeg_encode_nv21_end_to_end`` -- full encode pipeline run
+  with ``VIDEO_PIX_FMT_NV21`` (the baseline ``set_format_valid`` test
+  only verifies the format round-trip, not the encode path).
+* ``test_jpeg_encode_format_switch`` -- two consecutive encodes at
+  640x480 then 320x240 to prove ``set_format`` correctly re-programs
+  all dimension-dependent HW registers between encodes.
+* ``test_jpeg_enqueue_without_input_buffer`` -- negative path:
+  enqueue with ``input_buffer == NULL`` must return ``-EINVAL``.
+* ``test_jpeg_jfif_structural_validation`` -- deep marker walk:
+  asserts presence of APP0/JFIF, DQT, SOF0, DHT, SOS and EOI in
+  order, guaranteeing the stream is decodable.
+* ``test_jpeg_encode_large_1920x1080`` -- FHD stress encode. Skipped
+  automatically (``ztest_test_skip``) if
+  ``CONFIG_VIDEO_BUFFER_POOL_SZ_MAX`` is below 3,200,000.
+* ``test_jpeg_set_format_unsupported_hrm_formats`` -- HRM negative
+  contract: asserts ``set_format`` rejects YUYV (4:2:2), GREY/Y8
+  (4:0:0), RGB565 and XRGB32. These are HRM-listed IP-supported
+  formats that the current Zephyr driver does not expose.
+* ``test_jpeg_encode_max_width`` -- wide-stride / address-math stress
+  at 8192x32 NV12 (toward the HRM-documented 16K max width).
+  Auto-skipped if the buffer pool cannot accommodate it.
+
+Performance benchmark suite (jpeg_perf)
+========================================
+
+The ``jpeg_perf`` suite contains informational performance tests that
+measure encode latency and throughput. These tests have no hard
+pass/fail thresholds (the numbers are advisory) but will fail if the
+cycle counter is not running or encodes error out.
+
+* ``test_jpeg_encode_performance_1280x720`` -- runs one warm-up encode
+  plus 10 timed iterations at 1280x720 NV12, q=75, using
+  ``k_cycle_get_32()``. Reports mean / min / max per-frame latency in
+  microseconds, input-pixel throughput in MB/s, and frames per second (FPS).
+* ``test_jpeg_encode_performance_1920x1080`` -- same benchmark at
+  1920x1080 (2MP FHD) resolution to assess performance scaling. Uses
+  synthetic gradient pattern instead of the reference image. Auto-skipped
+  if the buffer pool cannot accommodate the larger buffers. Reports the
+  same metrics as the 1280x720 test.
+
+API contract validation tests
+==============================
+
+* ``test_jpeg_get_ctrl_input_buffer_roundtrip`` -- verifies that
+  ``get_ctrl(VIDEO_CID_JPEG_INPUT_BUFFER)`` returns the value
+  previously set via ``set_ctrl``.
+* ``test_jpeg_quality_range_validation`` -- verifies that
+  ``set_ctrl(VIDEO_CID_JPEG_COMPRESSION_QUALITY)`` validates range
+  (1-100) and rejects values of 0 and >100 with ``-EINVAL``.
+* ``test_jpeg_aa_initial_state_rejects_stream_start`` -- verifies that
+  ``stream_start`` requires a prior ``set_format``; on fresh init
+  ``data->fmt`` is zero (``width=0``, ``height=0``) yet ``stream_start``
+  must fail. The test name is prefixed with ``aa_`` so it sorts
+  alphabetically first and runs while the driver state is still
+  untouched (the suite-before hook only does ``device_is_ready``).
+  Auto-skipped if the driver pre-populates a default format.

--- a/tests/drivers/jpeg/app.overlay
+++ b/tests/drivers/jpeg/app.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&jpeg0 {
+	status = "okay";
+	quality-factor = <75>;
+	max-burst-length = <64>;
+};
+
+/* JPEG run profile: ensure SRAM0 + MRAM available for buffer pool. */
+&aipm_run_default {
+	memory-blocks = < (ALIF_SRAM0_MASK | ALIF_MRAM_MASK) >;
+};

--- a/tests/drivers/jpeg/prj.conf
+++ b/tests/drivers/jpeg/prj.conf
@@ -1,0 +1,29 @@
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=8192
+CONFIG_MAIN_STACK_SIZE=4096
+
+# Video subsystem + JPEG encoder
+CONFIG_VIDEO=y
+CONFIG_VIDEO_JPEG_HANTRO_VC9000E=y
+CONFIG_USE_ALIF_JPEG_SW_LIB=y
+
+# Two pool entries are enough: one input (raw YUV420) + one output (JPEG).
+CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=2
+# Sized to fit the 1280x720 NV12 reference image (1382400 B) plus the
+# JPEG header (CONFIG_VIDEO_JPEG_HANTRO_VC9000E_HEADER_SIZE, 623 B by
+# default). Total pool footprint: NUM_MAX * SZ_MAX ~= 2.8 MB which
+# fits in SRAM0 on alif_e8_dk RTSS-HP.
+#
+# The 1920x1080 stress test (test_jpeg_encode_large_1920x1080) needs
+# ~3.2 MB per slot (6.4 MB total) which overflows SRAM0 on this
+# target. With the value below the FHD test will auto-skip via
+# ztest_test_skip(). To run it on a target with more RAM (e.g. DDR
+# enabled), bump this to 3200000.
+CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=1400000
+CONFIG_SYS_HEAP_AUTO=y
+
+# Logging
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_VIDEO_LOG_LEVEL_INF=y

--- a/tests/drivers/jpeg/src/incbin.c
+++ b/tests/drivers/jpeg/src/incbin.c
@@ -1,0 +1,24 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <stdint.h>
+
+#define INCBIN_DEF(name, path) \
+	__asm__( \
+	".global "#name"_start\n" \
+	".global "#name"_end\n" \
+	".section \".rodata\"\n" \
+	""#name"_start:\n" \
+	".incbin \"" INCBIN_BASE_DIR "/" path "\"\n" \
+	""#name"_end:\n" \
+	".previous\n" \
+	);
+
+INCBIN_DEF(testimg, "../../../samples/drivers/jpeg/src/testing_images/1280x720.bin");

--- a/tests/drivers/jpeg/src/jpeg_common.c
+++ b/tests/drivers/jpeg/src/jpeg_common.c
@@ -1,0 +1,236 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <string.h>
+
+#include "jpeg_common.h"
+
+const struct device *jpeg_dev;
+
+void jpeg_suite_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	jpeg_dev = DEVICE_DT_GET(JPEG_DEVICE_NODE);
+	zassert_not_null(jpeg_dev, "JPEG device handle is NULL");
+	zassert_true(device_is_ready(jpeg_dev),
+		     "JPEG device %s not ready", jpeg_dev->name);
+}
+
+size_t jpeg_ref_image_size(void)
+{
+	return (size_t)(testimg_end - testimg_start);
+}
+
+void jpeg_copy_ref_image(uint8_t *dest)
+{
+	memcpy(dest, testimg_start, jpeg_ref_image_size());
+}
+
+void jpeg_fill_nv12_gradient(uint8_t *dest, uint32_t width, uint32_t height,
+			     uint32_t pitch)
+{
+	uint8_t *y_plane  = dest;
+	uint8_t *uv_plane = dest + (pitch * height);
+
+	for (uint32_t row = 0; row < height; row++) {
+		for (uint32_t col = 0; col < width; col++) {
+			y_plane[row * pitch + col] = (uint8_t)((row + col) & 0xFF);
+		}
+	}
+	for (uint32_t row = 0; row < (height / 2); row++) {
+		for (uint32_t col = 0; col < width; col += 2) {
+			uv_plane[row * pitch + col]     = (uint8_t)(0x80 + (col & 0x3F));
+			uv_plane[row * pitch + col + 1] = (uint8_t)(0x80 + (row & 0x3F));
+		}
+	}
+}
+
+bool jpeg_validate_markers(const uint8_t *buf, size_t size)
+{
+	if (size < 4) {
+		return false;
+	}
+	if (buf[0] != JPEG_MARKER_SOI_HI || buf[1] != JPEG_MARKER_SOI_LO) {
+		return false;
+	}
+	if (buf[size - 2] != JPEG_MARKER_EOI_HI ||
+	    buf[size - 1] != JPEG_MARKER_EOI_LO) {
+		return false;
+	}
+	return true;
+}
+
+bool jpeg_validate_jfif_structure(const uint8_t *buf, size_t size)
+{
+	bool have_app0_jfif = false;
+	bool have_dqt = false;
+	bool have_sof0 = false;
+	bool have_dht = false;
+	bool have_sos = false;
+	bool have_eoi = false;
+	size_t i;
+
+	if (size < 4 || buf[0] != 0xFF || buf[1] != 0xD8) {
+		return false;
+	}
+
+	i = 2;
+	while (i + 1 < size) {
+		uint8_t marker;
+		uint16_t seg_len;
+
+		/* Skip 0xFF fill bytes. */
+		while (i < size && buf[i] == 0xFF) {
+			i++;
+		}
+		if (i >= size) {
+			return false;
+		}
+		marker = buf[i++];
+
+		if (marker == 0xD9) { /* EOI */
+			have_eoi = true;
+			break;
+		}
+		/* Standalone markers carry no length. */
+		if (marker == 0x00 || marker == 0x01 ||
+		    (marker >= 0xD0 && marker <= 0xD7)) {
+			continue;
+		}
+
+		if (i + 2 > size) {
+			return false;
+		}
+		seg_len = ((uint16_t)buf[i] << 8) | buf[i + 1];
+		if (seg_len < 2 || i + seg_len > size) {
+			return false;
+		}
+
+		switch (marker) {
+		case 0xE0: /* APP0 */
+			if (seg_len >= 7 &&
+			    memcmp(&buf[i + 2], "JFIF\0", 5) == 0) {
+				have_app0_jfif = true;
+			}
+			break;
+		case 0xDB: /* DQT */
+			have_dqt = true;
+			break;
+		case 0xC0: /* SOF0 (baseline) */
+			have_sof0 = true;
+			break;
+		case 0xC4: /* DHT */
+			have_dht = true;
+			break;
+		case 0xDA: /* SOS - entropy-coded data follows; scan for EOI */
+			have_sos = true;
+			i += seg_len;
+			while (i + 1 < size) {
+				if (buf[i] == 0xFF && buf[i + 1] != 0x00) {
+					if (buf[i + 1] == 0xD9) {
+						have_eoi = true;
+					}
+					/* Restart markers (D0-D7) keep going,
+					 * but for our minimal validation it is
+					 * sufficient to stop here.
+					 */
+					goto done;
+				}
+				i++;
+			}
+			goto done;
+		default:
+			break;
+		}
+		i += seg_len;
+	}
+done:
+	return have_app0_jfif && have_dqt && have_sof0 &&
+	       have_dht && have_sos && have_eoi;
+}
+
+bool jpeg_extract_sof0_dimensions(const uint8_t *buf, size_t size,
+				  uint16_t *width, uint16_t *height)
+{
+	size_t i;
+
+	if (buf == NULL || size < 4 || width == NULL || height == NULL) {
+		return false;
+	}
+	if (buf[0] != 0xFF || buf[1] != 0xD8) {
+		return false;
+	}
+
+	i = 2;
+	while (i + 1 < size) {
+		uint8_t marker;
+		uint16_t seg_len;
+
+		while (i < size && buf[i] == 0xFF) {
+			i++;
+		}
+		if (i >= size) {
+			return false;
+		}
+		marker = buf[i++];
+
+		if (marker == 0xD9) { /* EOI */
+			return false;
+		}
+		if (marker == 0x00 || marker == 0x01 ||
+		    (marker >= 0xD0 && marker <= 0xD7)) {
+			continue;
+		}
+
+		if (i + 2 > size) {
+			return false;
+		}
+		seg_len = ((uint16_t)buf[i] << 8) | buf[i + 1];
+		if (seg_len < 2 || i + seg_len > size) {
+			return false;
+		}
+
+		if (marker == 0xC0) { /* SOF0 baseline */
+			/* Need at least: len(2) + precision(1) + h(2) + w(2) */
+			if (seg_len < 7) {
+				return false;
+			}
+			*height = ((uint16_t)buf[i + 3] << 8) | buf[i + 4];
+			*width  = ((uint16_t)buf[i + 5] << 8) | buf[i + 6];
+			return true;
+		}
+		i += seg_len;
+	}
+	return false;
+}
+
+bool alloc_pair_or_skip(size_t in_sz, size_t out_sz,
+			struct video_buffer **in, struct video_buffer **out,
+			const char *test_name)
+{
+	*in = video_buffer_alloc(in_sz, K_NO_WAIT);
+	*out = video_buffer_alloc(out_sz, K_NO_WAIT);
+
+	if (!*in || !*out) {
+		if (*in) {
+			video_buffer_release(*in);
+			*in = NULL;
+		}
+		if (*out) {
+			video_buffer_release(*out);
+			*out = NULL;
+		}
+		TC_PRINT("Skipping %s: buffer pool too small\n", test_name);
+		ztest_test_skip();
+		return false;
+	}
+
+	return true;
+}

--- a/tests/drivers/jpeg/src/jpeg_common.h
+++ b/tests/drivers/jpeg/src/jpeg_common.h
@@ -1,0 +1,101 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#ifndef ALIF_JPEG_TEST_COMMON_H_
+#define ALIF_JPEG_TEST_COMMON_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/video.h>
+#include <zephyr/drivers/video/video_alif.h>
+#include <zephyr/drivers/video-controls.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/ztest.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#define JPEG_DEVICE_NODE	DT_NODELABEL(jpeg0)
+
+/* Reference image embedded via incbin (NV12 / YUV420SP, 1280x720). */
+#define REF_IMG_WIDTH		1280
+#define REF_IMG_HEIGHT		720
+#define REF_IMG_PITCH		1280
+#define REF_IMG_NV12_SIZE	(REF_IMG_WIDTH * REF_IMG_HEIGHT * 3 / 2)
+
+#define JPEG_HEADER_SIZE	CONFIG_VIDEO_JPEG_HANTRO_VC9000E_HEADER_SIZE
+
+/* Output buffer sized for the 1280x720 reference image. Generous to absorb
+ * worst-case (low compression) high-quality output.
+ */
+#define DEFAULT_OUT_BUF_SIZE	(REF_IMG_NV12_SIZE + JPEG_HEADER_SIZE)
+
+/* JPEG markers */
+#define JPEG_MARKER_SOI_HI	0xFF
+#define JPEG_MARKER_SOI_LO	0xD8
+#define JPEG_MARKER_EOI_HI	0xFF
+#define JPEG_MARKER_EOI_LO	0xD9
+
+/* Embedded reference image (raw NV12 bytes). */
+extern uint8_t testimg_start[];
+extern uint8_t testimg_end[];
+
+/* Shared device handle. */
+extern const struct device *jpeg_dev;
+
+/* Suite hook: acquires + validates the JPEG device. */
+void jpeg_suite_before(void *fixture);
+
+/* Helpers shared across tests. */
+size_t jpeg_ref_image_size(void);
+void jpeg_copy_ref_image(uint8_t *dest);
+
+/* Fill a buffer with a deterministic NV12 gradient pattern of the given
+ * dimensions. Buffer must be at least (pitch * height * 3 / 2) bytes.
+ */
+void jpeg_fill_nv12_gradient(uint8_t *dest, uint32_t width, uint32_t height,
+			     uint32_t pitch);
+
+/* Validate that buf[0..size) contains an SOI marker at offset 0 and an
+ * EOI marker at the very end. Returns true if both checks pass.
+ */
+bool jpeg_validate_markers(const uint8_t *buf, size_t size);
+
+/* Deep JFIF structural validation: walks the marker chain and checks
+ * that all of the following are present in order:
+ *   SOI (FFD8) -> APP0 with "JFIF\0" identifier (FFE0) ->
+ *   at least one DQT (FFDB) -> SOF0 (FFC0) ->
+ *   at least one DHT (FFC4) -> SOS (FFDA) -> EOI (FFD9).
+ * Returns true on a structurally complete JFIF stream.
+ */
+bool jpeg_validate_jfif_structure(const uint8_t *buf, size_t size);
+
+/* Extract width and height from the SOF0 (baseline) marker of an
+ * encoded JPEG stream. SOF0 payload layout (after FFC0):
+ *   [len_hi][len_lo][precision][height_hi][height_lo][width_hi][width_lo][nf]...
+ * Returns true if SOF0 was found and width*height were populated.
+ */
+bool jpeg_extract_sof0_dimensions(const uint8_t *buf, size_t size,
+				  uint16_t *width, uint16_t *height);
+
+/* Encode helpers (shared across test files). */
+void alloc_ref_buffers(struct video_buffer **in, struct video_buffer **out);
+void release_buffers(struct video_buffer *in, struct video_buffer *out);
+int do_single_encode(struct video_buffer *in, struct video_buffer *out,
+		     uint16_t quality, uint32_t width, uint32_t height,
+		     uint32_t pitch, struct video_buffer **deq);
+
+/* Allocate a pair of video buffers (input and output). On allocation failure,
+ * releases any partial allocations, prints a message, calls ztest_test_skip(),
+ * and returns false. On success, returns true.
+ */
+bool alloc_pair_or_skip(size_t in_sz, size_t out_sz,
+			struct video_buffer **in, struct video_buffer **out,
+			const char *test_name);
+
+#endif /* ALIF_JPEG_TEST_COMMON_H_ */

--- a/tests/drivers/jpeg/src/jpeg_perf.c
+++ b/tests/drivers/jpeg/src/jpeg_perf.c
@@ -1,0 +1,143 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement.
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * JPEG encoder performance benchmark suite.
+ *
+ * This suite measures encode latency and throughput at various resolutions.
+ * Tests are informational (no hard pass/fail thresholds) but will fail if
+ * encode time goes to zero (clock not running) or any encode errors out.
+ */
+
+#include "jpeg_common.h"
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+
+/*
+ * Performance benchmark helper: runs warm-up encode, timed iterations,
+ * metrics calculation, and prints results. Takes pre-allocated buffers
+ * and dimensions as parameters, and a label for output identification.
+ */
+static void run_perf(uint32_t width, uint32_t height, uint32_t pitch,
+		     struct video_buffer *in, struct video_buffer *out,
+		     const char *label)
+{
+	struct video_buffer *deq = NULL;
+	const int iterations = 10;
+	uint32_t cyc_min = UINT32_MAX, cyc_max = 0;
+	uint64_t cyc_sum = 0;
+	int i, ret;
+
+	TC_PRINT("Performance test: %ux%u NV12, quality=75, iterations=%d\n",
+		 width, height, iterations);
+
+	/* Warm-up encode (not measured) to exclude one-time HW init costs. */
+	TC_PRINT("Step 1: Warm-up encode (excludes HW init costs)\n");
+	ret = do_single_encode(in, out, 75, width, height, pitch, &deq);
+	zassert_equal(ret, 0, "warm-up encode failed: %d", ret);
+	TC_PRINT("Warm-up complete: %u bytes encoded\n", deq->bytesused);
+
+	TC_PRINT("Step 2: Timed iterations (n=%d)\n", iterations);
+	for (i = 0; i < iterations; i++) {
+		uint32_t t0 = k_cycle_get_32();
+
+		ret = do_single_encode(in, out, 75, width, height, pitch, &deq);
+		uint32_t dt = k_cycle_get_32() - t0;
+
+		zassert_equal(ret, 0, "iter %d encode failed: %d", i, ret);
+		zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+						   deq->bytesused),
+			     "iter %d: SOI/EOI missing", i);
+
+		cyc_sum += dt;
+		if (dt < cyc_min) {
+			cyc_min = dt;
+		}
+		if (dt > cyc_max) {
+			cyc_max = dt;
+		}
+
+		uint32_t hz = sys_clock_hw_cycles_per_sec();
+		uint32_t us = (uint32_t)((uint64_t)dt * 1000000U / hz);
+
+		TC_PRINT("  Iter %2d: %u cycles (%u us), %u bytes\n",
+			 i, dt, us, deq->bytesused);
+	}
+
+	zassert_true(cyc_sum > 0, "cycle counter not running");
+
+	TC_PRINT("Step 3: Metrics calculation\n");
+	uint32_t cyc_mean = (uint32_t)(cyc_sum / iterations);
+	uint32_t hz       = sys_clock_hw_cycles_per_sec();
+	uint32_t us_mean  = (uint32_t)((uint64_t)cyc_mean * 1000000U / hz);
+	uint32_t us_min   = (uint32_t)((uint64_t)cyc_min  * 1000000U / hz);
+	uint32_t us_max   = (uint32_t)((uint64_t)cyc_max  * 1000000U / hz);
+	/* NV12 input bytes per frame = w*h*3/2 */
+	const uint64_t in_bytes = (uint64_t)width * height * 3U / 2U;
+	/* MB/s = bytes / sec / 1e6 = bytes * hz / cycles / 1e6 */
+	uint32_t mb_per_s = (uint32_t)((in_bytes * hz)
+				       / ((uint64_t)cyc_mean * 1000000U));
+
+	TC_PRINT("Step 4: Results\n");
+	TC_PRINT("  Clock frequency: %u Hz\n", hz);
+	TC_PRINT("  Input size: %llu bytes (%.2f MB)\n",
+		 (unsigned long long)in_bytes, (double)in_bytes / (1024.0 * 1024.0));
+	TC_PRINT("  Cycle statistics: mean=%u, min=%u, max=%u\n",
+		 cyc_mean, cyc_min, cyc_max);
+	TC_PRINT("  Latency statistics: mean=%u us, min=%u us, max=%u us\n",
+		 us_mean, us_min, us_max);
+	TC_PRINT("  Throughput: %u MB/s, %u FPS\n", mb_per_s,
+		 (us_mean > 0) ? (1000000U / us_mean) : 0);
+	TC_PRINT("Perf %s NV12 (q=75, n=%d): "
+		 "mean=%u us, min=%u us, max=%u us, throughput=%u MB/s, %u FPS\n",
+		 label, iterations, us_mean, us_min, us_max, mb_per_s,
+		 (us_mean > 0) ? (1000000U / us_mean) : 0);
+}
+
+/*
+ * Performance benchmark: measures encode latency and throughput at the
+ * reference 1280x720 resolution. Uses the shared run_perf helper.
+ */
+ZTEST(jpeg_perf, test_jpeg_encode_performance_1280x720)
+{
+	struct video_buffer *in = NULL, *out = NULL;
+
+	alloc_ref_buffers(&in, &out);
+	run_perf(REF_IMG_WIDTH, REF_IMG_HEIGHT, REF_IMG_PITCH, in, out,
+		 "1280x720");
+	release_buffers(in, out);
+}
+
+/*
+ * Performance benchmark at 2MP (1920x1080 FHD) resolution. Measures
+ * encode latency and throughput similar to the 1280x720 test but at
+ * a higher resolution to assess performance scaling. Auto-skipped if
+ * the buffer pool cannot accommodate the larger buffers. Uses the
+ * shared run_perf helper.
+ */
+ZTEST(jpeg_perf, test_jpeg_encode_performance_1920x1080)
+{
+	const uint32_t width  = 1920;
+	const uint32_t height = 1080;
+	const size_t   nv12_sz = (size_t)width * height * 3 / 2;
+	struct video_buffer *in = NULL, *out = NULL;
+
+	if (!alloc_pair_or_skip(nv12_sz, nv12_sz + JPEG_HEADER_SIZE,
+				&in, &out, "1920x1080_perf")) {
+		return;
+	}
+
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, width, height, width);
+	out->bytesused = nv12_sz + JPEG_HEADER_SIZE;
+
+	run_perf(width, height, width, in, out, "1920x1080");
+	release_buffers(in, out);
+}
+
+ZTEST_SUITE(jpeg_perf, NULL, NULL, jpeg_suite_before, NULL, NULL);

--- a/tests/drivers/jpeg/src/main.c
+++ b/tests/drivers/jpeg/src/main.c
@@ -1,0 +1,995 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+#include <string.h>
+
+#include "jpeg_common.h"
+
+LOG_MODULE_REGISTER(jpeg_test, LOG_LEVEL_INF);
+
+/*
+ * Test suite for the VeriSilicon Hantro VC9000E JPEG hardware encoder
+ * driver (compatible: verisilicon,hantro-vc9000e-jpeg).
+ *
+ * Each test is independent. A single buffer pair (input/output) is
+ * allocated/released per test to avoid cross-test state leaks.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Acquire one input + one output buffer; copy reference image to input.
+ * On any allocation failure, every successfully-allocated buffer is
+ * released before the zassert fires so a single failure does not leak
+ * pool slots and cascade into later tests.
+ */
+void alloc_ref_buffers(struct video_buffer **in, struct video_buffer **out)
+{
+	*in  = video_buffer_alloc(REF_IMG_NV12_SIZE, K_NO_WAIT);
+	*out = video_buffer_alloc(DEFAULT_OUT_BUF_SIZE, K_NO_WAIT);
+
+	if (*in == NULL || *out == NULL) {
+		if (*in) {
+			video_buffer_release(*in);
+			*in = NULL;
+		}
+		if (*out) {
+			video_buffer_release(*out);
+			*out = NULL;
+		}
+	}
+
+	zassert_not_null(*in,  "Failed to alloc input buffer");
+	zassert_not_null(*out, "Failed to alloc output buffer");
+
+	jpeg_copy_ref_image((uint8_t *)(*in)->buffer);
+	(*out)->bytesused = (*out)->size;
+}
+
+void release_buffers(struct video_buffer *in, struct video_buffer *out)
+{
+	if (in) {
+		video_buffer_release(in);
+	}
+	if (out) {
+		video_buffer_release(out);
+	}
+}
+
+/* Configure encoder for a single-shot encode of the reference image and
+ * dequeue the result. Returns the dequeued buffer pointer via *out_buf.
+ */
+int do_single_encode(struct video_buffer *in, struct video_buffer *out,
+			    uint16_t quality, uint32_t width, uint32_t height,
+			    uint32_t pitch, struct video_buffer **dequeued)
+{
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width = width,
+		.height = height,
+		.pitch = pitch,
+	};
+	int ret;
+
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	if (ret) {
+		return ret;
+	}
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &quality);
+	if (ret) {
+		return ret;
+	}
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, in->buffer);
+	if (ret) {
+		return ret;
+	}
+
+	out->bytesused = out->size;
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, out);
+	if (ret) {
+		return ret;
+	}
+
+	ret = video_stream_start(jpeg_dev);
+	if (ret) {
+		return ret;
+	}
+
+	ret = video_dequeue(jpeg_dev, VIDEO_EP_OUT, dequeued, K_SECONDS(5));
+	(void)video_stream_stop(jpeg_dev);
+	return ret;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Note: device-ready is enforced unconditionally by jpeg_suite_before()
+ * before every test, so a dedicated device_ready case is intentionally
+ * omitted.
+ */
+
+ZTEST(jpeg_hantro, test_jpeg_get_caps)
+{
+	struct video_caps caps = { 0 };
+	bool nv12_seen = false;
+	bool nv21_seen = false;
+	int ret;
+
+	ret = video_get_caps(jpeg_dev, VIDEO_EP_OUT, &caps);
+	zassert_equal(ret, 0, "video_get_caps failed: %d", ret);
+	zassert_not_null(caps.format_caps, "format_caps is NULL");
+
+	for (int i = 0; caps.format_caps[i].pixelformat != 0; i++) {
+		const struct video_format_cap *c = &caps.format_caps[i];
+
+		TC_PRINT("Cap[%d]: 0x%08x %ux%u..%ux%u step=%ux%u\n", i,
+			 c->pixelformat,
+			 c->width_min, c->height_min,
+			 c->width_max, c->height_max,
+			 c->width_step, c->height_step);
+
+		zassert_equal(c->width_step, 16, "width_step != 16");
+		zassert_equal(c->height_step, 16, "height_step != 16");
+		zassert_true(c->width_min  >= CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MIN_SIZE,
+			     "width_min %u < MIN_SIZE", c->width_min);
+		zassert_true(c->width_max  <= CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MAX_WIDTH,
+			     "width_max %u > MAX_WIDTH", c->width_max);
+		zassert_true(c->height_max <= CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MAX_HEIGHT,
+			     "height_max %u > MAX_HEIGHT", c->height_max);
+
+		if (c->pixelformat == VIDEO_PIX_FMT_NV12) {
+			nv12_seen = true;
+		} else if (c->pixelformat == VIDEO_PIX_FMT_NV21) {
+			nv21_seen = true;
+		}
+	}
+
+	zassert_true(nv12_seen, "NV12 missing from capabilities");
+	zassert_true(nv21_seen, "NV21 missing from capabilities");
+
+	/* Wrong endpoint */
+	ret = video_get_caps(jpeg_dev, VIDEO_EP_IN, &caps);
+	zassert_equal(ret, -EINVAL,
+		      "get_caps on EP_IN expected -EINVAL got %d", ret);
+}
+
+ZTEST(jpeg_hantro, test_jpeg_set_format_valid)
+{
+	const struct {
+		uint32_t pixfmt;
+		uint32_t w, h, pitch;
+		const char *name;
+	} cases[] = {
+		{ VIDEO_PIX_FMT_NV12, 640, 480, 640, "NV12" },
+		{ VIDEO_PIX_FMT_NV21, 320, 240, 320, "NV21" },
+	};
+
+	for (int i = 0; i < (int)ARRAY_SIZE(cases); i++) {
+		struct video_format set = {
+			.pixelformat = cases[i].pixfmt,
+			.width  = cases[i].w,
+			.height = cases[i].h,
+			.pitch  = cases[i].pitch,
+		};
+		struct video_format got = { 0 };
+		int ret;
+
+		ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &set);
+		zassert_equal(ret, 0,
+			      "set_format %s failed: %d", cases[i].name, ret);
+
+		ret = video_get_format(jpeg_dev, VIDEO_EP_OUT, &got);
+		zassert_equal(ret, 0,
+			      "get_format %s failed: %d", cases[i].name, ret);
+		zassert_equal(got.pixelformat, cases[i].pixfmt,
+			      "%s pixfmt mismatch", cases[i].name);
+		zassert_equal(got.width,  cases[i].w,
+			      "%s width mismatch",  cases[i].name);
+		zassert_equal(got.height, cases[i].h,
+			      "%s height mismatch", cases[i].name);
+		zassert_equal(got.pitch,  cases[i].pitch,
+			      "%s pitch mismatch",  cases[i].name);
+	}
+}
+
+ZTEST(jpeg_hantro, test_jpeg_set_format_invalid)
+{
+	struct video_format f;
+	int ret;
+
+	/* Too small */
+	f = (struct video_format){
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width = 16, .height = 16, .pitch = 16,
+	};
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &f);
+	zassert_equal(ret, -EINVAL, "tiny dims expected -EINVAL got %d", ret);
+
+	/* Too large */
+	f = (struct video_format){
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width  = CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MAX_WIDTH + 16,
+		.height = CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MAX_HEIGHT + 16,
+		.pitch  = CONFIG_VIDEO_JPEG_HANTRO_VC9000E_MAX_WIDTH + 16,
+	};
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &f);
+	zassert_equal(ret, -EINVAL, "huge dims expected -EINVAL got %d", ret);
+
+	/* Unsupported pixel format */
+	f = (struct video_format){
+		.pixelformat = VIDEO_PIX_FMT_RGB565,
+		.width = 320, .height = 240, .pitch = 640,
+	};
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &f);
+	zassert_equal(ret, -ENOTSUP,
+		      "RGB565 expected -ENOTSUP got %d", ret);
+
+	/* Wrong endpoint */
+	f = (struct video_format){
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width = 320, .height = 240, .pitch = 320,
+	};
+	ret = video_set_format(jpeg_dev, VIDEO_EP_IN, &f);
+	zassert_equal(ret, -EINVAL,
+		      "EP_IN set_format expected -EINVAL got %d", ret);
+}
+
+ZTEST(jpeg_hantro, test_jpeg_set_get_ctrl_quality)
+{
+	uint16_t q;
+	int ret;
+
+	const uint16_t levels[] = { 1, 50, 100 };
+
+	for (int i = 0; i < (int)ARRAY_SIZE(levels); i++) {
+		q = levels[i];
+		ret = video_set_ctrl(jpeg_dev,
+				     VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+		zassert_equal(ret, 0,
+			      "set quality %u failed: %d", levels[i], ret);
+
+		q = 0;
+		ret = video_get_ctrl(jpeg_dev,
+				     VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+		zassert_equal(ret, 0, "get quality failed: %d", ret);
+		zassert_equal(q, levels[i],
+			      "quality readback %u != %u", q, levels[i]);
+	}
+
+	/* Unsupported CID */
+	uint32_t dummy = 0;
+
+	ret = video_set_ctrl(jpeg_dev, 0xDEADBEEF, &dummy);
+	zassert_equal(ret, -ENOTSUP, "unknown CID expected -ENOTSUP got %d", ret);
+}
+
+/*
+ * Single-frame encode validation done at two quality levels: covers
+ * the basic-encode sanity (markers + > header size + < input size +
+ * compression ratio) and additionally checks that the quality knob
+ * has the documented monotonic effect on output size (higher Q =>
+ * larger compressed stream).
+ */
+ZTEST(jpeg_hantro, test_jpeg_encode_quality_levels)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	uint32_t size_q10, size_q90;
+	int ret;
+
+	alloc_ref_buffers(&in, &out);
+
+	ret = do_single_encode(in, out, 10, REF_IMG_WIDTH, REF_IMG_HEIGHT,
+			       REF_IMG_PITCH, &deq);
+	zassert_equal(ret, 0, "encode q=10 failed: %d", ret);
+	zassert_not_null(deq, "q=10 dequeued buffer NULL");
+	zassert_true(deq->bytesused > JPEG_HEADER_SIZE,
+		     "q=10 bytesused %u <= header size", deq->bytesused);
+	zassert_true(deq->bytesused < REF_IMG_NV12_SIZE,
+		     "q=10 no compression: out %u >= in %u",
+		     deq->bytesused, REF_IMG_NV12_SIZE);
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "q=10 markers missing");
+	size_q10 = deq->bytesused;
+
+	ret = do_single_encode(in, out, 90, REF_IMG_WIDTH, REF_IMG_HEIGHT,
+			       REF_IMG_PITCH, &deq);
+	zassert_equal(ret, 0, "encode q=90 failed: %d", ret);
+	zassert_not_null(deq, "q=90 dequeued buffer NULL");
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "q=90 markers missing");
+	size_q90 = deq->bytesused;
+
+	TC_PRINT("Encoded %ux%u: in=%u  q10=%u (%.2fx)  q90=%u (%.2fx)\n",
+		 REF_IMG_WIDTH, REF_IMG_HEIGHT, REF_IMG_NV12_SIZE,
+		 size_q10, (double)REF_IMG_NV12_SIZE / (double)size_q10,
+		 size_q90, (double)REF_IMG_NV12_SIZE / (double)size_q90);
+
+	/* Export hints (only the q=90 buffer survives in `out` at this point). */
+	TC_PRINT("EXPORT[q=90] gdb   : dump binary memory \"q90.jpg\" "
+		 "0x%08x 0x%08x\n",
+		 (uint32_t)(uintptr_t)deq->buffer,
+		 (uint32_t)(uintptr_t)deq->buffer + size_q90);
+	TC_PRINT("EXPORT[q=90] J-Link: savebin q90.jpg 0x%08x 0x%x\n",
+		 (uint32_t)(uintptr_t)deq->buffer, size_q90);
+
+	zassert_true(size_q90 > size_q10,
+		     "expected q90 (%u) > q10 (%u)", size_q90, size_q10);
+
+	release_buffers(in, out);
+}
+
+ZTEST(jpeg_hantro, test_jpeg_encode_multi_resolutions)
+{
+	const struct {
+		uint32_t w, h;
+	} cases[] = {
+		{ 32,  32  },
+		{ 320, 240 },
+		{ 640, 480 },
+	};
+	int ret;
+
+	for (int i = 0; i < (int)ARRAY_SIZE(cases); i++) {
+		uint32_t w = cases[i].w;
+		uint32_t h = cases[i].h;
+		size_t   nv12_size = (size_t)w * h * 3 / 2;
+		struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+
+		in  = video_buffer_alloc(nv12_size, K_NO_WAIT);
+		zassert_not_null(in,  "alloc in (%ux%u) failed", w, h);
+		out = video_buffer_alloc(nv12_size + JPEG_HEADER_SIZE, K_NO_WAIT);
+		zassert_not_null(out, "alloc out (%ux%u) failed", w, h);
+
+		jpeg_fill_nv12_gradient((uint8_t *)in->buffer, w, h, w);
+
+		ret = do_single_encode(in, out, 50, w, h, w, &deq);
+		zassert_equal(ret, 0, "encode %ux%u failed: %d", w, h, ret);
+		zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+						   deq->bytesused),
+			     "%ux%u markers missing", w, h);
+
+		TC_PRINT("Encoded %ux%u -> %u bytes\n", w, h, deq->bytesused);
+
+		release_buffers(in, out);
+	}
+}
+
+ZTEST(jpeg_hantro, test_jpeg_stream_already_started_stopped)
+{
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width = 320, .height = 240, .pitch = 320,
+	};
+	int ret;
+
+	/* Need a valid format before stream_start. */
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	zassert_equal(ret, 0, "set_format failed: %d", ret);
+
+	ret = video_stream_start(jpeg_dev);
+	zassert_equal(ret, 0, "stream_start failed: %d", ret);
+
+	ret = video_stream_start(jpeg_dev);
+	zassert_equal(ret, -EALREADY,
+		      "duplicate stream_start expected -EALREADY got %d", ret);
+
+	ret = video_stream_stop(jpeg_dev);
+	zassert_equal(ret, 0, "stream_stop failed: %d", ret);
+
+	ret = video_stream_stop(jpeg_dev);
+	zassert_equal(ret, -EALREADY,
+		      "duplicate stream_stop expected -EALREADY got %d", ret);
+}
+
+ZTEST(jpeg_hantro, test_jpeg_enqueue_busy)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	alloc_ref_buffers(&in, &out);
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, in->buffer);
+	zassert_equal(ret, 0, "set input buffer failed: %d", ret);
+
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width  = REF_IMG_WIDTH,
+		.height = REF_IMG_HEIGHT,
+		.pitch  = REF_IMG_PITCH,
+	};
+
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	zassert_equal(ret, 0, "set_format failed: %d", ret);
+
+	out->bytesused = DEFAULT_OUT_BUF_SIZE;
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, out);
+	zassert_equal(ret, 0, "first enqueue failed: %d", ret);
+
+	/* Second enqueue without dequeue — driver allows only 1 in flight. */
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, out);
+	zassert_equal(ret, -EBUSY,
+		      "second enqueue expected -EBUSY got %d", ret);
+
+	/* Drain so the test does not leak state. */
+	ret = video_stream_start(jpeg_dev);
+	zassert_equal(ret, 0, "stream_start failed: %d", ret);
+	ret = video_dequeue(jpeg_dev, VIDEO_EP_OUT, &deq, K_SECONDS(5));
+	zassert_equal(ret, 0, "drain dequeue failed: %d", ret);
+	(void)video_stream_stop(jpeg_dev);
+
+	release_buffers(in, out);
+}
+
+ZTEST(jpeg_hantro, test_jpeg_dequeue_timeout)
+{
+	struct video_buffer *deq = NULL;
+	int ret;
+
+	/* No enqueue performed — dequeue must time out. */
+	ret = video_dequeue(jpeg_dev, VIDEO_EP_OUT, &deq, K_MSEC(50));
+	zassert_equal(ret, -EAGAIN,
+		      "dequeue with no buffer expected -EAGAIN got %d", ret);
+}
+
+/*
+ * Repeated encode of the same input + same parameters must produce the
+ * same output size. This helps catch driver state leaks across encodes
+ * even when the test does not compare the full byte stream.
+ */
+ZTEST(jpeg_hantro, test_jpeg_back_to_back_encodes)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	const int iters = 5;
+	uint32_t first_size = 0;
+	int ret;
+
+	alloc_ref_buffers(&in, &out);
+
+	for (int i = 0; i < iters; i++) {
+		ret = do_single_encode(in, out, 50, REF_IMG_WIDTH,
+				       REF_IMG_HEIGHT, REF_IMG_PITCH, &deq);
+		zassert_equal(ret, 0, "encode iter %d failed: %d", i, ret);
+		zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+						   deq->bytesused),
+			     "iter %d markers missing", i);
+
+		if (i == 0) {
+			first_size = deq->bytesused;
+		} else {
+			zassert_equal(deq->bytesused, first_size,
+				      "iter %d size %u != iter0 size %u "
+				      "(non-deterministic re-encode)",
+				      i, deq->bytesused, first_size);
+		}
+		TC_PRINT("iter %d: %u bytes\n", i, deq->bytesused);
+
+		if (i == iters - 1) {
+			TC_PRINT("EXPORT[b2b q=50 iter %d] gdb   : "
+				 "dump binary memory \"b2b_q50.jpg\" "
+				 "0x%08x 0x%08x\n",
+				 i,
+				 (uint32_t)(uintptr_t)deq->buffer,
+				 (uint32_t)(uintptr_t)deq->buffer +
+					deq->bytesused);
+			TC_PRINT("EXPORT[b2b q=50 iter %d] J-Link: "
+				 "savebin b2b_q50.jpg 0x%08x 0x%x\n",
+				 i,
+				 (uint32_t)(uintptr_t)deq->buffer,
+				 deq->bytesused);
+		}
+	}
+
+	release_buffers(in, out);
+}
+
+/* ------------------------------------------------------------------ */
+/* Pre-init / zero-state test.                                         */
+/*                                                                     */
+/* Name prefixed with "aa_" so it sorts alphabetically BEFORE every    */
+/* other test_jpeg_* and therefore executes first, while data->fmt    */
+/* is still zero-initialized (no prior set_format anywhere in the      */
+/* suite). The suite-before hook only does device_is_ready and does    */
+/* NOT touch driver state, so the fresh-state condition is preserved.  */
+/* ------------------------------------------------------------------ */
+
+/*
+ * stream_start() must validate that a format was ever set.
+ * After fresh init data->fmt is zero (width=0, height=0), which is
+ * below the documented minimum (32). Per the video API contract
+ * stream_start on an unconfigured device must fail.
+ */
+ZTEST(jpeg_hantro, test_jpeg_aa_initial_state_rejects_stream_start)
+{
+	struct video_format fmt = { 0 };
+	int ret;
+
+	ret = video_get_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	zassert_equal(ret, 0, "get_format on init failed: %d", ret);
+
+	TC_PRINT("Initial fmt: pix=0x%08x %ux%u pitch=%u\n",
+		 fmt.pixelformat, fmt.width, fmt.height, fmt.pitch);
+
+	/* If the driver pre-initialized fmt to a valid default, the
+	 * "no set_format ever called" scenario is unreachable. Skip.
+	 */
+	if (fmt.width >= 32 && fmt.height >= 32) {
+		TC_PRINT("Driver provides default fmt; skipping check\n");
+		ztest_test_skip();
+		return;
+	}
+
+	ret = video_stream_start(jpeg_dev);
+	/* Best-effort cleanup so subsequent tests are unaffected. */
+	if (ret == 0) {
+		(void)video_stream_stop(jpeg_dev);
+	}
+	zassert_not_equal(ret, 0,
+			  "stream_start without set_format must fail,%d", ret);
+}
+
+/* ------------------------------------------------------------------ */
+/* API contract validation tests.                                       */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Verify that get_ctrl(VIDEO_CID_JPEG_INPUT_BUFFER) returns the
+ * value previously set via set_ctrl. After set/get round-trip the
+ * caller's variable must equal what was set.
+ */
+ZTEST(jpeg_hantro, test_jpeg_get_ctrl_input_buffer_roundtrip)
+{
+	uint8_t dummy_buf[16] = { 0 };
+	void *readback = NULL;
+	int ret;
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, dummy_buf);
+	zassert_equal(ret, 0, "set_ctrl(INPUT_BUFFER) failed: %d", ret);
+
+	ret = video_get_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, &readback);
+	zassert_equal(ret, 0, "get_ctrl(INPUT_BUFFER) failed: %d", ret);
+	zassert_equal_ptr(readback, dummy_buf,
+			  "INPUT_BUFFER get_ctrl did not return the value "
+			  "previously set: got=%p expected=%p",
+			  readback, dummy_buf);
+
+	/* Reset to NULL so it doesn't leak into other tests. */
+	(void)video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, NULL);
+}
+
+/*
+ * Verify that set_ctrl(VIDEO_CID_JPEG_COMPRESSION_QUALITY) validates
+ * range. Per JPEG conventions and the driver's own Kconfig/devicetree
+ * comments (1..100), values of 0 and >100 must be rejected with
+ * -EINVAL.
+ */
+ZTEST(jpeg_hantro, test_jpeg_quality_range_validation)
+{
+	uint16_t q;
+	int ret;
+
+	q = 0;
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+	zassert_equal(ret, -EINVAL,
+		      "quality=0 should be rejected, got %d", ret);
+
+	q = 200;
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+	zassert_equal(ret, -EINVAL,
+		      "quality=200 should be rejected, got %d", ret);
+
+	/* Sanity: legal extremes (1 and 100) must continue to succeed. */
+	q = 1;
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+	zassert_equal(ret, 0, "quality=1 unexpectedly rejected: %d", ret);
+
+	q = 100;
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY, &q);
+	zassert_equal(ret, 0, "quality=100 unexpectedly rejected: %d", ret);
+}
+
+/* ------------------------------------------------------------------ */
+/* Unique-scenario tests: stride / alignment edge cases.               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * NV12 with pitch > width (line padding). The encoder must walk the
+ * source using `pitch` bytes per row but emit only `width` columns.
+ * Validates that the driver's ROWLENGTH / LUMA_STRIDE / CHROMA_STRIDE
+ * register programming follows fmt.pitch rather than fmt.width.
+ */
+ZTEST(jpeg_hantro, test_jpeg_pitch_with_padding)
+{
+	const uint32_t width  = 320;
+	const uint32_t height = 240;
+	const uint32_t pitch  = 384; /* 64 bytes of right-side padding */
+	const size_t   nv12_sz = (size_t)pitch * height * 3 / 2;
+
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	if (!alloc_pair_or_skip(nv12_sz, nv12_sz + JPEG_HEADER_SIZE,
+				&in, &out, "pitch_with_padding")) {
+		return;
+	}
+
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, width, height, pitch);
+
+	ret = do_single_encode(in, out, 50, width, height, pitch, &deq);
+	zassert_equal(ret, 0, "padded-pitch encode failed: %d", ret);
+	zassert_not_null(deq, "padded-pitch dequeued buffer NULL");
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "padded-pitch SOI/EOI missing");
+
+	TC_PRINT("Encoded %ux%u (pitch=%u) -> %u bytes\n",
+		 width, height, pitch, deq->bytesused);
+
+	release_buffers(in, out);
+}
+
+/*
+ * Non-16-aligned dimensions exercise the xfill / yfill paths in
+ * set_format(). The JPEG header still reports the user-supplied
+ * width/height; the encoder pads internally to the 16-px MCU grid.
+ * Validates encode succeeds and produces a structurally-valid stream.
+ */
+ZTEST(jpeg_hantro, test_jpeg_non_aligned_dimensions)
+{
+	const uint32_t width  = 300;  /* 300 % 16 = 12  -> xfill = 2 */
+	const uint32_t height = 200;  /* 200 % 16 =  8  -> yfill = 8 */
+	const uint32_t pitch  = width;
+	const size_t   nv12_sz = (size_t)pitch * height * 3 / 2;
+
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	if (!alloc_pair_or_skip(nv12_sz, nv12_sz + JPEG_HEADER_SIZE,
+				&in, &out, "non_aligned_dimensions")) {
+		return;
+	}
+
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, width, height, pitch);
+
+	ret = do_single_encode(in, out, 50, width, height, pitch, &deq);
+	zassert_equal(ret, 0, "non-aligned encode failed: %d", ret);
+	zassert_not_null(deq, "non-aligned dequeued buffer NULL");
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "non-aligned SOI/EOI missing");
+
+	TC_PRINT("Encoded %ux%u (xfill=2, yfill=8) -> %u bytes\n",
+		 width, height, deq->bytesused);
+
+	release_buffers(in, out);
+}
+
+/* ------------------------------------------------------------------ */
+/* Extended coverage tests.                                            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * NV21 end-to-end encode. The set_format-only NV21 case in
+ * test_jpeg_set_format_valid does NOT run the actual encoder path
+ * (chroma-swap register programming, jpeg_start_encode with NV21,
+ * etc). This test closes that gap by performing a full encode using
+ * the same reference YUV bytes interpreted as NV21.
+ */
+ZTEST(jpeg_hantro, test_jpeg_encode_nv21_end_to_end)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_NV21,
+		.width  = REF_IMG_WIDTH,
+		.height = REF_IMG_HEIGHT,
+		.pitch  = REF_IMG_PITCH,
+	};
+	uint16_t quality = 50;
+	int ret;
+
+	alloc_ref_buffers(&in, &out);
+
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	zassert_equal(ret, 0, "set_format(NV21) failed: %d", ret);
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_COMPRESSION_QUALITY,
+			     &quality);
+	zassert_equal(ret, 0, "set_ctrl(quality) failed: %d", ret);
+
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, in->buffer);
+	zassert_equal(ret, 0, "set_ctrl(input) failed: %d", ret);
+
+	out->bytesused = DEFAULT_OUT_BUF_SIZE;
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, out);
+	zassert_equal(ret, 0, "NV21 enqueue failed: %d", ret);
+
+	ret = video_stream_start(jpeg_dev);
+	zassert_equal(ret, 0, "NV21 stream_start failed: %d", ret);
+
+	ret = video_dequeue(jpeg_dev, VIDEO_EP_OUT, &deq, K_SECONDS(5));
+	(void)video_stream_stop(jpeg_dev);
+
+	zassert_equal(ret, 0, "NV21 dequeue failed: %d", ret);
+	zassert_not_null(deq, "NV21 dequeued buffer NULL");
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "NV21 SOI/EOI missing");
+
+	TC_PRINT("NV21 encode %ux%u -> %u bytes\n",
+		 REF_IMG_WIDTH, REF_IMG_HEIGHT, deq->bytesused);
+
+	release_buffers(in, out);
+}
+
+/*
+ * Format-switch between encodes. Two encodes back-to-back at
+ * DIFFERENT resolutions on the same device. Validates that
+ * set_format() correctly re-programs all dimension-dependent HW
+ * registers (encoding_width/height, xfill/yfill, stride) and that no
+ * state leaks from the first encode into the second.
+ */
+ZTEST(jpeg_hantro, test_jpeg_encode_format_switch)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	const uint32_t w1 = 640, h1 = 480;
+	const uint32_t w2 = 320, h2 = 240;
+	const size_t   sz1 = (size_t)w1 * h1 * 3 / 2;
+	const size_t   sz2 = (size_t)w2 * h2 * 3 / 2;
+	uint32_t size_at_640, size_at_320;
+	int ret;
+
+	/* The video buffer pool has NUM_MAX=2 slots, so we can only
+	 * keep two buffers alive at once. Allocate the output buffer
+	 * once (reused across both encodes), and recycle the input
+	 * slot between the two resolutions.
+	 */
+	out = video_buffer_alloc(sz1 + JPEG_HEADER_SIZE, K_NO_WAIT);
+	zassert_not_null(out, "alloc out failed");
+
+	/* First encode at 640x480. */
+	in = video_buffer_alloc(sz1, K_NO_WAIT);
+	zassert_not_null(in, "alloc in (640x480) failed");
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, w1, h1, w1);
+
+	ret = do_single_encode(in, out, 50, w1, h1, w1, &deq);
+	zassert_equal(ret, 0, "640x480 encode failed: %d", ret);
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "640x480 markers missing");
+	size_at_640 = deq->bytesused;
+
+	video_buffer_release(in);
+	in = NULL;
+
+	/* Second encode at 320x240 (different resolution => set_format
+	 * must reprogram all dimension-dependent HW registers).
+	 */
+	in = video_buffer_alloc(sz2, K_NO_WAIT);
+	zassert_not_null(in, "alloc in (320x240) failed");
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, w2, h2, w2);
+
+	ret = do_single_encode(in, out, 50, w2, h2, w2, &deq);
+	zassert_equal(ret, 0, "320x240 encode (after 640x480) failed: %d",
+		      ret);
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "320x240 markers missing");
+	size_at_320 = deq->bytesused;
+
+	zassert_true(size_at_640 > size_at_320,
+		     "640x480 size %u should exceed 320x240 size %u",
+		     size_at_640, size_at_320);
+
+	TC_PRINT("Format-switch: 640x480=%u  320x240=%u\n",
+		 size_at_640, size_at_320);
+
+	video_buffer_release(in);
+	video_buffer_release(out);
+}
+
+/*
+ * Negative path: enqueue with NULL input buffer must be rejected.
+ * The driver checks data->input_buffer == NULL before queueing and
+ * returns -EINVAL. Resets state on entry/exit so it does not depend
+ * on test ordering.
+ */
+ZTEST(jpeg_hantro, test_jpeg_enqueue_without_input_buffer)
+{
+	struct video_buffer *out = NULL;
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_NV12,
+		.width = 320, .height = 240, .pitch = 320,
+	};
+	int ret;
+
+	/* Clear any input buffer left over from previous tests. */
+	ret = video_set_ctrl(jpeg_dev, VIDEO_CID_JPEG_INPUT_BUFFER, NULL);
+	zassert_equal(ret, 0, "clear input ctrl failed: %d", ret);
+
+	ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+	zassert_equal(ret, 0, "set_format failed: %d", ret);
+
+	out = video_buffer_alloc(64 * 1024, K_NO_WAIT);
+	zassert_not_null(out, "alloc out failed");
+	out->bytesused = 64 * 1024;
+
+	ret = video_enqueue(jpeg_dev, VIDEO_EP_OUT, out);
+	zassert_equal(ret, -EINVAL,
+		      "enqueue with NULL input expected -EINVAL got %d", ret);
+
+	video_buffer_release(out);
+}
+
+/*
+ * Deep structural validation of the produced JPEG. SOI/EOI-only
+ * checks accept many malformed streams; this test additionally
+ * asserts presence of APP0/JFIF identifier, at least one DQT, SOF0,
+ * at least one DHT, SOS and a terminating EOI -- enough to guarantee
+ * the stream is decodable by any baseline JPEG decoder.
+ */
+ZTEST(jpeg_hantro, test_jpeg_jfif_structural_validation)
+{
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	alloc_ref_buffers(&in, &out);
+
+	ret = do_single_encode(in, out, 75, REF_IMG_WIDTH, REF_IMG_HEIGHT,
+			       REF_IMG_PITCH, &deq);
+	zassert_equal(ret, 0, "encode failed: %d", ret);
+	zassert_true(jpeg_validate_markers((uint8_t *)deq->buffer,
+					   deq->bytesused),
+		     "SOI/EOI missing");
+	zassert_true(jpeg_validate_jfif_structure((uint8_t *)deq->buffer,
+						  deq->bytesused),
+		     "JFIF structure incomplete (missing APP0/JFIF, DQT, "
+		     "SOF0, DHT, SOS or EOI in proper order)");
+
+	/* Verify that SOF0 reports the same dimensions we encoded. Catches
+	 * driver bugs where the JPEG header carries stale/swapped W/H.
+	 */
+	uint16_t enc_w = 0, enc_h = 0;
+
+	zassert_true(jpeg_extract_sof0_dimensions((uint8_t *)deq->buffer,
+						  deq->bytesused,
+						  &enc_w, &enc_h),
+		     "SOF0 marker not found / unparseable");
+	zassert_equal(enc_w, REF_IMG_WIDTH,
+		      "SOF0 width mismatch: got %u, expected %u",
+		      enc_w, REF_IMG_WIDTH);
+	zassert_equal(enc_h, REF_IMG_HEIGHT,
+		      "SOF0 height mismatch: got %u, expected %u",
+		      enc_h, REF_IMG_HEIGHT);
+
+	TC_PRINT("JFIF structure OK: %u bytes, SOF0=%ux%u\n",
+		 deq->bytesused, enc_w, enc_h);
+
+	release_buffers(in, out);
+}
+
+/*
+ * Large-resolution stress: 1920x1080 NV12 encode. Validates that the
+ * driver handles address calculations and HW programming for FHD
+ * input. Skipped automatically if the buffer pool is too small for
+ * this resolution (e.g. when CONFIG_VIDEO_BUFFER_POOL_SZ_MAX has been
+ * lowered).
+ */
+ZTEST(jpeg_hantro, test_jpeg_encode_large_1920x1080)
+{
+	const uint32_t width  = 1920;
+	const uint32_t height = 1080;
+	const size_t   nv12_sz = (size_t)width * height * 3 / 2;
+
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	if (!alloc_pair_or_skip(nv12_sz, nv12_sz + JPEG_HEADER_SIZE,
+				&in, &out, "1920x1080")) {
+		return;
+	}
+
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, width, height, width);
+
+	ret = do_single_encode(in, out, 50, width, height, width, &deq);
+	zassert_equal(ret, 0, "1920x1080 encode failed: %d", ret);
+	zassert_not_null(deq, "1920x1080 dequeued NULL");
+	zassert_true(jpeg_validate_jfif_structure((uint8_t *)deq->buffer,
+						  deq->bytesused),
+		     "1920x1080 JFIF structure incomplete");
+
+	TC_PRINT("Encoded 1920x1080 -> %u bytes (%.2fx compression)\n",
+		 deq->bytesused, (double)nv12_sz / (double)deq->bytesused);
+	TC_PRINT("EXPORT[1920x1080 q=50] gdb   : "
+		 "dump binary memory \"fhd_q50.jpg\" 0x%08x 0x%08x\n",
+		 (uint32_t)(uintptr_t)deq->buffer,
+		 (uint32_t)(uintptr_t)deq->buffer + deq->bytesused);
+	TC_PRINT("EXPORT[1920x1080 q=50] J-Link: "
+		 "savebin fhd_q50.jpg 0x%08x 0x%x\n",
+		 (uint32_t)(uintptr_t)deq->buffer, deq->bytesused);
+
+	release_buffers(in, out);
+}
+
+/*
+ * HRM negative contract: the IP supports many input formats (YUV400,
+ * YUV422, RGB, tiled, etc.) but the Zephyr driver only exposes NV12
+ * and NV21. set_format MUST reject every other documented HRM input
+ * format with a non-zero error. Locks in the negative API contract
+ * so a future driver expansion cannot silently change behavior
+ * without updating this test.
+ */
+ZTEST(jpeg_hantro, test_jpeg_set_format_unsupported_hrm_formats)
+{
+	static const struct {
+		uint32_t fourcc;
+		const char *name;
+	} cases[] = {
+		{ VIDEO_PIX_FMT_YUYV, "YUYV (4:2:2)" },
+		{ VIDEO_PIX_FMT_GREY, "GREY/Y8 (4:0:0)" },
+		{ VIDEO_PIX_FMT_RGB565, "RGB565" },
+		{ VIDEO_PIX_FMT_XRGB32, "XRGB32" },
+	};
+	int ret;
+
+	for (int i = 0; i < (int)ARRAY_SIZE(cases); i++) {
+		struct video_format fmt = {
+			.pixelformat = cases[i].fourcc,
+			.width = 320, .height = 240, .pitch = 320,
+		};
+		ret = video_set_format(jpeg_dev, VIDEO_EP_OUT, &fmt);
+		zassert_not_equal(ret, 0,
+				  "%s (0x%08x) should be rejected, got 0",
+				  cases[i].name, cases[i].fourcc);
+		TC_PRINT("rejected %-20s (0x%08x): ret=%d\n",
+			 cases[i].name, cases[i].fourcc, ret);
+	}
+}
+
+/*
+ * Wide-image / max-width path. The IP and driver advertise a max
+ * width of 16384 px. Encoding at the full max would consume an
+ * impractical pool slot (16384 * H * 1.5); instead we encode at
+ * 8192x32 NV12 which still exercises the wide-stride address math
+ * end-to-end (~393 KB input). If your pool is sized smaller this
+ * test will auto-skip.
+ */
+ZTEST(jpeg_hantro, test_jpeg_encode_max_width)
+{
+	const uint32_t width  = 8192;
+	const uint32_t height = 32;
+	const size_t   nv12_sz = (size_t)width * height * 3 / 2;
+
+	struct video_buffer *in = NULL, *out = NULL, *deq = NULL;
+	int ret;
+
+	if (!alloc_pair_or_skip(nv12_sz, nv12_sz + JPEG_HEADER_SIZE,
+				&in, &out, "8192x32")) {
+		return;
+	}
+
+	jpeg_fill_nv12_gradient((uint8_t *)in->buffer, width, height, width);
+
+	ret = do_single_encode(in, out, 50, width, height, width, &deq);
+	zassert_equal(ret, 0, "8192x32 encode failed: %d", ret);
+	zassert_true(jpeg_validate_jfif_structure((uint8_t *)deq->buffer,
+						  deq->bytesused),
+		     "8192x32 JFIF structure incomplete");
+
+	TC_PRINT("Encoded 8192x32 -> %u bytes\n", deq->bytesused);
+
+	release_buffers(in, out);
+}
+
+ZTEST_SUITE(jpeg_hantro, NULL, NULL, jpeg_suite_before, NULL, NULL);

--- a/tests/drivers/jpeg/testcase.yaml
+++ b/tests/drivers/jpeg/testcase.yaml
@@ -1,0 +1,18 @@
+common:
+  tags:
+    - drivers
+    - video
+    - jpeg
+  depends_on: video
+  harness: ztest
+  harness_config:
+    fixture: fixture_jpeg
+  platform_allow:
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+  integration_platforms:
+    - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+
+tests:
+  drivers.video.jpeg.hantro_vc9000e:
+    filter: dt_compat_enabled("verisilicon,hantro-vc9000e-jpeg")


### PR DESCRIPTION
Add ZTest suite for JPEG driver with baseline API tests, extended coverage tests, API contract validation, and performance benchmarks. Includes helper functions, documentation, and build config.