### PR TITLE
manifest: Update Zephyr revision to Ethos clock support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0c8c78c5094c47a826d65ca934efcdaa5f734350
+      revision: pull/578/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update Zephyr revision to Ethos clock control support
depends on: https://github.com/alifsemi/zephyr_alif/pull/578