### PR TITLE
manifest: update zephyr revision for CAN RTR fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/620/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the Zephyr revision to include the CAN RTR transmission fix.
Related PR: https://github.com/alifsemi/zephyr_alif/pull/620