### PR TITLE
manifest: Update zephyr revision to include Picture size violation fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e97e11060130e34efb3f47ec67a323b40b92a0ba
+      revision: pull/570/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 97fddffd316f63f9325545ec5c3dfc9a5034d831
+      revision: 3e6f65c7c226c58a2c14d764d27e583cc94d6b80
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to include picture size violation fix.

This PR depends on: alifsemi/zephyr_alif/pull/570
This PR depends on: alifsemi/hal_alif/pull/133