### PR TITLE
manifest: update zephyr version for i2c2 and i2c3 support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0c8c78c5094c47a826d65ca934efcdaa5f734350
+      revision: 37acbc14641440556c76cefc0974ef2761597f6d
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
updating zephyr revision to pick the i2c2 and i2c3 support.