### PR TITLE
manifest: update Zephyr version to ethosu_config_select support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: f002a4d8499c35fc70ec4d5324faa7b01c152c72
+      revision: 971dd2293afeb22d84fb2f1291de94ccda5852f5
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updated Zephyr version to ethosu_config_select support.

Picks up the hal_ethos_u update to upstream commit db2caeb33975acbcd4db1c517120c0eada1798ac, which adds the ethosu_config_select platform hook allowing NPU config and port selection to be overridden by the platform.

Depends on: alifsemi/zephyr_alif#431