### PR TITLE
manifest: Update zephyr version to OV5675 resolution support changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 1b73a3025f75c647f1368ab51d4a9dd3ce393c76
+      revision: 815e15f4948c9484b6287d822390985f74f10965
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update Zephyr revision to OV5675 multiple resolution support changes.

This PR depends on: alifsemi/zephyr_alif/pull/586