### PR TITLE
manifest: update zephyr version to pre_device_resume gate fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/607/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 3e6f65c7c226c58a2c14d764d27e583cc94d6b80
+      revision: pull/607/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr fix guarding pm_state_notify_pre_resume() with the same conditions as pm_resume_devices().
Depends: https://github.com/alifsemi/zephyr_alif/pull/607/