### PR TITLE
manifest: update Zephyr revision for CAN fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 18fcd1512438f65480abd06bb9284fe76e413a37
+      revision: d15fa8ef684ddededf28d7d0bc59299500ad92c9
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/606/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the Zephyr revision to include the CAN driver fixes for clear interrupt handling and filter management.

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/606