### PR TITLE
samples: modules: tflite-micro: select specified sensor resolution

### DIFF
--- a/samples/modules/tflite-micro/alif_img_class/src/use_case/alif_img_class/src/image_ensemble.c
+++ b/samples/modules/tflite-micro/alif_img_class/src/use_case/alif_img_class/src/image_ensemble.c
@@ -194,7 +194,14 @@ int image_init(int req_output_width, int req_output_height)
 		       fcap->width_min, fcap->width_max, fcap->width_step,
 		       fcap->height_min, fcap->height_max, fcap->height_step);
 
-		if (fcap->pixelformat == VIDEO_PIX_FMT_Y10P) {
+		if (fcap->pixelformat == VIDEO_PIX_FMT_Y10P &&
+		    fcap->width_min == CIMAGE_X && fcap->height_min == CIMAGE_Y) {
+			/*
+			 * Select the exact resolution the image pipeline is built
+			 * for (CIMAGE_X x CIMAGE_Y). The downstream buffers, crop
+			 * math and RAW10->RAW8 conversion are dimensioned at compile
+			 * time, so no other resolution can be processed correctly.
+			 */
 			fmt.pixelformat = VIDEO_PIX_FMT_Y10P;
 			fmt.width = fcap->width_min;
 			fmt.height = fcap->height_min;
@@ -203,7 +210,8 @@ int image_init(int req_output_width, int req_output_height)
 	}
 
 	if (fmt.pixelformat == 0) {
-		LOG_ERR("Desired Pixel format is not supported.");
+		LOG_ERR("Sensor does not advertise the required Y10P %ux%u mode",
+			CIMAGE_X, CIMAGE_Y);
 		return -1;
 	}
 

--- a/samples/modules/tflite-micro/alif_object_detection/src/use_case/object_detection/src/image_ensemble.c
+++ b/samples/modules/tflite-micro/alif_object_detection/src/use_case/object_detection/src/image_ensemble.c
@@ -193,7 +193,14 @@ int image_init(int req_output_width, int req_output_height)
 		       fcap->width_min, fcap->width_max, fcap->width_step,
 		       fcap->height_min, fcap->height_max, fcap->height_step);
 
-		if (fcap->pixelformat == VIDEO_PIX_FMT_Y10P) {
+		if (fcap->pixelformat == VIDEO_PIX_FMT_Y10P &&
+		    fcap->width_min == CIMAGE_X && fcap->height_min == CIMAGE_Y) {
+			/*
+			 * Select the exact resolution the image pipeline is built
+			 * for (CIMAGE_X x CIMAGE_Y). The downstream buffers, crop
+			 * math and RAW10->RAW8 conversion are dimensioned at compile
+			 * time, so no other resolution can be processed correctly.
+			 */
 			fmt.pixelformat = VIDEO_PIX_FMT_Y10P;
 			fmt.width = fcap->width_min;
 			fmt.height = fcap->height_min;
@@ -202,7 +209,8 @@ int image_init(int req_output_width, int req_output_height)
 	}
 
 	if (fmt.pixelformat == 0) {
-		LOG_ERR("Desired Pixel format is not supported.");
+		LOG_ERR("Sensor does not advertise the required Y10P %ux%u mode",
+			CIMAGE_X, CIMAGE_Y);
 		return -1;
 	}
 


### PR DESCRIPTION
This pull request updates the image initialization logic for both image classification and object detection modules to ensure that the sensor only selects the exact resolution (`CIMAGE_X` x `CIMAGE_Y`) required by the image processing pipeline when using the `Y10P` pixel format. Additionally, the error logging is improved to provide more specific feedback if the required mode is not available.

**Image pipeline configuration improvements:**

* Updated the selection logic in `image_ensemble.c` for both image classification and object detection to only accept the `VIDEO_PIX_FMT_Y10P` pixel format if the sensor advertises the exact required resolution (`CIMAGE_X` x `CIMAGE_Y`). This prevents incorrect resolutions from being selected, which could cause downstream processing errors. [[1]](diffhunk://#diff-5a94fd500dde489f51ab5dff81057b78932f42cff0cee97c81cb885fedd682b2L197-R204) [[2]](diffhunk://#diff-82b97afbafd3bb08a3f54b4a9d08f2d7638cf07fefb3431828a31134abfd0640L196-R203)

**Error handling enhancements:**

* Improved error messages to specify when the sensor does not advertise the required `Y10P` pixel format at the expected resolution, making debugging easier. [[1]](diffhunk://#diff-5a94fd500dde489f51ab5dff81057b78932f42cff0cee97c81cb885fedd682b2L206-R214) [[2]](diffhunk://#diff-82b97afbafd3bb08a3f54b4a9d08f2d7638cf07fefb3431828a31134abfd0640L205-R213)