### PR TITLE
manifest: update zephyr revision for i3c bus recovery changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: a1884e63a23f7779cc1923b349a03d126d176054
+      revision: 2134310f0be8bacd09c776513e66b6012b4a86b2
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Updates the zephyr revision to [alifsemi/zephyr_alif#638](https://github.com/alifsemi/zephyr_alif/pull/638).