### PR TITLE
manifest: update Zephyr version to include usb ncm class support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
+      revision: pull/583/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr revision to enable usb ncm class support.
Depends: https://github.com/alifsemi/zephyr_alif/pull/583