### PR TITLE
manifest: bump zephyr for external BLE/LC3 ROM API support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e97e11060130e34efb3f47ec67a323b40b92a0ba
+      revision: 0c8c78c5094c47a826d65ca934efcdaa5f734350
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
## Enable an externally supplied BLE/LC3 ROM API

### Summary
Advance the SDK to the point where an out-of-tree module can supply the BLE/LC3
ROM API — the public headers, the ROM symbol-address linker scripts, and the
host-stack patch — instead of the version bundled in the HAL.

### Motivation
The BLE/LC3 ROM API is currently fixed to the single version bundled in
`hal_alif`, selected from the `ble-rom-version` device-tree property. This
provides no way to build against a different ROM, which is required for **ROM
development**: a ROM build under development has its own symbol addresses and
host-stack patch, paired to the ROM image they were produced from, and is not
part of the public HAL.

### Changes
| Component | Change |
| --- | --- |
| `hal_alif` | Adds the opt-in hook: `ALIF_BLE_ROM_API_EXTERNAL` and the path options `ALIF_BLE_ROM_API_DIR`, `ALIF_LC3_ROM_API_DIR`, `ALIF_BLE_ROM_SYMBOLS_LDS`, `ALIF_LC3_ROM_SYMBOLS_LDS`. When set, the `ble`/`lc3` CMake adds the external provider directory and `linker_add_rom_symbols.ld` includes the external symbol scripts. |
| `zephyr` (SoC Kconfig) | Gates the device-tree-driven bundled selection (`ALIF_BLE_ROM_IMAGE_V1_2`) on `!ALIF_BLE_ROM_API_EXTERNAL`, so an external provider supersedes the bundled version instead of both contributing ROM symbol linker scripts. |
| `west.yml` | Advances the `zephyr` revision to pull in the above. |

### Provider contract
An external provider is a directory added with `add_subdirectory()` that exposes
the public API headers, links the host-stack patch, and wires the patch sections
(via `ALIF_BLE_ROM_PATCH_LD_DIR`). `ALIF_BLE_ROM_SYMBOLS_LDS` /
`ALIF_LC3_ROM_SYMBOLS_LDS` are absolute paths to the ROM symbol-address linker
scripts. Selection is typically set from a board's `Kconfig.defconfig`.

### Compatibility
Opt-in. When no module selects `ALIF_BLE_ROM_API_EXTERNAL`, selection flows from
`ble-rom-version` to the bundled ROM API as before. The on-chip ROM is not
shipped or modified; only the interface used to call into it is supplied.

Depends on alifsemi/zephyr_alif#567.