### PR TITLE
manifest: update zephyr to lfs fstab changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 97fddffd316f63f9325545ec5c3dfc9a5034d831
+      revision: pull/626/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update manifest to fetch lfs fstab fixes.

Depends on : [fstab](https://github.com/alifsemi/zephyr_alif/pull/626)