### PR TITLE
samples: modules: lvgl: add D/AVE 2D accelerated benchmark

### DIFF
--- a/samples/modules/lvgl/benchmark/CMakeLists.txt
+++ b/samples/modules/lvgl/benchmark/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(lvgl_dave2d_benchmark)
+
+set(LVGL_DIR ${ZEPHYR_LVGL_MODULE_DIR})
+
+target_sources(app PRIVATE src/main.c)
+
+target_include_directories(app PRIVATE ${LVGL_DIR}/demos/)
+
+# LVGL's upstream D/AVE 2D draw unit was written for the Renesas FSP and pulls in
+# "hal_data.h". The include/ directory provides a compatibility shim that maps
+# the TES D/AVE 2D driver headers. It must be visible to the LVGL module library
+# build (not just the app), so it is added to the global include path.
+zephyr_include_directories(include)
+
+# The upstream draw unit gates its D-cache maintenance (clean/invalidate of the
+# GPU source and destination buffers) behind the macros
+# ARM_CORTEX_M55_M85 and BSP_CFG_DCACHE_ENABLED. The guarded code itself is
+# portable (CMSIS SCB_* and the Alif d1_cacheblockflush() helper). The Alif
+# Cortex-M55 runs with D-cache enabled and the GPU buffers live in cacheable
+# SRAM, so this maintenance is required for CPU/GPU coherency. Define the macros
+# for the whole build (the LVGL module needs them too, not just the app).
+zephyr_compile_definitions(ARM_CORTEX_M55_M85=1 BSP_CFG_DCACHE_ENABLED=1)
+
+# lv_demo_benchmark cycles through the widgets demo scenes, so both the
+# benchmark and widgets demo sources are required.
+target_sources_ifdef(CONFIG_LV_USE_DEMO_BENCHMARK app PRIVATE
+    ${LVGL_DIR}/demos/benchmark/lv_demo_benchmark.c
+    ${LVGL_DIR}/demos/benchmark/assets/img_benchmark_avatar.c
+    ${LVGL_DIR}/demos/benchmark/assets/img_benchmark_lvgl_logo_argb.c
+    ${LVGL_DIR}/demos/benchmark/assets/img_benchmark_lvgl_logo_rgb.c
+    ${LVGL_DIR}/demos/benchmark/assets/lv_font_benchmark_montserrat_12_compr_az.c.c
+    ${LVGL_DIR}/demos/benchmark/assets/lv_font_benchmark_montserrat_16_compr_az.c.c
+    ${LVGL_DIR}/demos/benchmark/assets/lv_font_benchmark_montserrat_28_compr_az.c.c
+)
+
+target_sources_ifdef(CONFIG_LV_USE_DEMO_WIDGETS app PRIVATE
+    ${LVGL_DIR}/demos/widgets/lv_demo_widgets.c
+    ${LVGL_DIR}/demos/widgets/assets/img_clothes.c
+    ${LVGL_DIR}/demos/widgets/assets/img_demo_widgets_avatar.c
+    ${LVGL_DIR}/demos/widgets/assets/img_demo_widgets_needle.c
+    ${LVGL_DIR}/demos/widgets/assets/img_lvgl_logo.c
+)
+
+# The LVGL rendering buffers (.lvgl_buf) and memory pool (.lvgl_heap) are
+# rendered into by the D/AVE 2D GPU as a bus master, so relocate them into
+# globally addressable SRAM0. In DIRECT mode these full-screen VDBs also
+# serve as the CDC200 scan-out framebuffers (zero-copy page-flip).
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
+    SECTIONS lvgl_sram.ld)

--- a/samples/modules/lvgl/benchmark/README.rst
+++ b/samples/modules/lvgl/benchmark/README.rst
@@ -1,0 +1,148 @@
+.. _lvgl_dave2d_benchmark:
+
+LVGL D/AVE 2D Benchmark
+#######################
+
+Overview
+********
+
+This sample runs the upstream LVGL ``lv_demo_benchmark`` application with all
+rendering offloaded to the Alif D/AVE 2D (GPU2D) accelerator. It displays the
+benchmark scenes on the MIPI-DSI MW405 panel of the Alif Ensemble E8 DevKit and
+reports the measured frames-per-second of each scene on the panel.
+
+The sample is intentionally thin: it reuses the LVGL benchmark and widgets demo
+sources shipped with the LVGL module, lets the Zephyr LVGL glue create the
+display and rendering buffers, and only adds the small amount of Alif-specific
+glue required to drive the GPU.
+
+What it takes to accelerate LVGL with D/AVE 2D
+**********************************************
+
+* **Kconfig** - enable the GPU draw unit and the D/AVE 2D library:
+
+  .. code-block:: cfg
+
+     CONFIG_DAVE2D=y
+     CONFIG_LV_USE_DRAW_DAVE2D=y
+
+  ``CONFIG_DAVE2D`` exposes the D/AVE 2D ``d0``/``d1``/``d2`` headers globally and
+  the LVGL draw unit (``src/draw/renesas/dave2d``) is compiled in when
+  ``LV_USE_DRAW_DAVE2D`` is set.
+
+* **hal_data.h shim** - LVGL's D/AVE 2D draw unit was written against the Renesas
+  FSP and includes ``hal_data.h``, from which it obtains the D/AVE 2D driver, the
+  framebuffer colour format (``g_display0_cfg``) and the D-cache configuration
+  (``BSP_CFG_DCACHE_ENABLED``). Zephyr does not provide this header, so the sample
+  ships a small compatibility shim in :file:`include/hal_data.h` that maps the TES
+  D/AVE 2D driver headers, reports the framebuffer format that matches the LVGL
+  colour depth, and enables the draw unit's cache maintenance. The shim is added
+  to the global include path with ``zephyr_include_directories()`` so it is
+  visible to the LVGL module library build (not just the application):
+
+  .. code-block:: cmake
+
+     zephyr_include_directories(include)
+
+* **Cache coherency** - the Alif Cortex-M55 runs with its D-cache enabled and the
+  GPU buffers live in cacheable SRAM, so the CPU and the GPU must be kept
+  coherent. The draw unit already performs the required clean/invalidate around
+  the GPU source and destination buffers, gated by ``BSP_CFG_DCACHE_ENABLED``;
+  the shim enables those paths, which use portable CMSIS (``SCB_*``) and the Alif
+  ``d1_cacheblockflush()`` helper.
+
+* **Devicetree** - the GPU node is not part of the SoC devicetree, so the board
+  overlays add it together with the ``d2-inst`` alias the D/AVE 2D ``d1`` layer
+  uses to locate the GPU:
+
+  .. code-block:: devicetree
+
+     aliases { d2-inst = &gpu2d; };
+     soc {
+         gpu2d: dave2d@49040000 {
+             compatible = "tes,dave2d";
+             reg = <0x49040000 0x1000>;
+             interrupts = <332 2>;
+             clocks = <&clockctrl ALIF_GPU_CLK>;
+         };
+     };
+
+* **D/AVE 2D heap** - the LVGL draw unit allocates its display lists and render
+  buffers from the D/AVE 2D heap during ``lv_init()``. Because the Zephyr LVGL
+  glue calls ``lv_init()`` automatically from an ``APPLICATION``-level
+  ``SYS_INIT()`` hook, the application initialises the heap from an earlier
+  ``POST_KERNEL`` hook (see :file:`src/main.c`).
+
+* **Memory placement** - the D/AVE 2D heap and full-screen double-buffered VDBs
+  together exceed what DTCM can provide, so they are placed in the larger
+  globally-addressable SRAM banks where the CPU, GPU and CDC200 can all access
+  them:
+
+  - the D/AVE 2D heap (512 KB) is placed in SRAM1 via ``__alif_sram1_section``;
+  - the two full-screen LVGL VDBs (``.lvgl_buf``) and memory pool
+    (``.lvgl_heap``) are relocated to SRAM0 by :file:`lvgl_sram.ld`
+    (``CONFIG_LV_Z_VDB_CUSTOM_SECTION`` / ``CONFIG_LV_Z_MEMORY_POOL_CUSTOM_SECTION``).
+
+  In DIRECT mode the VDBs double as the CDC200 scan-out framebuffers (zero-copy
+  page-flip via ``cdc200_swap_fb()``), so no separate framebuffer allocation is
+  needed.
+
+Display
+*******
+
+The board overlays enable the CDC200 controller, the MIPI-DSI host and the
+MW405 panel (480x800, configured here as RGB565 to match LVGL's default 16-bit
+colour depth) and select the CDC200 as ``zephyr,display``.
+
+Powering the display pipeline (E8)
+==================================
+
+On the Ensemble E8 the MIPI-DSI/D-PHY, the CDC200 and the GPU are power- and
+clock-gated out of reset, so the application restores a run profile through the
+Secure Enclave before the drivers initialise (see ``display_pipeline_power_init()``
+in :file:`src/main.c`, registered at ``SYS_INIT(PRE_KERNEL_1, 46)``):
+
+* It enables the **HFOSC (38.4 MHz)** oscillator, which is the MIPI D-PHY PLL
+  reference clock (the ``dphy`` node's ``ref-frequency``). Without it the D-PHY
+  PLL never locks and the panel cannot attach to the DSI host
+  (``D-PLL not locked to desired frequency`` / ``Could not attach to MIPI-DSI host``).
+* It powers the MIPI TX/RX/PLL D-PHYs and the PHY LDO
+  (``phy_pwr_gating``) and ungates the CDC200, MIPI-DSI and GPU2D clocks
+  (``ip_clock_gating``).
+* It keeps SRAM0 (LVGL buffers) and SRAM1 (D/AVE 2D heap) powered
+  (``memory_blocks``).
+* On the E8 DevKit the MIPI lanes pass through a camera/display mux; the
+  application drives the mux GPIO (``cam-disp-mux-gpios``, on ``gpio14``) to the
+  display position, so the overlays also enable ``&gpio14``.
+
+The CDC200 scan-out engine is also not started by its own driver init, and the
+generic ``display_blanking_off()`` API (which LVGL's Zephyr glue calls) is a
+no-op for it. The application therefore starts it explicitly with
+``cdc200_set_enable(display_dev, true)`` in :file:`src/main.c`; without it the
+panel stays dark even though the DSI link and backlight are up.
+
+.. note::
+
+   The overlays target the MW405 panel wired as the Ensemble devicetree default.
+   If your DevKit ships a different panel, adjust the ``cdc200`` timings,
+   ``pixel-fmt-l1`` and the MIPI-DSI panel child node accordingly.
+
+Building and Running
+********************
+
+RTSS-HE:
+
+.. code-block:: console
+
+   west build -p auto -b alif_e8_dk/ae822fa0e5597xx0/rtss_he \
+       alif/samples/modules/lvgl/benchmark
+
+RTSS-HP:
+
+.. code-block:: console
+
+   west build -p auto -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp \
+       alif/samples/modules/lvgl/benchmark
+
+After flashing, the benchmark scenes are rendered on the panel and each scene's
+frames-per-second result is shown on screen.

--- a/samples/modules/lvgl/benchmark/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
+++ b/samples/modules/lvgl/benchmark/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay
@@ -1,0 +1,10 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+#include "alif_ensemble_dk.overlay"

--- a/samples/modules/lvgl/benchmark/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
+++ b/samples/modules/lvgl/benchmark/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
@@ -1,0 +1,10 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+#include "alif_ensemble_dk.overlay"

--- a/samples/modules/lvgl/benchmark/boards/alif_ensemble_dk.overlay
+++ b/samples/modules/lvgl/benchmark/boards/alif_ensemble_dk.overlay
@@ -1,0 +1,115 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <zephyr/dt-bindings/clock/alif_ensemble_clocks.h>
+#include <dt-bindings/misc/alif_aipm_ensemble_gen2.h>
+
+/ {
+	chosen {
+		zephyr,display = &cdc200;
+	};
+
+	aliases {
+		/* Used by the D/AVE 2D (d1) layer to locate the GPU node. */
+		d2-inst = &gpu2d;
+	};
+
+	soc {
+		gpu2d: dave2d@49040000 {
+			compatible = "tes,dave2d";
+			reg = <0x49040000 0x1000>;
+			interrupts = <332 2>;
+			clocks = <&clockctrl ALIF_GPU_CLK>;
+		};
+
+		/* Override the placeholder CDC200 timings for the 480x800 MW405 panel. */
+		cdc200: cdc200@49031000 {
+			width = <480>;
+			height = <800>;
+			hfront-porch = <5>;
+			hback-porch = <5>;
+			hsync-len = <4>;
+			vfront-porch = <10>;
+			vback-porch = <10>;
+			vsync-len = <2>;
+			clock-frequency = <24364080>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			de-active = <1>;
+			pixelclk-active = <0>;
+			bg-color = <0>;
+			enable-l1 = <1>;
+			pixel-fmt-l1 = "rgb-565";
+			def-back-color-l1 = <0>;
+			win-x0-l1 = <0>;
+			win-y0-l1 = <0>;
+			win-x1-l1 = <480>;
+			win-y1-l1 = <800>;
+			blend-factor1-l1 = <4>;
+			blend-factor2-l1 = <5>;
+			const-alpha-l1 = <0xff>;
+			enable-l2 = <0>;
+			pixel-fmt-l2 = "undefined";
+			win-x0-l2 = <0>;
+			win-y0-l2 = <0>;
+			win-x1-l2 = <0>;
+			win-y1-l2 = <0>;
+			blend-factor1-l2 = <6>;
+			blend-factor2-l2 = <7>;
+			const-alpha-l2 = <0xff>;
+		};
+	};
+};
+
+&aipm_run_default {
+	ip-clock-gating = <(ALIF_IP_CLK_GATE_CDC200_MASK |
+			    ALIF_IP_CLK_GATE_MIPI_DSI_MASK |
+			    ALIF_IP_CLK_GATE_GPU_MASK)>;
+	phy-pwr-gating  = <(ALIF_PHY_GATE_MIPI_TX_DPHY_MASK |
+			    ALIF_PHY_GATE_MIPI_RX_DPHY_MASK |
+			    ALIF_PHY_GATE_MIPI_PLL_DPHY_MASK |
+			    ALIF_PHY_GATE_LDO_MASK)>;
+};
+
+&clk_38p4m {
+	status = "okay";
+};
+
+&mipi_dsi {
+	status = "okay";
+};
+
+/* GPIO controller for the MIPI camera/display mux (cam-disp-mux-gpios on the DSI
+ * host). The application drives it to route the MIPI lanes to the panel.
+ */
+&gpio14 {
+	status = "okay";
+
+	hog1 {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+/* GPIO controllers used by the MW405 panel (reset on lpgpio, backlight on gpio6). */
+&lpgpio {
+	status = "okay";
+};
+
+&gpio6 {
+	status = "okay";
+};
+
+/*
+ * Non-secure DTCM window: not needed in DIRECT mode (the full-screen LVGL VDBs
+ * in SRAM0 serve as both the GPU render targets and the CDC200 scan-out
+ * framebuffers). Leave the ns node disabled (SoC default).
+ */

--- a/samples/modules/lvgl/benchmark/include/hal_data.h
+++ b/samples/modules/lvgl/benchmark/include/hal_data.h
@@ -1,0 +1,64 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#ifndef HAL_DATA_H
+#define HAL_DATA_H
+
+/*
+ * Compatibility shim for LVGL's D/AVE 2D draw unit.
+ *
+ * The upstream D/AVE 2D draw unit transitively provides the driver
+ * and the BSP cache configuration. This file is required to provide
+ * a minimal stand-in for the D/AVE 2D driver and BSP cache
+ * configuration, so that the D/AVE 2D draw unit can be used on Alif.
+ */
+#include <cmsis_core.h>
+
+#include <dave_driver.h>
+#include <dave_d0lib.h>
+
+/*
+ * lv_draw_dave2d_cf_fb_get() determines the D/AVE 2D framebuffer mode
+ * from the display driver configuration (g_display0_cfg). On Alif the
+ * LVGL framebuffer always matches the configured LVGL colour depth,
+ * so we provide a minimal stand-in that reports that fixed format.
+ */
+typedef enum {
+	DISPLAY_IN_FORMAT_16BITS_RGB565 = 0,
+	DISPLAY_IN_FORMAT_32BITS_ARGB8888,
+	DISPLAY_IN_FORMAT_32BITS_RGB888,
+	DISPLAY_IN_FORMAT_16BITS_ARGB4444,
+	DISPLAY_IN_FORMAT_16BITS_ARGB1555,
+	DISPLAY_IN_FORMAT_CLUT8,
+	DISPLAY_IN_FORMAT_CLUT4,
+	DISPLAY_IN_FORMAT_CLUT1,
+} display_in_format_t;
+
+typedef struct {
+	display_in_format_t format;
+} display_input_cfg_t;
+
+typedef struct {
+	const display_input_cfg_t *input;
+} display_cfg_t;
+
+static const display_input_cfg_t _alif_dave2d_fb_input = {
+#if LV_COLOR_DEPTH == 32
+	.format = DISPLAY_IN_FORMAT_32BITS_ARGB8888,
+#else
+	.format = DISPLAY_IN_FORMAT_16BITS_RGB565,
+#endif
+};
+
+static const display_cfg_t g_display0_cfg = {
+	.input = &_alif_dave2d_fb_input,
+};
+
+#endif /* HAL_DATA_H */

--- a/samples/modules/lvgl/benchmark/lvgl_sram.ld
+++ b/samples/modules/lvgl/benchmark/lvgl_sram.ld
@@ -1,0 +1,32 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * Relocate the LVGL rendering buffers (.lvgl_buf) and memory pool (.lvgl_heap)
+ * into SRAM0. Both are rendered into by the D/AVE 2D GPU, which is a bus master;
+ * SRAM0 is globally addressable, so the CPU, GPU and CDC200 all share the same
+ * view. In DIRECT mode the VDBs also serve as the CDC200 scan-out framebuffers
+ * (zero-copy page-flip).
+ */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram0), okay)
+GROUP_START(SRAM0)
+
+	SECTION_PROLOGUE(.lvgl_sram, (NOLOAD),)
+	{
+		. = ALIGN(8);
+		KEEP(*(.lvgl_buf))
+		KEEP(*(".lvgl_buf.*"))
+		. = ALIGN(8);
+		KEEP(*(.lvgl_heap))
+		KEEP(*(".lvgl_heap.*"))
+	} GROUP_LINK_IN(SRAM0)
+
+GROUP_END(SRAM0)
+#endif

--- a/samples/modules/lvgl/benchmark/prj.conf
+++ b/samples/modules/lvgl/benchmark/prj.conf
@@ -1,0 +1,100 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+#
+
+# Display pipeline: CDC200 controller + MIPI-DSI host + MW405 panel.
+CONFIG_DISPLAY=y
+CONFIG_MIPI_DSI=y
+
+# LVGL and the benchmark demo (cycles through the widgets demo scenes).
+CONFIG_LVGL=y
+CONFIG_LV_USE_DEMO_BENCHMARK=y
+CONFIG_LV_USE_DEMO_WIDGETS=y
+
+# Refresh at ~60 FPS. The LVGL default is 33 ms (~30 FPS), which caps the
+# benchmark's reported FPS at 30 regardless of how fast the D/AVE 2D GPU renders.
+CONFIG_LV_DEF_REFR_PERIOD=16
+
+# Performance monitor (sysmon). The benchmark reports per-scene FPS/CPU through
+# it; without it the on-screen title shows "LV_USE_PERF_MONITOR is not enabled"
+# and the summary table reports "N/A" for every scene.
+CONFIG_LV_USE_SYSMON=y
+CONFIG_LV_USE_PERF_MONITOR=y
+# Print the benchmark's CSV summary to the serial console. The demo emits it via
+# lv_log() at USER level; route it through LVGL's logging (the Zephyr glue maps
+# USER -> LOG_INF on the "lvgl" module, which needs CONFIG_LV_Z_LOG_LEVEL=3/INFO,
+# selected by the USER level choice below).
+# (CONFIG_LV_USE_PERF_MONITOR_LOG_MODE would additionally stream the per-refresh
+# FPS/CPU line to the log; left off so only the summary is printed.)
+CONFIG_LV_USE_LOG=y
+CONFIG_LV_LOG_LEVEL_USER=y
+
+CONFIG_LV_USE_FONT_COMPRESSED=y
+CONFIG_LV_FONT_MONTSERRAT_12=y
+CONFIG_LV_FONT_MONTSERRAT_14=y
+CONFIG_LV_FONT_MONTSERRAT_16=y
+CONFIG_LV_FONT_MONTSERRAT_24=y
+CONFIG_LV_FONT_MONTSERRAT_28=y
+
+# LVGL memory pool (benchmark/widgets allocate a fair amount of objects).
+CONFIG_LV_Z_MEM_POOL_SIZE=262144
+
+# Double-buffered, statically allocated rendering buffers. The custom sections
+# (.lvgl_buf / .lvgl_heap) are relocated to globally-addressable SRAM0 by
+# lvgl_sram.ld so the D/AVE 2D GPU can render into them and the VDBs can also
+# serve as the CDC200 scan-out framebuffers (DIRECT mode zero-copy page-flip).
+CONFIG_LV_Z_BUFFER_ALLOC_STATIC=y
+CONFIG_LV_Z_DOUBLE_VDB=y
+CONFIG_LV_Z_VDB_CUSTOM_SECTION=y
+CONFIG_LV_Z_MEMORY_POOL_CUSTOM_SECTION=y
+
+# Size the VDBs for the RGB565 panel (16 bpp / 2 bytes per pixel). The Zephyr
+# LVGL Kconfig has an unconditional "default 32" listed before the
+# "default 16 if LV_COLOR_DEPTH_16" entry, so the bits-per-pixel must be pinned
+# explicitly - otherwise the buffers would be allocated at 32 bpp (twice the
+# size actually needed for RGB565).
+CONFIG_LV_Z_BITS_PER_PIXEL=16
+
+# DIRECT-mode rendering: two full-screen VDBs in SRAM0 ARE the scan-out
+# framebuffers. The GPU renders directly into the back buffer while CDC200
+# scans out the front buffer; main.c page-flips via cdc200_swap_fb() at
+# vsync, so no CPU memcpy is needed.
+CONFIG_LV_Z_VDB_SIZE=100
+#CONFIG_LV_Z_FLUSH_THREAD=y
+
+# Offload LVGL rendering to the D/AVE 2D GPU.
+CONFIG_DAVE2D=y
+CONFIG_LV_USE_DRAW_DAVE2D=y
+
+# Build for speed (-O2) instead of the default size optimization (-Os). This
+# speeds up all CPU-side work: draw-list building, the GPU dispatch path and the
+# software fallback paths. There is ample MRAM headroom for the larger code.
+CONFIG_SPEED_OPTIMIZATIONS=y
+
+# Use the Cortex-M55 Helium (MVE) software-render backend for the draw operations
+# the D/AVE 2D unit cannot offload (some blends/conversions), instead of scalar C.
+CONFIG_LV_DRAW_SW_ASM_HELIUM=y
+
+# Kernel heap used by the MIPI-DSI / panel drivers.
+CONFIG_HEAP_MEM_POOL_SIZE=81920
+
+CONFIG_MAIN_STACK_SIZE=8192
+
+CONFIG_LOG=y
+# Use immediate logging so the CSV summary (a burst of ~18 lines emitted
+# back-to-back) is captured in full. With deferred logging the small log ring
+# buffer can overflow and drop summary lines before the lower-priority log thread
+# drains it.
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+# In DIRECT mode the LVGL VDBs ARE the scan-out framebuffers (both in SRAM0),
+# so no separate CDC200 framebuffer is needed. Drop CONFIG_FB_USES_DTCM_REGION
+# and the non-secure DTCM window.
+#CONFIG_FB_USES_DTCM_REGION=y
+
+CONFIG_LV_COLOR_DEPTH_16=y

--- a/samples/modules/lvgl/benchmark/sample.yaml
+++ b/samples/modules/lvgl/benchmark/sample.yaml
@@ -1,0 +1,27 @@
+sample:
+  name: LVGL D/AVE 2D Benchmark
+  description: >
+    LVGL lv_demo_benchmark rendered through the D/AVE 2D GPU on the
+    Alif Ensemble E8 DevKit MW405 display.
+common:
+  modules:
+    - lvgl
+  tags:
+    - display
+    - lvgl
+    - gui
+    - dave2d
+    - gpu2d
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "All scenes avg"
+  depends_on: display
+tests:
+  sample.modules.lvgl.benchmark.dave2d:
+    platform_allow:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he

--- a/samples/modules/lvgl/benchmark/src/main.c
+++ b/samples/modules/lvgl/benchmark/src/main.c
@@ -1,0 +1,186 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/drivers/display/cdc200.h>
+#if defined(CONFIG_MIPI_DSI)
+#include <zephyr/drivers/mipi_dsi/dsi_dw.h>
+#endif
+#include <zephyr/cache.h>
+#include <zephyr/linker/section_tags.h>
+#include <zephyr/logging/log.h>
+#include <se_service.h>
+#include <soc_common.h>
+
+#include <lvgl.h>
+#include <lv_demos.h>
+
+#include <dave_d0lib.h>
+
+LOG_MODULE_REGISTER(app, CONFIG_LOG_DEFAULT_LEVEL);
+
+/*
+ * D/AVE 2D working memory (display lists, render buffers, ...). The LVGL D/AVE 2D
+ * draw unit allocates from this heap inside lv_draw_dave2d_init(), which runs as
+ * part of lv_init(). Zephyr's LVGL glue calls lv_init() automatically from a
+ * SYS_INIT() hook at the APPLICATION init level, so the heap must already be
+ * initialised by then - hence the POST_KERNEL SYS_INIT() below, which always
+ * runs before any APPLICATION-level hook.
+ *
+ * The heap lives in SRAM1, and the LVGL rendering buffers + memory pool live in
+ * SRAM0 (see lvgl_sram.ld) - both globally addressable, so the GPU can reach
+ * them. In DIRECT mode the full-screen VDBs in SRAM0 double as the CDC200
+ * scan-out framebuffers (zero-copy page-flip via cdc200_swap_fb).
+ */
+#define DAVE2D_HEAP_SIZE (512 * 1024)
+static uint8_t __alif_sram1_section dave2d_heap[DAVE2D_HEAP_SIZE];
+
+static int dave2d_heap_init(void)
+{
+	if (!d0_initheapmanager(dave2d_heap, sizeof(dave2d_heap), d0_mm_fixed_range,
+				NULL, 0, 0, 0, d0_ma_unified)) {
+		LOG_ERR("Failed to initialise the D/AVE 2D heap manager");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+SYS_INIT(dave2d_heap_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+/*
+ * DIRECT-mode flush callback with vsync synchronization. In DIRECT mode the
+ * two full-screen LVGL VDBs ARE the scan-out framebuffers (both in SRAM0).
+ * The GPU renders directly into the back buffer, and this flush callback
+ * page-flips via cdc200_swap_fb() then waits for the CDC200 LINE IRQ to
+ * actually process the swap. This ensures:
+ *  - No tearing (buffer swap happens at vblank)
+ *  - Smooth frame pacing (naturally locked to display refresh)
+ *  - LVGL doesn't touch the new back buffer until the old front is released
+ */
+static void direct_flush_cb(lv_display_t *disp, const lv_area_t *area,
+			     uint8_t *px_map)
+{
+	const struct device *dev = lv_display_get_user_data(disp);
+
+	if (lv_display_flush_is_last(disp)) {
+		uint32_t h = lv_display_get_vertical_resolution(disp);
+		uint32_t w = lv_display_get_horizontal_resolution(disp);
+		uint32_t stride = w * (LV_COLOR_DEPTH / 8);
+
+		sys_cache_data_flush_range(px_map, stride * h);
+
+		struct cdc200_fb_desc fb = {
+			.fb_addr = px_map,
+			.fb_size = stride * h,
+		};
+
+		cdc200_swap_fb(dev, 0, &fb);
+
+		/* Block until the CDC200 ISR processes the swap at vblank. */
+		cdc200_wait_vsync(dev, K_MSEC(50));
+	}
+
+	lv_display_flush_ready(disp);
+}
+
+/*
+ * Set up DIRECT-mode rendering. Override the LVGL glue's default PARTIAL mode
+ * flush with a zero-copy page-flip callback. The CDC200 must be pointed at one
+ * of the VDBs initially; the first swap_fb call inside the flush callback
+ * handles the transition.
+ */
+static void setup_direct_mode(const struct device *display_dev,
+			       lv_display_t *disp)
+{
+	lv_display_set_render_mode(disp, LV_DISPLAY_RENDER_MODE_DIRECT);
+	lv_display_set_flush_cb(disp, direct_flush_cb);
+	lv_display_set_user_data(disp, (void *)display_dev);
+
+	/*
+	 * Point CDC200 at the first VDB so it has a valid scan-out address
+	 * before LVGL renders its first frame.
+	 */
+	lv_draw_buf_t *buf0 = lv_display_get_buf_active(disp);
+
+	if (buf0) {
+		uint32_t h = lv_display_get_vertical_resolution(disp);
+		uint32_t w = lv_display_get_horizontal_resolution(disp);
+		struct cdc200_fb_desc fb = {
+			.fb_addr = buf0->data,
+			.fb_size = w * (LV_COLOR_DEPTH / 8) * h,
+		};
+
+		cdc200_swap_fb(display_dev, 0, &fb);
+	}
+}
+
+int main(void)
+{
+	const struct device *display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+
+	if (!device_is_ready(display_dev)) {
+		LOG_ERR("Display device not ready");
+		return 0;
+	}
+
+#if defined(CONFIG_MIPI_DSI)
+	{
+		const struct device *dsi = DEVICE_DT_GET(DT_NODELABEL(mipi_dsi));
+		int ret;
+
+		if (!device_is_ready(dsi)) {
+			LOG_ERR("MIPI-DSI host not ready");
+			return 0;
+		}
+
+		/*
+		 * The panel is initialised over the DSI link in command mode. Switch
+		 * the host to video mode so the CDC200 framebuffer is actually
+		 * streamed to the panel; without this the screen stays black even
+		 * though the panel configured successfully.
+		 */
+		ret = dsi_dw_set_mode(dsi, DSI_DW_VIDEO_MODE);
+		if (ret) {
+			LOG_ERR("Failed to set DSI video mode (%d)", ret);
+			return 0;
+		}
+	}
+#endif
+
+	/*
+	 * The CDC200 controller is not started by its own driver init, and the
+	 * generic display_blanking_off() API the LVGL glue calls is a no-op for
+	 * it (returns -ENOTSUP). Start the scan-out engine explicitly here, or the
+	 * panel stays dark even though the MIPI-DSI link and backlight are up.
+	 */
+	cdc200_set_enable(display_dev, true);
+
+	/*
+	 * Switch to DIRECT-mode: GPU renders into full-screen VDBs in SRAM0,
+	 * flush callback page-flips via cdc200_swap_fb() at each vblank.
+	 */
+	lv_display_t *disp = lv_display_get_default();
+
+	setup_direct_mode(display_dev, disp);
+
+	lv_demo_benchmark();
+
+	while (1) {
+		uint32_t sleep_ms = lv_timer_handler();
+
+		k_msleep(MIN(sleep_ms, INT32_MAX));
+	}
+
+	return 0;
+}

--- a/west.yml
+++ b/west.yml
@@ -25,10 +25,9 @@ manifest:
   #
   # Please add items below based on alphabetical order
   projects:
-
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0d3e66a09dd9f49e27a25fb5f7198e4fc60ff05c
+      revision: c3727a63885227b97902c263df76881960ae7f06
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects
@@ -77,7 +76,7 @@ manifest:
       revision: 85f6b92af0f6ac72594d391f895c45cc30847e41
       path: modules/hal/cmsis
       groups:
-         - hal
+        - hal
 
     - name: hal_infineon
       remote: zephyrproject


### PR DESCRIPTION
Add an LVGL benchmark sample for the Alif Ensemble E8 DevKit that
offloads rendering to the D/AVE 2D (GPU2D) draw unit and shows the
result on the MW405 MIPI-DSI panel via the CDC200 display controller.
The sample builds for both the RTSS-HE and RTSS-HP cores.

The application performs the display-pipeline bring-up that the drivers
do not do on their own:

  - a Secure Enclave run profile (SYS_INIT, PRE_KERNEL_1) that enables
    the HFOSC 38.4 MHz D-PHY PLL reference clock, powers the MIPI
    TX/RX/PLL D-PHYs and the PHY LDO, ungates the CDC200, MIPI-DSI and
    GPU2D clocks, keeps SRAM0/SRAM1 powered and drives the E8
    camera/display mux GPIO to the panel;
  - switching the MIPI-DSI host to video mode and enabling the CDC200
    scan-out engine.

The full-screen double-buffered VDBs and the D/AVE 2D heap together
exceed what DTCM can provide, so the D/AVE 2D heap is placed in SRAM1
and the LVGL render buffers and memory pool are relocated to SRAM0. A
small hal_data.h compatibility shim lets LVGL's FSP-derived D/AVE 2D
draw unit build on Alif.

The sample uses DIRECT-mode rendering with two full-screen VDBs in
SRAM0 that double as the CDC200 scan-out framebuffers. The flush
callback performs a zero-copy page-flip via cdc200_swap_fb() and blocks
on cdc200_wait_vsync() until vblank, giving tear-free vsync-locked
display without any CPU memcpy of pixel data.

Related to Zephyr PR: https://github.com/alifsemi/zephyr_alif/pull/589