### PR TITLE
manifest: updated zephyr revision to pick adc sign extension

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: b43923555d01135092b85fcf8b75296b941aef16
+      revision: ba7e137f14f31156731de2b816df1c3c99222a13
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
updated the zephyr revision version to pick the adc sign extension for negative value.

Zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/557