### PR TITLE
samples: display: fix run-profile race causing DSI init failure

### DIFF
--- a/samples/drivers/display/boards/serial_display_1lane.overlay
+++ b/samples/drivers/display/boards/serial_display_1lane.overlay
@@ -8,6 +8,8 @@
  *
  */
 
+#include <dt-bindings/misc/alif_aipm_common.h>
+
 / {
 	soc {
 		cdc200: cdc200@49031000 {
@@ -69,4 +71,14 @@ ns: &ns {
 
 &gpio8 {
 	status = "okay";
+};
+
+&aipm_run_default {
+	phy-pwr-gating = <(ALIF_PHY_GATE_LDO_MASK |
+			ALIF_PHY_GATE_MIPI_TX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_RX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_PLL_DPHY_MASK)>;
+	ip-clock-gating = <(ALIF_IP_CLK_GATE_CDC200_MASK |
+			ALIF_IP_CLK_GATE_MIPI_DSI_MASK |
+			ALIF_IP_CLK_GATE_GPU_MASK)>;
 };

--- a/samples/drivers/display/boards/serial_display_2lane.overlay
+++ b/samples/drivers/display/boards/serial_display_2lane.overlay
@@ -8,6 +8,8 @@
  *
  */
 
+#include <dt-bindings/misc/alif_aipm_common.h>
+
 / {
 	soc {
 		cdc200: cdc200@49031000 {
@@ -54,4 +56,14 @@
 
 &gpio14 {
 	status = "okay";
+};
+
+&aipm_run_default {
+	phy-pwr-gating = <(ALIF_PHY_GATE_LDO_MASK |
+			ALIF_PHY_GATE_MIPI_TX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_RX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_PLL_DPHY_MASK)>;
+	ip-clock-gating = <(ALIF_IP_CLK_GATE_CDC200_MASK |
+			ALIF_IP_CLK_GATE_MIPI_DSI_MASK |
+			ALIF_IP_CLK_GATE_GPU_MASK)>;
 };

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -349,13 +349,10 @@ int main(void)
 }
 
 /**
- * Set the RUN profile parameters for this application.
+ * Set the early init configuration for this application.
  */
-static int app_set_run_params(void)
+static int app_board_early_init(void)
 {
-	run_profile_t runp;
-	int ret;
-
 #if (defined(CONFIG_ENSEMBLE_GEN2) && defined(CONFIG_MIPI_DSI))
 	const struct gpio_dt_spec cam_disp_mux_gpio =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(mipi_dsi), cam_disp_mux_gpios);
@@ -365,30 +362,7 @@ static int app_set_run_params(void)
 	/* Enable HFOSC (38.4 MHz) and CFG (100 MHz) clock. */
 	sys_set_bits(CGU_CLK_ENA, BIT(21) | BIT(23));
 
-	runp.power_domains = PD_SYST_MASK | PD_SSE700_AON_MASK;
-	runp.dcdc_voltage  = 825;
-	runp.dcdc_mode     = DCDC_MODE_PWM;
-	runp.aon_clk_src   = CLK_SRC_LFXO;
-	runp.run_clk_src   = CLK_SRC_PLL;
-	runp.vdd_ioflex_3V3 = IOFLEX_LEVEL_1V8;
-#if defined(CONFIG_RTSS_HP)
-	runp.cpu_clk_freq  = CLOCK_FREQUENCY_400MHZ;
-#else
-	runp.cpu_clk_freq  = CLOCK_FREQUENCY_160MHZ;
-#endif
-
-	runp.memory_blocks = MRAM_MASK;
-#if DT_NODE_EXISTS(DT_NODELABEL(sram0))
-	runp.memory_blocks |= SRAM0_MASK;
-#endif
-	runp.phy_pwr_gating = MIPI_TX_DPHY_MASK | MIPI_RX_DPHY_MASK |
-		MIPI_PLL_DPHY_MASK | LDO_PHY_MASK;
-	runp.ip_clock_gating = CDC200_MASK | MIPI_DSI_MASK | GPU_MASK;
-
-	ret = se_service_set_run_cfg(&runp);
-	__ASSERT(ret == 0, "SE: set_run_cfg failed = %d", ret);
-
-	return ret;
+	return 0;
 }
 /*
  * CRITICAL: Must run at PRE_KERNEL_1 to restore SYSTOP before peripherals initialize.
@@ -401,4 +375,4 @@ static int app_set_run_params(void)
  * On cold boot: SYSTOP is already ON by default, safe to call.
  * On SOFT_OFF wakeup: SYSTOP is OFF, must restore BEFORE peripherals access registers.
  */
-SYS_INIT(app_set_run_params, PRE_KERNEL_1, 46);
+SYS_INIT(app_board_early_init, PRE_KERNEL_1, 46);


### PR DESCRIPTION
Fixed by overriding phy-pwr-gating and ip-clock-gating directly on the aipm_run_default DTS node in the board overlays, so the DTS-applied profile at priority 45 already contains the correct settings. This removes the need for a duplicate app-level set_run_cfg() call and eliminates the race entirely.

Also app_set_run_params() is renamed to app_board_early_init() and now only handles early HFOSC/CFG clock enablement and cam/display mux GPIO configuration, which remain app/board-specific and outside the scope of the DTS-driven run-profile mechanism.