### PR TITLE
manifest: zephyr: pull in clock control CGU restore on PM resume

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: a72a819428d5c45eff939d8b00643b5de5eaea43
+      revision: pull/616/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 07c9ae4eba96af007c604ebee24004b5c891233a
+      revision: 7927786ab4d9c180e19e9ba9d28467a5f12908cb
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Pull the zephyr revision to include the Alif clock control PM-resume to restore the CGU clock enables.

Depends: https://github.com/alifsemi/zephyr_alif/pull/616