### PR TITLE
manifest: update Zephyr revision for CAN fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 2052dc39d6a984c38b2257a7f2df52e645b68273
+      revision: a1884e63a23f7779cc1923b349a03d126d176054
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects

--- a/west.yml
+++ b/west.yml
@@ -27,7 +27,7 @@ manifest:
   projects:
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 760cbea73f1cee8ef63500cb824cf39bea45f046
+      revision: pull/623/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the Zephyr revision to include the CAN timing and bus recovery fixes.

Zephyr PR: https://github.com/alifsemi/zephyr_alif/pull/623