### PR TITLE
manifest: zephyr: clock_control: use SE services to read clock freq

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/604/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: c3fda14df07e328507cdcd86d020f38f91017be5
+      revision: 01c3b051a63d5c97edad047a198f0b446145f7b2
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
The ensemble clock driver now queries SE at runtime for AXI, AHB, APB, SYSREF, HFOSC, EXTSYS0, and EXTSYS1 frequencies through a new se_service_clocks_setting_get() API. Update the manifest.

Depends: https://github.com/alifsemi/zephyr_alif/pull/604