### PR TITLE
samples: bluetooth: add Twister sample.yaml for build coverage

### DIFF
--- a/samples/bluetooth/le_audio/auracast/sample.yaml
+++ b/samples/bluetooth/le_audio/auracast/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Audio Auracast
+tests:
+  sample.bt_custom.le_audio.auracast:
+    build_only: true
+    filter: dt_alias_exists("i2s_bus") and dt_alias_exists("audio_codec")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_audio/broadcast_mode_switch/sample.yaml
+++ b/samples/bluetooth/le_audio/broadcast_mode_switch/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Audio Broadcast Mode Switch
+tests:
+  sample.bt_custom.le_audio.broadcast_mode_switch:
+    build_only: true
+    filter: dt_alias_exists("i2s_bus")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_audio/unicast_acceptor/sample.yaml
+++ b/samples/bluetooth/le_audio/unicast_acceptor/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Audio Unicast Acceptor
+tests:
+  sample.bt_custom.le_audio.unicast_acceptor:
+    build_only: true
+    filter: dt_alias_exists("i2s_bus") and dt_alias_exists("audio_codec")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_audio/unicast_initiator/sample.yaml
+++ b/samples/bluetooth/le_audio/unicast_initiator/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Audio Unicast Initiator
+tests:
+  sample.bt_custom.le_audio.unicast_initiator:
+    build_only: true
+    filter: dt_nodelabel_enabled("gpio5")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_central_batt/sample.yaml
+++ b/samples/bluetooth/le_central_batt/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Central Batt
+tests:
+  sample.bt_custom.le_central_batt:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_central_csip/sample.yaml
+++ b/samples/bluetooth/le_central_csip/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Central CSIP
+tests:
+  sample.bt_custom.le_central_csip:
+    build_only: true
+    filter: dt_nodelabel_enabled("gpio5")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_multiprofile/sample.yaml
+++ b/samples/bluetooth/le_multiprofile/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Multiprofile
+tests:
+  sample.bt_custom.le_multiprofile:
+    build_only: true
+    filter: dt_alias_exists("led0")
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph/sample.yaml
+++ b/samples/bluetooth/le_periph/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph
+tests:
+  sample.bt_custom.le_periph:
+    build_only: true
+    filter: dt_alias_exists("led0")
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_anps/sample.yaml
+++ b/samples/bluetooth/le_periph_anps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph ANPS
+tests:
+  sample.bt_custom.le_periph_anps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_batt/sample.yaml
+++ b/samples/bluetooth/le_periph_batt/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph Batt
+tests:
+  sample.bt_custom.le_periph_batt:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_blinky/sample.yaml
+++ b/samples/bluetooth/le_periph_blinky/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph Blinky
+tests:
+  sample.bt_custom.le_periph_blinky:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_blps/sample.yaml
+++ b/samples/bluetooth/le_periph_blps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph BLPS
+tests:
+  sample.bt_custom.le_periph_blps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_ccp/sample.yaml
+++ b/samples/bluetooth/le_periph_ccp/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph CCP
+tests:
+  sample.bt_custom.le_periph_ccp:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_cgms/sample.yaml
+++ b/samples/bluetooth/le_periph_cgms/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph CGMS
+tests:
+  sample.bt_custom.le_periph_cgms:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_cpps/sample.yaml
+++ b/samples/bluetooth/le_periph_cpps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph CPPS
+tests:
+  sample.bt_custom.le_periph_cpps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_cscps/sample.yaml
+++ b/samples/bluetooth/le_periph_cscps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph CSCPS
+tests:
+  sample.bt_custom.le_periph_cscps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_csip/sample.yaml
+++ b/samples/bluetooth/le_periph_csip/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph CSIP
+tests:
+  sample.bt_custom.le_periph_csip:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_dis/sample.yaml
+++ b/samples/bluetooth/le_periph_dis/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph DIS
+tests:
+  sample.bt_custom.le_periph_dis:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_glps/sample.yaml
+++ b/samples/bluetooth/le_periph_glps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph GLPS
+tests:
+  sample.bt_custom.le_periph_glps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_haps/sample.yaml
+++ b/samples/bluetooth/le_periph_haps/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph HAPS
+tests:
+  sample.bt_custom.le_periph_haps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_has/sample.yaml
+++ b/samples/bluetooth/le_periph_has/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph HAS
+tests:
+  sample.bt_custom.le_periph_has:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_hello/sample.yaml
+++ b/samples/bluetooth/le_periph_hello/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph Hello
+tests:
+  sample.bt_custom.le_periph_hello:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_hr/sample.yaml
+++ b/samples/bluetooth/le_periph_hr/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph HR
+tests:
+  sample.bt_custom.le_periph_hr:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_htpt/sample.yaml
+++ b/samples/bluetooth/le_periph_htpt/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph HTPT
+tests:
+  sample.bt_custom.le_periph_htpt:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_mics/sample.yaml
+++ b/samples/bluetooth/le_periph_mics/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Periph MICS
+tests:
+  sample.bt_custom.le_periph_mics:
+    build_only: true
+    filter: dt_alias_exists("ledred") and dt_alias_exists("ledblue")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_ots/sample.yaml
+++ b/samples/bluetooth/le_periph_ots/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph OTS
+tests:
+  sample.bt_custom.le_periph_ots:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_pacs/sample.yaml
+++ b/samples/bluetooth/le_periph_pacs/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph PACS
+tests:
+  sample.bt_custom.le_periph_pacs:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_past/sample.yaml
+++ b/samples/bluetooth/le_periph_past/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph PAST
+tests:
+  sample.bt_custom.le_periph_past:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_plxp/sample.yaml
+++ b/samples/bluetooth/le_periph_plxp/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph PLXP
+tests:
+  sample.bt_custom.le_periph_plxp:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_pm/sample.yaml
+++ b/samples/bluetooth/le_periph_pm/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: LE Periph PM
+tests:
+  sample.bt_custom.le_periph_pm:
+    build_only: true
+    filter: dt_compat_enabled("snps,dw-apb-rtc") or dt_compat_enabled("snps,dw-timers")
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_prxp/sample.yaml
+++ b/samples/bluetooth/le_periph_prxp/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph PRXP
+tests:
+  sample.bt_custom.le_periph_prxp:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_rscps/sample.yaml
+++ b/samples/bluetooth/le_periph_rscps/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph RSCPS
+tests:
+  sample.bt_custom.le_periph_rscps:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_tips/sample.yaml
+++ b/samples/bluetooth/le_periph_tips/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph TIPS
+tests:
+  sample.bt_custom.le_periph_tips:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_periph_vcp/sample.yaml
+++ b/samples/bluetooth/le_periph_vcp/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: LE Periph VCP
+tests:
+  sample.bt_custom.le_periph_vcp:
+    build_only: true
+    filter: dt_alias_exists("ledgreen")
+    tags:
+      - bluetooth
+      - bt_custom
+      - le_audio

--- a/samples/bluetooth/le_periph_ws/sample.yaml
+++ b/samples/bluetooth/le_periph_ws/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Periph WS
+tests:
+  sample.bt_custom.le_periph_ws:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/le_throughput/sample.yaml
+++ b/samples/bluetooth/le_throughput/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: LE Throughput
+tests:
+  sample.bt_custom.le_throughput:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/mesh_light_bulb/sample.yaml
+++ b/samples/bluetooth/mesh_light_bulb/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: Mesh Light Bulb
+tests:
+  sample.bt_custom.mesh_light_bulb:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom

--- a/samples/bluetooth/smp_svr/sample.yaml
+++ b/samples/bluetooth/smp_svr/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: SMP Svr
+tests:
+  sample.bt_custom.smp_svr:
+    build_only: true
+    tags:
+      - bluetooth
+      - bt_custom


### PR DESCRIPTION
Add a sample.yaml to each Bluetooth sample so they are discovered by Twister and can be built as a regression matrix (build-only).

Each scenario is tagged so the two Bluetooth host implementations can be selected independently:

  - bluetooth  - all BLE samples
  - bt_custom  - samples using the custom host (CONFIG_BT_CUSTOM) instead of the Zephyr host
  - le_audio   - LE Audio / audio-profile samples

Scenario names are namespaced under sample.bt_custom.* so they do not clash with the upstream sample.bluetooth.* identifiers. The files are board-agnostic; the target platform is chosen at invocation time.