### PR TITLE
samples: modules: tflite-micro: add MT9M114 MIPI camera support

### DIFF
--- a/samples/modules/tflite-micro/alif_img_class/README.md
+++ b/samples/modules/tflite-micro/alif_img_class/README.md
@@ -17,24 +17,9 @@ There is also separate thread which updates LVGL graphics.
 
 ## Supported hardware
 Alif E7-DK HP & E8-DK HP & ARX3A0 serial camera & MW-405 display
+Alif E8-DK HP & MT9M114 MIPI serial camera (+ISP) & MW-405 display
 Alif E8-DK HP & OV5675 serial camera (+ISP) & MW-405 display
 
-
-## Prerequisites (TensorFlow Lite for Microcontrollers)
-To build the sample, you first need to pull in the optional dependencies by running the following commands:
-
-```
-west config manifest.group-filter -- +optional
-west update
-```
-
-## Building OV5675 non-ISP configurations
-E7 does not have ISP.
-
-Also E8 non-ISP configuration can be useful to apply own image manipulation operations on the captured
-frames.
-
-Pass `ov5675.conf` via `-DOVERLAY_CONFIG` to set the required buffer pool size (see build commands below).
 
 ## Prerequisites
 Before building, set up the MLEK resources (downloads and Vela-compiles the ML models):
@@ -46,8 +31,16 @@ python3 modules/alif-mlek/set_up_default_resources.py
 ```
 The model and labels source code is generated automatically at CMake configure time.
 
+## Building OV5675 non-ISP configurations
+E7 does not have ISP.
+
+Also E8 non-ISP configuration can be useful to apply own image manipulation operations on the captured
+frames.
+
+Pass `ov5675.conf` via `-DOVERLAY_CONFIG` to set the required buffer pool size (see build commands below).
+
 ## Building and running: E7-DK
-Build
+arx3a0:
 ```
 west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_img_class --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_arx3a0.overlay serial_camera.overlay"
 ```
@@ -56,6 +49,16 @@ west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp -S ethos-u55-enable samples/mod
 arx3a0:
 ```
 west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_img_class --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_arx3a0_selfie.overlay serial_camera.overlay"
+```
+
+mt9m114:
+```
+west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_img_class --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_mt9m114.overlay serial_camera.overlay" -DOVERLAY_CONFIG="mt9m114.conf"
+```
+
+mt9m114 & ISP:
+```
+west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_img_class -- -DEXTRA_DTC_OVERLAY_FILE="serial_camera_mt9m114.overlay serial_camera_isp.overlay serial_camera_mt9m114_isp.overlay" -DOVERLAY_CONFIG="mt9m114.conf;isp.conf"
 ```
 
 arx3a0 & ISP:

--- a/samples/modules/tflite-micro/alif_img_class/boards/alif_e7_dk_ae722f80f55d5xx_rtss_hp.overlay
+++ b/samples/modules/tflite-micro/alif_img_class/boards/alif_e7_dk_ae722f80f55d5xx_rtss_hp.overlay
@@ -8,8 +8,28 @@
  *
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 #include "common.overlay"
 
 &cam {
 	csi-halt-en;
+};
+
+/*
+ * The MW405 flat board's GT911 touch controller shares i2c1 with the camera
+ * sensor and defaults to 7-bit address 0x5D - the same address as the MT9M114.
+ * Touch is not used in this sample, so hold the GT911 in reset (E7-DK RESETn on
+ * gpio4.0, active-low) so it never drives the bus and cannot collide with the
+ * camera. output-high drives the active-low reset line to its active (reset)
+ * state.
+ */
+&gpio4 {
+	status = "okay";
+
+	gt911_touch_reset_hold {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
 };

--- a/samples/modules/tflite-micro/alif_img_class/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
+++ b/samples/modules/tflite-micro/alif_img_class/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
@@ -8,4 +8,24 @@
  *
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 #include "common.overlay"
+
+/*
+ * The MW405 flat board's GT911 touch controller shares i2c1 with the camera
+ * sensor and defaults to 7-bit address 0x5D - the same address as the MT9M114.
+ * Touch is not used in this sample, so hold the GT911 in reset (E8-DK RESETn on
+ * gpio6.5, active-low) so it never drives the bus and cannot collide with the
+ * camera. output-high drives the active-low reset line to its active (reset)
+ * state.
+ */
+&gpio6 {
+	status = "okay";
+
+	gt911_touch_reset_hold {
+		gpio-hog;
+		gpios = <5 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};

--- a/samples/modules/tflite-micro/alif_img_class/mt9m114.conf
+++ b/samples/modules/tflite-micro/alif_img_class/mt9m114.conf
@@ -1,0 +1,24 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https: //alifsemi.com/license
+#
+
+# MT9M114 over MIPI CSI-2 serial interface
+CONFIG_VIDEO_MIPI_CSI2_DW=y
+
+# Serial (MIPI) init path. The default (=y) configures the sensor for parallel
+# capture and skips the MIPI LP11 setup, which prevents the RX D-PHY from
+# locking to stop-state.
+CONFIG_MT9M114_PARALLEL_INIT=n
+
+# The MIPI supply is switched by a regulator-fixed node in the overlay.
+CONFIG_REGULATOR=y
+CONFIG_REGULATOR_FIXED_INIT_PRIORITY=40
+
+# A single 1288x728 Y10P frame is ~1.87 MB, larger than the default 1 MB buffer.
+CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=1900000
+CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=1

--- a/samples/modules/tflite-micro/alif_img_class/prj.conf
+++ b/samples/modules/tflite-micro/alif_img_class/prj.conf
@@ -48,6 +48,10 @@ CONFIG_LV_THEME_DEFAULT_DARK=y
 CONFIG_DISPLAY=y
 CONFIG_MIPI_DSI=y
 
+# Apply the GT911 touch reset-hold gpio-hog defined in the board overlays so the
+# unused touch controller cannot collide with the camera on i2c1.
+CONFIG_GPIO_HOGS=y
+
 # arm_math.h
 CONFIG_CMSIS_DSP=y
 

--- a/samples/modules/tflite-micro/alif_img_class/serial_camera_mt9m114.overlay
+++ b/samples/modules/tflite-micro/alif_img_class/serial_camera_mt9m114.overlay
@@ -1,0 +1,117 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/video/video-interfaces.h>
+
+&i2c1 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	/*
+	 * For Standard  speed LCNT=0 and HCNT=0
+	 * For Fast      speed LCNT=50 and HCNT=30
+	 * For Fast Plus speed LCNT=35 and HCNT=5
+	 */
+	hcnt-offset = <30>;
+	lcnt-offset = <50>;
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&gpio14 {
+	status = "okay";
+};
+
+/ {
+	csi_cam_power: regulator-v1.2-v1.8v {
+		compatible = "regulator-fixed";
+
+		regulator-name = "MIPI supply";
+
+		enable-gpios = < &gpio7 5 GPIO_ACTIVE_HIGH >;
+
+		regulator-boot-on;
+		regulator-always-on;
+		status = "okay";
+	};
+
+	i2c_mux: i2c-mux {
+		compatible = "gpio-i2c-mux";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-inst = <&i2c1>;
+
+		ctrl-gpios = <&gpio14 3 GPIO_ACTIVE_HIGH>;
+
+		mux_i2c@0 {
+			compatible = "gpio-i2c-mux-channel";
+			reg = <0>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mt9m114_selfie: mt9m114_selfie@5d {
+				compatible = "aptina,mt9m114";
+				reg = <0x5d>;
+
+				reset-gpios = <&gpio14 4 GPIO_ACTIVE_LOW>;
+
+				status = "okay";
+
+				port {
+					mt9m114_csi2_ep_out0: endpoint {
+						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+						link-frequencies = < 384000000 >;
+						data-lanes = <1>;
+						clock-lane = <0>;
+
+						remote-endpoint-label = "csi2_ep_in0";
+					};
+				};
+			};
+		};
+	};
+};
+
+&csi {
+	status = "okay";
+
+	/* Selfie camera D-PHY */
+	phy-if = <&dphy 0>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			csi2_ep_in0: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				link-frequencies = < 384000000 >;
+				data-lanes = <1>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "mt9m114_csi2_ep_out0";
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csi2_ep_out: endpoint {
+				remote-endpoint-label = "cam_csi2_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			};
+		};
+	};
+};

--- a/samples/modules/tflite-micro/alif_img_class/serial_camera_mt9m114_isp.overlay
+++ b/samples/modules/tflite-micro/alif_img_class/serial_camera_mt9m114_isp.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+/*
+ * MT9M114-specific ISP crop. Apply this on top of serial_camera_isp.overlay
+ * for MT9M114 ISP builds (E8 only). Kept separate from the sensor overlay
+ * because the &isp node does not exist on E7.
+ *
+ * The MT9M114 Y10P input is 1288x728 (16:9) but the capture output is square,
+ * so without a crop the ISP would stretch the frame. crop-x0 removes
+ * (1288-728)/2 = 280 px from each side, yielding a centered 728x728 square ROI
+ * that the ISP then scales to the square output without distortion.
+ */
+
+&isp {
+	crop-x0 = <280>;
+};

--- a/samples/modules/tflite-micro/alif_img_class/src/use_case/alif_img_class/include/image_processing.h
+++ b/samples/modules/tflite-micro/alif_img_class/src/use_case/alif_img_class/include/image_processing.h
@@ -20,6 +20,8 @@
 #define RTE_ARX3A0_CAMERA_SENSOR_ENABLE 1
 #elif CONFIG_DT_HAS_OVTI_OV5675_ENABLED
 #define RTE_OV5675_CAMERA_SENSOR_ENABLE 1
+#elif CONFIG_DT_HAS_APTINA_MT9M114_ENABLED
+#define RTE_MT9M114_CAMERA_SENSOR_ENABLE 1
 #else
 #error "Unsupported camera"
 #endif
@@ -45,6 +47,19 @@
 #define CIMAGE_EXPOSURE_CALC    (0)
 #define CIMAGE_RGB_WIDTH_MAX    (800)
 #define CIMAGE_RGB_HEIGHT_MAX   (800)
+#define CAM_BAYER_FORMAT        (AIPL_BAYER_GRBG)
+#elif RTE_MT9M114_CAMERA_SENSOR_ENABLE // MT9M114 RTE
+/*
+ * With MIPI (CONFIG_MT9M114_PARALLEL_INIT=n) the largest advertised Y10P mode
+ * is 1288x728, which the pipeline selects. Crop a centered square (even offsets
+ * preserve the Bayer phase) before demosaicing.
+ */
+#define CIMAGE_X                (1288)
+#define CIMAGE_Y                (728)
+#define CIMAGE_COLOR_CORRECTION (0)
+#define CIMAGE_EXPOSURE_CALC    (0)
+#define CIMAGE_RGB_WIDTH_MAX    (560)
+#define CIMAGE_RGB_HEIGHT_MAX   (560)
 #define CAM_BAYER_FORMAT        (AIPL_BAYER_GRBG)
 #endif
 

--- a/samples/modules/tflite-micro/alif_object_detection/README.md
+++ b/samples/modules/tflite-micro/alif_object_detection/README.md
@@ -17,23 +17,8 @@ There is also separate thread which updates LVGL graphics.
 
 ## Supported hardware
 Alif E7-DK HP & E8-DK HP & ARX3A0 serial camera & MW-405 display
+Alif E7-DK HP & E8-DK HP & MT9M114 MIPI serial camera (+ISP on E8) & MW-405 display
 Alif E8-DK HP & OV5675 serial camera (+ISP) & MW-405 display
-
-## Prerequisites (TensorFlow Lite for Microcontrollers)
-To build the sample, you first need to pull in the optional dependencies by running the following commands:
-
-```
-west config manifest.group-filter -- +optional
-west update
-```
-
-## Building OV5675 non-ISP configurations
-E7 does not have ISP.
-
-Also E8 non-ISP configuration can be useful to apply own image manipulation operations on the captured
-frames.
-
-Pass `ov5675.conf` via `-DOVERLAY_CONFIG` to set the required buffer pool size (see build commands below).
 
 ## Prerequisites
 Before building, set up the MLEK resources (downloads and Vela-compiles the ML models):
@@ -45,16 +30,39 @@ python3 modules/alif-mlek/set_up_default_resources.py
 ```
 The model source code is generated automatically at CMake configure time.
 
+## Building OV5675 non-ISP configurations
+E7 does not have ISP.
+
+Also E8 non-ISP configuration can be useful to apply own image manipulation operations on the captured
+frames.
+
+Pass `ov5675.conf` via `-DOVERLAY_CONFIG` to set the required buffer pool size (see build commands below).
+
 ## Building and running: E7-DK
-Build
+arx3a0:
 ```
 west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_object_detection --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_arx3a0.overlay serial_camera.overlay"
+```
+
+mt9m114:
+```
+west build -b alif_e7_dk/ae722f80f55d5xx/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_object_detection --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_mt9m114.overlay serial_camera.overlay" -DOVERLAY_CONFIG="mt9m114.conf"
 ```
 
 ## Building and running: E8-DK
 arx3a0:
 ```
 west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_object_detection --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_arx3a0_selfie.overlay serial_camera.overlay"
+```
+
+mt9m114:
+```
+west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_object_detection --   -DEXTRA_DTC_OVERLAY_FILE="serial_camera_mt9m114.overlay serial_camera.overlay" -DOVERLAY_CONFIG="mt9m114.conf"
+```
+
+mt9m114 & ISP:
+```
+west build -b alif_e8_dk/ae822fa0e5597xx0/rtss_hp -S ethos-u55-enable samples/modules/tflite-micro/alif_object_detection -- -DEXTRA_DTC_OVERLAY_FILE="serial_camera_mt9m114.overlay serial_camera_isp.overlay serial_camera_mt9m114_isp.overlay" -DOVERLAY_CONFIG="mt9m114.conf;isp.conf"
 ```
 
 arx3a0 & ISP:

--- a/samples/modules/tflite-micro/alif_object_detection/boards/alif_e7_dk_ae722f80f55d5xx_rtss_hp.overlay
+++ b/samples/modules/tflite-micro/alif_object_detection/boards/alif_e7_dk_ae722f80f55d5xx_rtss_hp.overlay
@@ -8,8 +8,28 @@
  *
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 #include "common.overlay"
 
 &cam {
 	csi-halt-en;
+};
+
+/*
+ * The MW405 flat board's GT911 touch controller shares i2c1 with the camera
+ * sensor and defaults to 7-bit address 0x5D - the same address as the MT9M114.
+ * Touch is not used in this sample, so hold the GT911 in reset (E7-DK RESETn on
+ * gpio4.0, active-low) so it never drives the bus and cannot collide with the
+ * camera. output-high drives the active-low reset line to its active (reset)
+ * state.
+ */
+&gpio4 {
+	status = "okay";
+
+	gt911_touch_reset_hold {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
 };

--- a/samples/modules/tflite-micro/alif_object_detection/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
+++ b/samples/modules/tflite-micro/alif_object_detection/boards/alif_e8_dk_ae822fa0e5597xx0_rtss_hp.overlay
@@ -8,4 +8,24 @@
  *
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 #include "common.overlay"
+
+/*
+ * The MW405 flat board's GT911 touch controller shares i2c1 with the camera
+ * sensor and defaults to 7-bit address 0x5D - the same address as the MT9M114.
+ * Touch is not used in this sample, so hold the GT911 in reset (E8-DK RESETn on
+ * gpio6.5, active-low) so it never drives the bus and cannot collide with the
+ * camera. output-high drives the active-low reset line to its active (reset)
+ * state.
+ */
+&gpio6 {
+	status = "okay";
+
+	gt911_touch_reset_hold {
+		gpio-hog;
+		gpios = <5 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};

--- a/samples/modules/tflite-micro/alif_object_detection/mt9m114.conf
+++ b/samples/modules/tflite-micro/alif_object_detection/mt9m114.conf
@@ -1,0 +1,24 @@
+# Copyright (C) Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https: //alifsemi.com/license
+#
+
+# MT9M114 over MIPI CSI-2 serial interface
+CONFIG_VIDEO_MIPI_CSI2_DW=y
+
+# Serial (MIPI) init path. The default (=y) configures the sensor for parallel
+# capture and skips the MIPI LP11 setup, which prevents the RX D-PHY from
+# locking to stop-state.
+CONFIG_MT9M114_PARALLEL_INIT=n
+
+# The MIPI supply is switched by a regulator-fixed node in the overlay.
+CONFIG_REGULATOR=y
+CONFIG_REGULATOR_FIXED_INIT_PRIORITY=40
+
+# A single 1288x728 Y10P frame is ~1.87 MB, larger than the default 1 MB buffer.
+CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=1900000
+CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=1

--- a/samples/modules/tflite-micro/alif_object_detection/prj.conf
+++ b/samples/modules/tflite-micro/alif_object_detection/prj.conf
@@ -43,6 +43,10 @@ CONFIG_LV_THEME_DEFAULT_DARK=y
 CONFIG_DISPLAY=y
 CONFIG_MIPI_DSI=y
 
+# Apply the GT911 touch reset-hold gpio-hog defined in the board overlays so the
+# unused touch controller cannot collide with the camera on i2c1.
+CONFIG_GPIO_HOGS=y
+
 # arm_math.h
 CONFIG_CMSIS_DSP=y
 

--- a/samples/modules/tflite-micro/alif_object_detection/serial_camera_mt9m114.overlay
+++ b/samples/modules/tflite-micro/alif_object_detection/serial_camera_mt9m114.overlay
@@ -1,0 +1,117 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+#include <dt-bindings/pinctrl/ensemble-pinctrl.h>
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/video/video-interfaces.h>
+
+&i2c1 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	/*
+	 * For Standard  speed LCNT=0 and HCNT=0
+	 * For Fast      speed LCNT=50 and HCNT=30
+	 * For Fast Plus speed LCNT=35 and HCNT=5
+	 */
+	hcnt-offset = <30>;
+	lcnt-offset = <50>;
+};
+
+&gpio7 {
+	status = "okay";
+};
+
+&gpio14 {
+	status = "okay";
+};
+
+/ {
+	csi_cam_power: regulator-v1.2-v1.8v {
+		compatible = "regulator-fixed";
+
+		regulator-name = "MIPI supply";
+
+		enable-gpios = < &gpio7 5 GPIO_ACTIVE_HIGH >;
+
+		regulator-boot-on;
+		regulator-always-on;
+		status = "okay";
+	};
+
+	i2c_mux: i2c-mux {
+		compatible = "gpio-i2c-mux";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-inst = <&i2c1>;
+
+		ctrl-gpios = <&gpio14 3 GPIO_ACTIVE_HIGH>;
+
+		mux_i2c@0 {
+			compatible = "gpio-i2c-mux-channel";
+			reg = <0>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mt9m114_selfie: mt9m114_selfie@5d {
+				compatible = "aptina,mt9m114";
+				reg = <0x5d>;
+
+				reset-gpios = <&gpio14 4 GPIO_ACTIVE_LOW>;
+
+				status = "okay";
+
+				port {
+					mt9m114_csi2_ep_out0: endpoint {
+						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+						link-frequencies = < 384000000 >;
+						data-lanes = <1>;
+						clock-lane = <0>;
+
+						remote-endpoint-label = "csi2_ep_in0";
+					};
+				};
+			};
+		};
+	};
+};
+
+&csi {
+	status = "okay";
+
+	/* Selfie camera D-PHY */
+	phy-if = <&dphy 0>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			csi2_ep_in0: endpoint {
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				link-frequencies = < 384000000 >;
+				data-lanes = <1>;
+				clock-lane = <0>;
+
+				remote-endpoint-label = "mt9m114_csi2_ep_out0";
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csi2_ep_out: endpoint {
+				remote-endpoint-label = "cam_csi2_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			};
+		};
+	};
+};

--- a/samples/modules/tflite-micro/alif_object_detection/serial_camera_mt9m114_isp.overlay
+++ b/samples/modules/tflite-micro/alif_object_detection/serial_camera_mt9m114_isp.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https: //alifsemi.com/license
+ *
+ */
+
+/*
+ * MT9M114-specific ISP crop. Apply this on top of serial_camera_isp.overlay
+ * for MT9M114 ISP builds (E8 only). Kept separate from the sensor overlay
+ * because the &isp node does not exist on E7.
+ *
+ * The MT9M114 Y10P input is 1288x728 (16:9) but the capture output is square,
+ * so without a crop the ISP would stretch the frame. crop-x0 removes
+ * (1288-728)/2 = 280 px from each side, yielding a centered 728x728 square ROI
+ * that the ISP then scales to the square output without distortion.
+ */
+
+&isp {
+	crop-x0 = <280>;
+};

--- a/samples/modules/tflite-micro/alif_object_detection/src/use_case/object_detection/include/image_processing.h
+++ b/samples/modules/tflite-micro/alif_object_detection/src/use_case/object_detection/include/image_processing.h
@@ -20,6 +20,8 @@
 #define RTE_ARX3A0_CAMERA_SENSOR_ENABLE 1
 #elif CONFIG_DT_HAS_OVTI_OV5675_ENABLED
 #define RTE_OV5675_CAMERA_SENSOR_ENABLE 1
+#elif CONFIG_DT_HAS_APTINA_MT9M114_ENABLED
+#define RTE_MT9M114_CAMERA_SENSOR_ENABLE 1
 #else
 #error "Unsupported camera"
 #endif
@@ -45,6 +47,19 @@
 #define CIMAGE_EXPOSURE_CALC    (0)
 #define CIMAGE_RGB_WIDTH_MAX    (800)
 #define CIMAGE_RGB_HEIGHT_MAX   (800)
+#define CAM_BAYER_FORMAT        (AIPL_BAYER_GRBG)
+#elif RTE_MT9M114_CAMERA_SENSOR_ENABLE // MT9M114 RTE
+/*
+ * With MIPI (CONFIG_MT9M114_PARALLEL_INIT=n) the largest advertised Y10P mode
+ * is 1288x728, which the pipeline selects. Crop a centered square (even offsets
+ * preserve the Bayer phase) before demosaicing.
+ */
+#define CIMAGE_X                (1288)
+#define CIMAGE_Y                (728)
+#define CIMAGE_COLOR_CORRECTION (0)
+#define CIMAGE_EXPOSURE_CALC    (0)
+#define CIMAGE_RGB_WIDTH_MAX    (560)
+#define CIMAGE_RGB_HEIGHT_MAX   (560)
 #define CAM_BAYER_FORMAT        (AIPL_BAYER_GRBG)
 #endif
 


### PR DESCRIPTION
Add MT9M114 (aptina,mt9m114) MIPI CSI-2 camera support to the alif_object_detection and alif_img_class Ethos-U samples.

The non-ISP path crops a centered square before demosaicing; the ISP path uses crop-x0 to crop the 16:9 frame to a square before scaling, avoiding distortion.