### PR TITLE
manifest: Take ns16550 TX FIFO empty fix into use

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: a72a819428d5c45eff939d8b00643b5de5eaea43
+      revision: df4907c285101caba23ee4d8345aaa0d188b4427
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr version to get ns16550 fix into use

Zephyr PR: https://github.com/alifsemi/zephyr_alif/pull/617