### PR TITLE
manifest: update Zephyr version to sdhc emmc mode support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
+      revision: pull/611/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 9a8bc4c96f0c3020961cbdb9aa221ff414df20fb
+      revision: 2bf85a84edf53da5060b30ae88bea6e0046cdd86
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr revision to include sdhc_dwc emmc support.
Depends: https://github.com/alifsemi/zephyr_alif/pull/611