### PR TITLE
manifest: update Zephyr revision for preserve CAN mode across restart

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 0337305734427e130746e9b4022298afd06ac8ea
+      revision: pull/600/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: a1884e63a23f7779cc1923b349a03d126d176054
+      revision: 98166afb70ad08c3e602010d0609ce123f7c40e0
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update Zephyr revision for CAN mode across restart fix.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/600