### PR TITLE
Add Alif MLEK as submanifest

### DIFF
--- a/submanifests/alif-mlek.yaml
+++ b/submanifests/alif-mlek.yaml
@@ -1,0 +1,19 @@
+# alif-mlek module manifest for Zephyr RTOS
+# This file enables fetching the alif-mlek module using west
+# Usage:
+#   west config manifest.project-filter -- +alif-mlek
+#   west update
+
+manifest:
+  remotes:
+    - name: alif
+      url-base: https://github.com/alifsemi
+
+  projects:
+    - name: alif-mlek
+      remote: alif
+      repo-path: alif_ml-embedded-evaluation-kit
+      revision: 0b6ce72c495265501f7a12eaed8e6ea71ef4bf15
+      path: modules/alif-mlek
+      groups:
+        - alif-mlek


### PR DESCRIPTION
This pull request introduces a new module manifest file for integrating the Alif MLEK (Machine Learning Embedded Kit) module with Zephyr RTOS. The manifest enables users to fetch and manage the Alif MLEK module using the `west` tool.

Module integration:

* Added `submanifests/alif-mlek.yaml` manifest file to allow fetching the Alif MLEK module from the `alifsemi` GitHub organization, specifying the repository, revision, and local path for integration with Zephyr projects.

Usage:
west config manifest.project-filter -- +alif-mlek