### PR TITLE
manifest: update Zephyr version to MHUv2 poll_out NR2R latch fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/608/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 4c50057dc827ce87d60cec601ad1f2651ae5ba63
+      revision: 4cc57b899f109771997d60d2e0922d303bd3e294
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr fix in mhuv2_poll_out() that masks and clears the top-level NR2R/R2NR/CHCOMB sources before requesting access.
Depends: https://github.com/alifsemi/zephyr_alif/pull/608/