### PR TITLE
manifest: update zephyr revision to pickup e8 ak apss support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/603/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: e71dcc37a497f4676b51b3862fd5ab26262c0c74
+      revision: eb4f4ceb4fc8b5da225da85a640d380f68dd9be4
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr revision to pickup support for the APSS board variant of E8 Appkit.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/603