### PR TITLE
manifest: update Zephyr version to include usb hid class support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 94fb484829c4443444aa4b914f26a3c2738ecf19
+      revision: 9a8bc4c96f0c3020961cbdb9aa221ff414df20fb
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
+      revision: pull/605/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr revision to enable usb hid class support.
Depends: https://github.com/alifsemi/zephyr_alif/pull/605