### PR TITLE
samples: sensor: bmi323_pm: add BMI323 I3C power-management sample

### DIFF
--- a/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
+++ b/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
@@ -281,6 +281,15 @@
 		};
 	};
 
+	pinctrl_i3c0_sleep: pinctrl_i3c0_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+				 <PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+			driver-state-control = <0x2>;
+		};
+	};
+
 	pinctrl_i3c0_recovery: pinctrl_i3c0_recovery {
 		group0 {
 			pinmux = <PIN_P0_6__GPIO>,

--- a/doc/appnotes/source/i3c.rst
+++ b/doc/appnotes/source/i3c.rst
@@ -144,4 +144,97 @@ Console Output
 Observation
 -----------
 
-Upon reviewing the output logs, it can be concluded that the I3C functionality has been successfully validated with the ICM42670P IMU sensor.
+Upon reviewing the output logs, it can be concluded that the I3C functionality has been successfully validated with the BMI323 IMU sensor.
+
+I3C Power Management Application
+================================
+
+``samples/sensor/bmi323_pm`` walks Alif power-management states and polls
+the same on-board BMI323 over I3C after each wake. Hardware, pinmux and
+the ``alif-dk-ak`` overlay are unchanged from the sample above. The SoC
+is woken by the RTC (EWIC). The sensor GPIO INT pin is not used (it is
+not LPGPIO and cannot wake STOP/S2RAM).
+
+Sequence (HE TCM boot)::
+
+  BMI323 poll
+  RUNTIME_IDLE  (~18 s)  -> poll
+  SUSPEND_TO_IDLE        -> poll
+  S2RAM STANDBY (~20 s)  -> poll
+  S2RAM STOP    (~22 s)  -> poll
+
+MRAM boot and the HP core use SOFT_OFF instead of S2RAM (the system
+resets on wake).
+
+.. note::
+   Do not leave a debugger attached if you want STOP/SOFT_OFF; it holds
+   the core out of those states.
+
+Build command for the M55 HE core:
+
+.. code-block:: console
+
+   west build -p always \
+     -b alif_e7_dk/ae722f80f55d5xx/rtss_he \
+     ../alif/samples/sensor/bmi323_pm \
+     -S alif-dk-ak -S pm-system-off-he
+
+Build command for the M55 HP core (use ``pm-system-off-hp``):
+
+.. code-block:: console
+
+   west build -p always \
+     -b alif_e7_dk/ae722f80f55d5xx/rtss_hp \
+     ../alif/samples/sensor/bmi323_pm \
+     -S alif-dk-ak -S pm-system-off-hp
+
+Flash with ``west flash`` as above. Example console output from
+``alif_e8_dk`` RTSS_HE, TCM boot (other boards follow the same
+sequence; accel/gyro values vary):
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build 97fddffd316f ***
+    Device 0xef30 name is bmi323@69000003b810431000
+    [00:00:00.025,000] <inf> bmi323_pm: alif_e8_dk RTSS_HE (TCM boot): BMI323 PM states demo (RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM)
+    [00:00:00.037,000] <inf> bmi323_pm: --- BMI323 poll before sleep ---
+    Accel AX: 0.025803; AY: -0.001220; AZ: 0.980331 g        Gyro GX: 0.030518; GY: 0.488288; GZ: -0.305180 deg/s
+    [00:00:00.066,000] <inf> bmi323_pm: POWER STATE SEQUENCE:
+    [00:00:00.072,000] <inf> bmi323_pm:   1. PM_STATE_RUNTIME_IDLE
+    [00:00:00.078,000] <inf> bmi323_pm:   2. PM_STATE_SUSPEND_TO_IDLE
+    [00:00:00.085,000] <inf> bmi323_pm:   3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)
+    [00:00:00.093,000] <inf> bmi323_pm:   4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)
+    [00:00:00.101,000] <inf> bmi323_pm:   5. (SOFT_OFF skipped - TCM boot, using retention)
+    [00:00:00.110,000] <inf> bmi323_pm: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+    [00:00:18.119,000] <inf> bmi323_pm: Exited from RUNTIME_IDLE sleep
+    [00:00:18.125,000] <inf> bmi323_pm: --- BMI323 poll after RUNTIME_IDLE ---
+    Accel AX: 0.025376; AY: -0.001708; AZ: 0.980392 g        Gyro GX: 0.030518; GY: 0.503547; GZ: -0.274662 deg/s
+    [00:00:18.149,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_IDLE for (4000 microseconds)
+    [00:00:18.164,000] <inf> bmi323_pm: Exited from PM_STATE_SUSPEND_TO_IDLE
+    [00:00:18.171,000] <inf> bmi323_pm: --- BMI323 poll after SUSPEND_TO_IDLE ---
+    Accel AX: 0.023790; AY: -0.000549; AZ: 0.980514 g        Gyro GX: 0.045777; GY: 0.442511; GZ: -0.289921 deg/s
+    [00:00:18.195,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) for (20000000 microseconds)
+    [00:00:38.208,000] <inf> bmi323_pm: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) ===
+    [00:00:38.239,000] <inf> bmi323_pm: Main thread running - iteration 0 - tick: 38239
+    [00:00:40.249,000] <inf> bmi323_pm: Main thread running - iteration 1 - tick: 40249
+    [00:00:42.259,000] <inf> bmi323_pm: Main thread running - iteration 2 - tick: 42259
+    [00:00:44.269,000] <inf> bmi323_pm: --- BMI323 poll after S2RAM (STANDBY) ---
+    Accel AX: 0.026718; AY: -0.001647; AZ: 0.980880 g        Gyro GX: 0.106813; GY: 0.457770; GZ: -0.274662 deg/s
+    [00:00:44.298,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) for (22000000 microseconds)
+    [00:01:06.311,000] <inf> bmi323_pm: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) ===
+    [00:01:06.342,000] <inf> bmi323_pm: Main thread running - iteration 0 - tick: 66342
+    [00:01:08.352,000] <inf> bmi323_pm: Main thread running - iteration 1 - tick: 68352
+    [00:01:10.362,000] <inf> bmi323_pm: Main thread running - iteration 2 - tick: 70362
+    [00:01:12.371,000] <inf> bmi323_pm: --- BMI323 poll after S2RAM (STOP) ---
+    Accel AX: 0.025010; AY: 0.000488; AZ: 0.980270 g         Gyro GX: 0.045777; GY: 0.442511; GZ: -0.274662 deg/s
+    [00:01:12.400,000] <inf> bmi323_pm: Skipping PM_STATE_SOFT_OFF (TCM boot, using retention instead)
+    [00:01:12.410,000] <inf> bmi323_pm: === BMI323 PM TEST COMPLETED ===
+
+See ``samples/sensor/bmi323_pm/README.rst`` for the MRAM/HP SOFT_OFF log.
+
+PM observation
+--------------
+
+A valid BMI323 sample after each listed power state means the I3C
+controller resumed (clock, DAT, dynamic address) and the target was
+reachable over I3C.

--- a/doc/release_notes/source/release_note.rst
+++ b/doc/release_notes/source/release_note.rst
@@ -96,6 +96,14 @@ This release adds two new APIs to the SE Host Services component:
    * - read_otp
      - Read an OTP word specified by offset.
 
+I3C
+~~~
+
+- Power-management support for the DesignWare I3C controller (suspend/resume,
+  sleep pinctrl, DAT restore across S2RAM).
+- New sample ``samples/sensor/bmi323_pm``: poll the on-board BMI323 over I3C
+  after RUNTIME_IDLE, SUSPEND_TO_IDLE, and S2RAM (or SOFT_OFF on MRAM/HP).
+
 Compatibility Notes
 -------------------
 
@@ -145,7 +153,7 @@ Communication Interfaces
    * - LPI2C
      - Low-power I2C controller for power-efficient peripheral communication.
    * - I3C
-     - Improved Inter-Integrated Circuit (I3C) interface supporting high-speed, low-power communication with dynamic addressing, in-band interrupts, and backward compatibility with I2C devices.
+     - Improved Inter-Integrated Circuit (I3C) interface supporting high-speed, low-power communication with dynamic addressing, in-band interrupts, and backward compatibility with I2C devices. Supports device PM suspend/resume, including sleep pinctrl and DAT restore across S2RAM.
    * - LP-UART
      - Low-power Universal Asynchronous Receiver/Transmitter supporting extended sleep modes with wake-on-receive capability. Maintains serial communication during system low-power states with reduced power consumption compared to standard UART peripherals.
    * - LP-SPI

--- a/samples/sensor/bmi323_pm/CMakeLists.txt
+++ b/samples/sensor/bmi323_pm/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bmi323_pm)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/bmi323_pm/README.rst
+++ b/samples/sensor/bmi323_pm/README.rst
@@ -1,0 +1,117 @@
+.. _bmi323_pm:
+
+BMI323 Power Management
+#######################
+
+Description
+***********
+
+This sample walks Alif power-management states and, after each wake,
+polls the on-board BMI323 over I3C. The SoC is woken by the RTC (EWIC).
+The sensor GPIO INT pin is not used; it is not LPGPIO and cannot wake
+STOP/S2RAM.
+
+Sequence (HE TCM boot)::
+
+  BMI323 poll
+  RUNTIME_IDLE  (~18 s)  -> poll
+  SUSPEND_TO_IDLE        -> poll
+  S2RAM STANDBY (~20 s)  -> poll
+  S2RAM STOP    (~22 s)  -> poll
+
+MRAM boot / HP core use SOFT_OFF instead of S2RAM (system resets on wake).
+
+Building and Running
+********************
+
+Requires a BMI323 on I3C0 (Alif DevKit / AppKit). Build with both the
+board sensor overlay and the HE PM snippet (RTC + SE off profile):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/bmi323_pm
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :gen-args: -S alif-dk-ak -S pm-system-off-he
+
+For HP core use ``-S pm-system-off-hp`` instead of ``pm-system-off-he``.
+
+Do not leave a debugger attached if you want STOP/SOFT_OFF; it holds the
+core out of those states.
+
+Sample Output
+=============
+
+HE TCM boot (S2RAM STANDBY and STOP; SOFT_OFF skipped)
+------------------------------------------------------
+
+``alif_e8_dk`` RTSS_HE, TCM boot. After S2RAM the I3C controller DAT is
+restored and board targets keep their DTS dynamic address.
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build 97fddffd316f ***
+    Device 0xef30 name is bmi323@69000003b810431000
+    [00:00:00.025,000] <inf> bmi323_pm: alif_e8_dk RTSS_HE (TCM boot): BMI323 PM states demo (RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM)
+    [00:00:00.037,000] <inf> bmi323_pm: --- BMI323 poll before sleep ---
+    Accel AX: 0.025803; AY: -0.001220; AZ: 0.980331 g        Gyro GX: 0.030518; GY: 0.488288; GZ: -0.305180 deg/s
+    [00:00:00.066,000] <inf> bmi323_pm: POWER STATE SEQUENCE:
+    [00:00:00.072,000] <inf> bmi323_pm:   1. PM_STATE_RUNTIME_IDLE
+    [00:00:00.078,000] <inf> bmi323_pm:   2. PM_STATE_SUSPEND_TO_IDLE
+    [00:00:00.085,000] <inf> bmi323_pm:   3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)
+    [00:00:00.093,000] <inf> bmi323_pm:   4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)
+    [00:00:00.101,000] <inf> bmi323_pm:   5. (SOFT_OFF skipped - TCM boot, using retention)
+    [00:00:00.110,000] <inf> bmi323_pm: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+    [00:00:18.119,000] <inf> bmi323_pm: Exited from RUNTIME_IDLE sleep
+    [00:00:18.125,000] <inf> bmi323_pm: --- BMI323 poll after RUNTIME_IDLE ---
+    Accel AX: 0.025376; AY: -0.001708; AZ: 0.980392 g        Gyro GX: 0.030518; GY: 0.503547; GZ: -0.274662 deg/s
+    [00:00:18.149,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_IDLE for (4000 microseconds)
+    [00:00:18.164,000] <inf> bmi323_pm: Exited from PM_STATE_SUSPEND_TO_IDLE
+    [00:00:18.171,000] <inf> bmi323_pm: --- BMI323 poll after SUSPEND_TO_IDLE ---
+    Accel AX: 0.023790; AY: -0.000549; AZ: 0.980514 g        Gyro GX: 0.045777; GY: 0.442511; GZ: -0.289921 deg/s
+    [00:00:18.195,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) for (20000000 microseconds)
+    [00:00:38.208,000] <inf> bmi323_pm: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) ===
+    [00:00:38.239,000] <inf> bmi323_pm: Main thread running - iteration 0 - tick: 38239
+    [00:00:40.249,000] <inf> bmi323_pm: Main thread running - iteration 1 - tick: 40249
+    [00:00:42.259,000] <inf> bmi323_pm: Main thread running - iteration 2 - tick: 42259
+    [00:00:44.269,000] <inf> bmi323_pm: --- BMI323 poll after S2RAM (STANDBY) ---
+    Accel AX: 0.026718; AY: -0.001647; AZ: 0.980880 g        Gyro GX: 0.106813; GY: 0.457770; GZ: -0.274662 deg/s
+    [00:00:44.298,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) for (22000000 microseconds)
+    [00:01:06.311,000] <inf> bmi323_pm: === Resumed from PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) ===
+    [00:01:06.342,000] <inf> bmi323_pm: Main thread running - iteration 0 - tick: 66342
+    [00:01:08.352,000] <inf> bmi323_pm: Main thread running - iteration 1 - tick: 68352
+    [00:01:10.362,000] <inf> bmi323_pm: Main thread running - iteration 2 - tick: 70362
+    [00:01:12.371,000] <inf> bmi323_pm: --- BMI323 poll after S2RAM (STOP) ---
+    Accel AX: 0.025010; AY: 0.000488; AZ: 0.980270 g         Gyro GX: 0.045777; GY: 0.442511; GZ: -0.274662 deg/s
+    [00:01:12.400,000] <inf> bmi323_pm: Skipping PM_STATE_SOFT_OFF (TCM boot, using retention instead)
+    [00:01:12.410,000] <inf> bmi323_pm: === BMI323 PM TEST COMPLETED ===
+
+HE MRAM boot (SOFT_OFF; S2RAM skipped)
+--------------------------------------
+
+``alif_e8_dk`` RTSS_HE, MRAM boot. SOFT_OFF has no retention: the core
+resets on RTC wakeup, so the console stops at the enter-SOFT_OFF lines
+and the next output is a fresh boot banner.
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build 97fddffd316f ***
+    Device 0x8000efc8 name is bmi323@69000003b810431000
+    [00:00:00.025,000] <inf> bmi323_pm: alif_e8_dk RTSS_HE (MRAM boot): BMI323 PM states demo (RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)
+    [00:00:00.037,000] <inf> bmi323_pm: --- BMI323 poll before sleep ---
+    Accel AX: 0.034648; AY: -0.006039; AZ: 0.978806 g        Gyro GX: 0.106813; GY: 0.427252; GZ: -0.274662 deg/s
+    [00:00:00.067,000] <inf> bmi323_pm: POWER STATE SEQUENCE:
+    [00:00:00.072,000] <inf> bmi323_pm:   1. PM_STATE_RUNTIME_IDLE
+    [00:00:00.079,000] <inf> bmi323_pm:   2. PM_STATE_SUSPEND_TO_IDLE
+    [00:00:00.085,000] <inf> bmi323_pm:   3. (S2RAM skipped - MRAM boot)
+    [00:00:00.092,000] <inf> bmi323_pm:   4. PM_STATE_SOFT_OFF
+    [00:00:00.098,000] <inf> bmi323_pm: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+    [00:00:18.107,000] <inf> bmi323_pm: Exited from RUNTIME_IDLE sleep
+    [00:00:18.113,000] <inf> bmi323_pm: --- BMI323 poll after RUNTIME_IDLE ---
+    Accel AX: 0.032574; AY: -0.006893; AZ: 0.977952 g        Gyro GX: 0.091554; GY: 0.457770; GZ: -0.213626 deg/s
+    [00:00:18.137,000] <inf> bmi323_pm: Enter PM_STATE_SUSPEND_TO_IDLE for (4000 microseconds)
+    [00:00:18.152,000] <inf> bmi323_pm: Exited from PM_STATE_SUSPEND_TO_IDLE
+    [00:00:18.159,000] <inf> bmi323_pm: --- BMI323 poll after SUSPEND_TO_IDLE ---
+    Accel AX: 0.033428; AY: -0.005063; AZ: 0.977891 g        Gyro GX: 0.076295; GY: 0.381475; GZ: -0.289921 deg/s
+    [00:00:18.183,000] <inf> bmi323_pm: Skipping PM_STATE_SUSPEND_TO_RAM (MRAM boot)
+    [00:00:18.191,000] <inf> bmi323_pm: Enter PM_STATE_SOFT_OFF for (26000000 microseconds)
+    [00:00:18.199,000] <inf> bmi323_pm: Note: SOFT_OFF has no retention - system will reset on wakeup

--- a/samples/sensor/bmi323_pm/prj.conf
+++ b/samples/sensor/bmi323_pm/prj.conf
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_PM=y
+CONFIG_IDLE_STACK_SIZE=1024
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+CONFIG_MAIN_STACK_SIZE=4096
+
+CONFIG_COUNTER=y
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_ASSERT=y
+
+# Logging Configuration
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=0
+CONFIG_LOG_MODE_IMMEDIATE=y
+CONFIG_LOG_BUFFER_SIZE=8192
+
+# I3C / sensor
+CONFIG_I3C=y
+CONFIG_I3C_INIT_RSTACT=y
+CONFIG_I3C_USE_IBI=n
+CONFIG_I3C_LOG_LEVEL_INF=y
+CONFIG_I3C_DW_LOG_LEVEL_INF=y
+CONFIG_GPIO=y
+CONFIG_SENSOR=y
+CONFIG_CLOCK_CONTROL=y
+CONFIG_FPU=y
+CONFIG_CBPRINTF_FP_SUPPORT=y
+
+# PM Configuration
+CONFIG_PM_DEVICE=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_PM_S2RAM=y
+CONFIG_PM_SAU_SAVE_RESTORE=y

--- a/samples/sensor/bmi323_pm/sample.yaml
+++ b/samples/sensor/bmi323_pm/sample.yaml
@@ -1,0 +1,41 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+sample:
+  name: BMI323 Sensor Power Management
+  description: >
+    Walks Alif PM states (RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM or SOFT_OFF)
+    while polling the on-board BMI323 over I3C.
+common:
+  tags:
+    - i3c
+    - sensors
+    - pm
+  filter: SOC_FAMILY_ENSEMBLE or SOC_FAMILY_BALLETTO
+  depends_on:
+    - i3c
+    - counter
+tests:
+  sample.sensor.bmi323_pm.he:
+    extra_args:
+      - SNIPPET="alif-dk-ak;pm-system-off-he"
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+      - alif_e8_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+  sample.sensor.bmi323_pm.hp:
+    extra_args:
+      - SNIPPET="alif-dk-ak;pm-system-off-hp"
+    platform_allow:
+      - alif_e7_dk_rtss_hp
+      - alif_e8_dk_rtss_hp
+    integration_platforms:
+      - alif_e7_dk_rtss_hp

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_b1_e1c_dk.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_b1_e1c_dk.overlay
@@ -1,0 +1,35 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&i3c0 {
+	status = "okay";
+
+	bmi323: bmi323@69000003b810431000 {
+		compatible = "bosch,bmi323";
+		reg = <0x69 0x03b8 0x10431000>;
+		/* Dynamic Address To Be Assigned To The Device */
+		assigned-address = <0xA>;
+		int-gpios	 = <&gpio6 6 GPIO_ACTIVE_HIGH>;
+		status		 = "okay";
+	};
+};
+
+&pinctrl_gpio6 {
+	group0 {
+		/* Enable only Port-6 Pin-6 */
+		pinmux = <PIN_P6_6__GPIO>;
+	};
+};
+
+&gpio6 {
+	pinctrl-0       = <&pinctrl_gpio6>;
+	pinctrl-names   = "default";
+	status		= "okay";
+};

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e3_e4_e7_e8_dk.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e3_e4_e7_e8_dk.overlay
@@ -1,0 +1,36 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&i3c0 {
+	status = "okay";
+
+	bmi323: bmi323@69000003b810431000 {
+		compatible = "bosch,bmi323";
+		reg = <0x69 0x03b8 0x10431000>;
+		/* Dynamic Address To Be Assigned To The Device */
+		assigned-address = <0xA>;
+		int-gpios	 = <&gpio8 4 GPIO_ACTIVE_HIGH>;
+		status		 = "okay";
+	};
+};
+
+&pinctrl_gpio8 {
+	group0 {
+		/* Enable only Port-8 Pin-4 */
+		pinmux = <PIN_P8_4__GPIO>;
+	};
+};
+
+&gpio8 {
+	pinctrl-0       = <&pinctrl_gpio8>;
+	pinctrl-names   = "default";
+	status		= "okay";
+};
+

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e8_ak.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e8_ak.overlay
@@ -1,0 +1,35 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&i3c0 {
+	status = "okay";
+
+	bmi323: bmi323@69000003b810431000 {
+		compatible = "bosch,bmi323";
+		reg = <0x69 0x03b8 0x10431000>;
+		/* Dynamic Address To Be Assigned To The Device */
+		assigned-address = <0xA>;
+		int-gpios	 = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		status		 = "okay";
+	};
+};
+
+&pinctrl_gpio1 {
+	group0 {
+		/* Enable only Port-1 Pin-4 */
+		pinmux = <PIN_P1_4__GPIO>;
+	};
+};
+
+&gpio1 {
+	pinctrl-0	= <&pinctrl_gpio1>;
+	pinctrl-names	= "default";
+	status		= "okay";
+};

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/snippet.yml
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+name: alif-dk-ak
+
+boards:
+  /alif_(b1|e1c)_dk/.*/rtss_he/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_b1_e1c_dk.overlay
+
+  /alif_(e3|e4|e7|e8)_dk/.*/rtss_(hp|he)/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_e3_e4_e7_e8_dk.overlay
+
+  /alif_e8_ak/.*/rtss_(hp|he)/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: alif_e8_ak.overlay

--- a/samples/sensor/bmi323_pm/src/main.c
+++ b/samples/sensor/bmi323_pm/src/main.c
@@ -1,0 +1,840 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * BMI323 power-management demo for Alif SoCs.
+ *
+ * RTC/LPTIMER wakes the SoC through EWIC, then the app polls the BMI323
+ * over I3C. The sensor INT pin is not used (it is not LPGPIO, so it
+ * cannot wake S2RAM/STOP).
+ */
+
+#include "aipm.h"
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#if defined(CONFIG_POWEROFF)
+#include <zephyr/sys/poweroff.h>
+#endif
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/sensor.h>
+#include <se_service.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bmi323_pm, LOG_LEVEL_INF);
+
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+/**
+ * As per the application requirements, it can remove the memory blocks which are not in use.
+ */
+#if defined(CONFIG_SOC_SERIES_E1C) || defined(CONFIG_SOC_SERIES_B1)
+	#define APP_RET_MEM_BLOCKS SRAM4_1_MASK | SRAM4_2_MASK | SRAM4_3_MASK | SRAM4_4_MASK | \
+					SRAM5_1_MASK | SRAM5_2_MASK | SRAM5_3_MASK | SRAM5_4_MASK |\
+					SRAM5_5_MASK
+	#define SERAM_MEMORY_BLOCKS_IN_USE SERAM_1_MASK | SERAM_2_MASK | SERAM_3_MASK | SERAM_4_MASK
+#else
+	#define APP_RET_MEM_BLOCKS SRAM4_1_MASK | SRAM4_2_MASK | SRAM5_1_MASK | SRAM5_2_MASK
+	#define SERAM_MEMORY_BLOCKS_IN_USE SERAM_MASK
+#endif
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE || CONFIG_ALIF_SE_DTS_OFF_PROFILE */
+
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define SE_OFFP_EWIC_CFG EWIC_RTC_A
+	#define SE_OFFP_WAKEUP_EVENTS WE_LPRTC
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define SE_OFFP_EWIC_CFG EWIC_VBAT_TIMER
+	#define SE_OFFP_WAKEUP_EVENTS WE_LPTIMER0
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lputimer0), alif_utimer, okay)
+	#define SE_OFFP_EWIC_CFG EWIC_VBAT_TIMER
+	#define SE_OFFP_WAKEUP_EVENTS WE_LPTIMER0
+#endif
+#endif /* CONFIG_ALIF_SE_DTS_OFF_PROFILE */
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lputimer0), alif_utimer, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(lputimer0)
+#else
+#error "Wakeup Device not enabled in the dts"
+#endif
+
+
+/* Sleep duration for PM_STATE_RUNTIME_IDLE */
+#define RUNTIME_IDLE_SLEEP_USEC (18 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_IDLE */
+#define SUSPEND_IDLE_SLEEP_USEC (4 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 0 (STANDBY) */
+#define S2RAM_STANDBY_SLEEP_USEC (20 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 1 (STOP) */
+#define S2RAM_STOP_SLEEP_USEC (22 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SOFT_OFF */
+#define SOFT_OFF_SLEEP_USEC (26 * 1000 * 1000)
+/* Wakeup duration for sys_poweroff (permanent power off) */
+#define POWEROFF_WAKEUP_USEC (30 * 1000 * 1000)
+
+/*
+ * MRAM base address - used to determine boot location
+ * TCM boot: VTOR = 0x0
+ * MRAM boot: VTOR >= 0x80000000
+ */
+#define MRAM_BASE_ADDRESS 0x80000000
+
+/*
+ * Helper macro to check if booting from MRAM
+ */
+#define IS_BOOTING_FROM_MRAM() (SCB->VTOR >= MRAM_BASE_ADDRESS)
+
+/*
+ * PM_STATE_SUSPEND_TO_RAM (S2RAM) support:
+ * - HP core: NOT supported (no retention capability)
+ * - HE core + TCM boot: SUPPORTED (TCM retention keeps code and context)
+ */
+#if defined(CONFIG_RTSS_HE)
+#define S2RAM_SUPPORTED (!IS_BOOTING_FROM_MRAM())
+#else
+#define S2RAM_SUPPORTED 0
+#endif
+
+/*
+ * PM_STATE_SOFT_OFF support:
+ * - HP core: Always supported (no retention, must use SOFT_OFF)
+ * - HE core + MRAM boot: Supported (MRAM preserved, wakeup possible)
+ * - HE core + TCM boot: Skip (use S2RAM with retention instead)
+ */
+#if defined(CONFIG_RTSS_HP)
+#define SOFT_OFF_SUPPORTED 1
+#elif defined(CONFIG_RTSS_HE)
+#define SOFT_OFF_SUPPORTED IS_BOOTING_FROM_MRAM()
+#else
+#define SOFT_OFF_SUPPORTED 0
+#endif
+
+#if defined(CONFIG_RTSS_HE)
+BUILD_ASSERT((S2RAM_STOP_SLEEP_USEC > S2RAM_STANDBY_SLEEP_USEC),
+	"STOP sleep duration should be greater than STANDBY sleep duration");
+BUILD_ASSERT((SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC),
+	"SOFT_OFF sleep duration should be greater than STOP sleep duration");
+#endif
+
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
+/**
+ * Set the RUN profile parameters for this application.
+ */
+static int app_set_run_params(void)
+{
+	run_profile_t runp;
+	int ret;
+
+	runp.power_domains = PD_SYST_MASK | PD_SSE700_AON_MASK;
+	runp.dcdc_voltage  = 825;
+	runp.dcdc_mode     = DCDC_MODE_PWM;
+	runp.aon_clk_src   = CLK_SRC_LFXO;
+	runp.run_clk_src   = CLK_SRC_PLL;
+	runp.vdd_ioflex_3V3 = IOFLEX_LEVEL_1V8;
+	runp.ip_clock_gating = 0;
+	runp.phy_pwr_gating = 0;
+#if defined(CONFIG_RTSS_HP)
+	runp.cpu_clk_freq  = CLOCK_FREQUENCY_400MHZ;
+#else
+	runp.cpu_clk_freq  = CLOCK_FREQUENCY_160MHZ;
+#endif
+
+	runp.memory_blocks = MRAM_MASK;
+
+	ret = se_service_set_run_cfg(&runp);
+	__ASSERT(ret == 0, "SE: set_run_cfg failed = %d", ret);
+
+	return ret;
+}
+/*
+ * CRITICAL: Must run at PRE_KERNEL_1 to restore SYSTOP before peripherals initialize.
+ *
+ * Priority 46 ensures this runs:
+ *   - AFTER SE Services (priority 45) - SE must be ready for set_run_cfg()
+ *   - BEFORE Power Domain (priority 47) - Power domain needs SYSTOP enabled
+ *   - BEFORE UART and peripherals (priority 50+) - Peripherals need SYSTOP ON
+ *
+ * On cold boot: SYSTOP is already ON by default, safe to call.
+ * On SOFT_OFF wakeup: SYSTOP is OFF, must restore BEFORE peripherals access registers.
+ */
+SYS_INIT(app_set_run_params, PRE_KERNEL_1, 46);
+#endif /* CONFIG_ALIF_SE_DTS_RUN_PROFILE */
+
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+static int app_set_off_params(enum pm_state state, uint8_t substate_id)
+{
+	int ret;
+	off_profile_t offp;
+
+	offp.dcdc_voltage  = 825;
+	offp.dcdc_mode     = DCDC_MODE_OFF;
+	offp.stby_clk_freq = SCALED_FREQ_RC_STDBY_76_8_MHZ;
+	offp.aon_clk_src   = CLK_SRC_LFXO;
+	offp.stby_clk_src  = CLK_SRC_HFRC;
+	offp.vtor_address  = SCB->VTOR;
+	offp.ip_clock_gating = 0;
+	offp.phy_pwr_gating = 0;
+	offp.vdd_ioflex_3V3 = IOFLEX_LEVEL_1V8;
+	offp.ewic_cfg      = SE_OFFP_EWIC_CFG;
+	offp.wakeup_events = SE_OFFP_WAKEUP_EVENTS;
+	offp.memory_blocks = MRAM_MASK;
+
+
+#if defined(CONFIG_RTSS_HE)
+	/*
+	 * HE core retention configuration:
+	 * - TCM boot (VTOR = 0): Enable TCM retention (SERAM + APP_RET_MEM_BLOCKS)
+	 * - MRAM boot (VTOR >= 0x80000000): Only SERAM retention needed
+	 */
+	if (!IS_BOOTING_FROM_MRAM()) {
+		/* TCM boot: enable full retention including TCM memory blocks */
+		offp.memory_blocks |= APP_RET_MEM_BLOCKS | SERAM_MEMORY_BLOCKS_IN_USE;
+	} else {
+		/* MRAM boot */
+		offp.memory_blocks |= SERAM_MEMORY_BLOCKS_IN_USE;
+	}
+#else
+	/*
+	 * HP core: Retention is not possible with HP-TCM
+	 */
+	__ASSERT(IS_BOOTING_FROM_MRAM(), "HP TCM Retention is not possible - VTOR is set to TCM");
+#endif
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_RAM:
+		if (substate_id == 0) {
+			offp.power_domains = PD_SSE700_AON_MASK;
+		} else if (substate_id == 1) {
+			offp.power_domains = PD_VBAT_AON_MASK;
+
+		}
+		break;
+	case PM_STATE_SOFT_OFF:
+		offp.memory_blocks = MRAM_MASK | SERAM_MEMORY_BLOCKS_IN_USE;
+		offp.power_domains = PD_VBAT_AON_MASK;
+		break;
+	default:
+		break;
+	}
+
+	ret = se_service_set_off_cfg(&offp);
+	__ASSERT(ret == 0, "SE: set_off_cfg failed = %d", ret);
+
+	return ret;
+}
+
+/**
+ * PM Notifier callback for power state entry
+ */
+static void pm_notify_state_entry(enum pm_state state)
+{
+	const struct pm_state_info *next_state = pm_state_next_get(0);
+	uint8_t substate_id = next_state ? next_state->substate_id : 0;
+	int ret;
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* No action needed */
+		break;
+	case PM_STATE_SUSPEND_TO_RAM:
+	case PM_STATE_SOFT_OFF:
+		ret = app_set_off_params(state, substate_id);
+		__ASSERT(ret == 0, "app_set_off_params failed = %d", ret);
+		break;
+	default:
+		__ASSERT(false, "Entering unknown power state %d", state);
+		break;
+	}
+}
+#endif /* CONFIG_ALIF_SE_DTS_OFF_PROFILE */
+
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
+/**
+ * PM Notifier callback called BEFORE devices are resumed
+ *
+ * This restores SE run configuration when resuming from S2RAM states.
+ * Note: For SOFT_OFF, the system resets completely and app_set_run_params()
+ * runs during normal PRE_KERNEL_1 initialization, so this callback is not needed.
+ */
+static void pm_notify_pre_device_resume(enum pm_state state)
+{
+	int ret;
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_RAM:
+		ret = app_set_run_params();
+		__ASSERT(ret == 0, "app_set_run_params failed = %d", ret);
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* No action needed - IWIC keeps power, no restoration required */
+		break;
+	case PM_STATE_SOFT_OFF:
+		/* No action needed - SOFT_OFF causes reset, not resume */
+		break;
+	default:
+		__ASSERT(false, "Pre-resume for unknown power state %d", state);
+		break;
+	}
+}
+#endif
+
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+/**
+ * PM Notifier structure
+ */
+static struct pm_notifier app_pm_notifier = {
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+	.state_entry = pm_notify_state_entry,
+#endif
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE)
+	.pre_device_resume = pm_notify_pre_device_resume,
+#endif
+};
+#endif
+
+/**
+ * Helper function to lock/unlock deeper power states
+ * @param lock true to lock deeper states (allow only RUNTIME_IDLE), false to unlock all
+ */
+static void app_pm_lock_deeper_states(bool lock)
+{
+	const char *state_desc = "";
+
+#if defined(CONFIG_RTSS_HP)
+	/* HP core: only SOFT_OFF (no S2RAM support) */
+	enum pm_state deep_states[] = {
+		PM_STATE_SOFT_OFF
+	};
+	state_desc = "SOFT_OFF";
+
+	for (int i = 0; i < ARRAY_SIZE(deep_states); i++) {
+		if (lock) {
+			pm_policy_state_lock_get(deep_states[i], PM_ALL_SUBSTATES);
+		} else {
+			pm_policy_state_lock_put(deep_states[i], PM_ALL_SUBSTATES);
+		}
+	}
+
+#elif defined(CONFIG_RTSS_HE)
+	/*
+	 * HE core: States depend on boot location
+	 * - TCM boot: S2RAM only (SOFT_OFF not needed with retention)
+	 * - MRAM boot: SOFT_OFF only (Keep S2RAM locked)
+	 */
+	enum pm_state deep_states[2];
+	int num_states = 0;
+
+	if (S2RAM_SUPPORTED) {
+		/* TCM boot: S2RAM works with retention */
+		deep_states[num_states++] = PM_STATE_SUSPEND_TO_RAM;
+		state_desc = "S2RAM";
+	} else {
+		/* MRAM boot: Keep S2RAM locked so SOFT_OFF is selected */
+		if (!lock) {
+			/* Ensure S2RAM stays locked when unlocking SOFT_OFF */
+			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		}
+	}
+
+	if (SOFT_OFF_SUPPORTED) {
+		/* MRAM boot: SOFT_OFF is the only deep sleep option for now */
+		deep_states[num_states++] = PM_STATE_SOFT_OFF;
+		state_desc = "SOFT_OFF";
+	}
+
+	for (int i = 0; i < num_states; i++) {
+		if (lock) {
+			pm_policy_state_lock_get(deep_states[i], PM_ALL_SUBSTATES);
+		} else {
+			pm_policy_state_lock_put(deep_states[i], PM_ALL_SUBSTATES);
+		}
+	}
+
+#else
+	#error "Unknown core type"
+#endif
+
+	LOG_DBG("%s deeper power state(s) (%s)",
+	       lock ? "Locked" : "Unlocked", state_desc);
+}
+
+/*
+ * This function will be invoked in the PRE_KERNEL_2 phase of the init routine.
+ */
+static int app_pre_kernel_init(void)
+{
+	/* Lock deeper power states to allow only RUNTIME_IDLE */
+	app_pm_lock_deeper_states(true);
+
+#if !defined(CONFIG_ALIF_SE_DTS_RUN_PROFILE) || !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+	/* Register PM notifier callbacks */
+	pm_notifier_register(&app_pm_notifier);
+#endif
+
+	return 0;
+}
+SYS_INIT(app_pre_kernel_init, PRE_KERNEL_2, 0);
+
+static int bmi323_configure(const struct device *dev)
+{
+	struct sensor_value full_scale, sampling_freq, feat_mask;
+
+	/* Setting scale in G, due to loss of precision if the SI unit m/s^2
+	 * is used
+	 */
+	full_scale.val1 = 2;            /* G */
+	full_scale.val2 = 0;
+	sampling_freq.val1 = 100;       /* Hz. Performance mode */
+	sampling_freq.val2 = 0;
+	feat_mask.val1 = 1;          /* High performance mode */
+	feat_mask.val2 = 0;
+
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_FULL_SCALE,
+			&full_scale);
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_FEATURE_MASK,
+			&feat_mask);
+	/* Set sampling frequency last as this also sets the appropriate
+	 * power mode. If already sampling, change to 0.0Hz before changing
+	 * other attributes
+	 */
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY,
+			&sampling_freq);
+
+	/* Setting scale in degrees/s to match the sensor scale */
+	full_scale.val1 = 500;          /* dps */
+	full_scale.val2 = 0;
+	sampling_freq.val1 = 100;       /* Hz. Performance mode */
+	sampling_freq.val2 = 0;
+	feat_mask.val1 = 1;          /* High performance mode */
+	feat_mask.val2 = 0;
+
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_FULL_SCALE,
+			&full_scale);
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_FEATURE_MASK,
+			&feat_mask);
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY,
+			&sampling_freq);
+
+	return 0;
+}
+
+/*
+ * Poll the BMI323 once the SoC is awake. The I3C controller is resumed
+ * by PM_DEVICE before this runs from main.
+ */
+static int bmi323_poll(const struct device *dev)
+{
+	struct sensor_value acc[3], gyr[3];
+	int ret;
+	int retries = 20;
+
+	/*
+	 * After enable/ODR change the data path is 0x8000 until the first
+	 * conversion. Fetch returns -ENODATA until then; wait for DRDY.
+	 */
+	do {
+		ret = sensor_sample_fetch(dev);
+		if (ret != -ENODATA) {
+			break;
+		}
+		k_sleep(K_MSEC(10));
+	} while (--retries);
+
+	if (ret) {
+		LOG_ERR("BMI323 sample fetch failed: %d", ret);
+		return ret;
+	}
+
+	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_XYZ, acc);
+	sensor_channel_get(dev, SENSOR_CHAN_GYRO_XYZ, gyr);
+
+	printk("Accel AX: %f; AY: %f; AZ: %f g"
+	       "\t Gyro GX: %f; GY: %f; GZ: %f deg/s\n",
+	       sensor_value_to_double(&acc[0]),
+	       sensor_value_to_double(&acc[1]),
+	       sensor_value_to_double(&acc[2]),
+	       sensor_value_to_double(&gyr[0]),
+	       sensor_value_to_double(&gyr[1]),
+	       sensor_value_to_double(&gyr[2]));
+
+	return 0;
+}
+
+/*
+ * Quiesce the BMI323 from this thread before the idle thread tears down
+ * I3C. System PM must not issue I3C transfers from idle.
+ */
+static int bmi323_prepare_deep_sleep(const struct device *dev)
+{
+	int ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
+
+	if (ret && ret != -EALREADY) {
+		LOG_ERR("BMI323 suspend failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * Re-init the BMI323 from this thread (I3C clock is already on).
+ *
+ * STANDBY/STOP only drop SoC islands (SYSTOP / SSE700 AON). Board I3C
+ * targets keep VDD and their DA. The BMI323 I3C path uses a const
+ * i3c_dt_spec.addr from assigned-address, so a runtime DAA cannot be
+ * used — a new DA would not be visible to the driver.
+ */
+static int bmi323_restore_after_deep_sleep(const struct device *dev)
+{
+	int ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
+
+	if (ret && ret != -EALREADY) {
+		LOG_ERR("BMI323 resume failed: %d", ret);
+		return ret;
+	}
+
+	return bmi323_configure(dev);
+}
+
+#if !defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+static volatile uint32_t alarm_cb_status;
+static void alarm_callback_fn(const struct device *wakeup_dev,
+				uint8_t chan_id, uint32_t ticks,
+				void *user_data)
+{
+	LOG_DBG("%s: Alarm triggered", wakeup_dev->name);
+	alarm_cb_status = 1;
+}
+#endif
+
+static int app_enter_normal_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Could not set the alarm (err %d)", ret);
+		return ret;
+	}
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+
+	k_sleep(K_USEC(sleep_usec));
+
+	if (!alarm_cb_status) {
+		return -1;
+	}
+	alarm_cb_status = 0;
+
+
+#endif
+	return 0;
+}
+
+#if !defined(CONFIG_POWEROFF)
+static int app_enter_deep_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	/**
+	 * Set a delay more than the min-residency-us configured so that
+	 * the sub-system will go to OFF state.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+	/*
+	 * Set the alarm and delay so that idle thread can run
+	 */
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set the alarm (err %d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+	/*
+	 * Wait for the alarm to trigger. The idle thread will
+	 * take care of entering the deep sleep state via PM framework.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#endif
+
+	return 0;
+}
+#endif /* !CONFIG_POWEROFF */
+
+int main(void)
+{
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	const struct device *const dev = DEVICE_DT_GET_ONE(bosch_bmi323);
+	int ret;
+
+	__ASSERT(device_is_ready(cons), "%s: device not ready", cons->name);
+	__ASSERT(device_is_ready(wakeup_dev), "%s: device not ready", wakeup_dev->name);
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("BMI323 device not ready");
+		return 0;
+	}
+
+	printk("Device %p name is %s\n", dev, dev->name);
+
+	ret = bmi323_configure(dev);
+	if (ret) {
+		LOG_ERR("BMI323 configure failed: %d", ret);
+		return 0;
+	}
+
+#if defined(CONFIG_RTSS_HE)
+	/* Boot location determines which PM states are available */
+	bool is_mram_boot = IS_BOOTING_FROM_MRAM();
+
+	if (is_mram_boot) {
+		LOG_INF("%s RTSS_HE (MRAM boot): BMI323 PM states demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)",
+			CONFIG_BOARD);
+	} else {
+		LOG_INF("%s RTSS_HE (TCM boot): BMI323 PM states demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM)",
+			CONFIG_BOARD);
+	}
+#else
+	LOG_INF("%s RTSS_HP: BMI323 PM states demo "
+		"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)", CONFIG_BOARD);
+#endif
+
+	ret = counter_start(wakeup_dev);
+	__ASSERT(!ret || ret == -EALREADY, "Failed to start counter (err %d)", ret);
+
+	LOG_INF("--- BMI323 poll before sleep ---");
+	ret = bmi323_poll(dev);
+	if (ret) {
+		LOG_WRN("BMI323 poll failed before sleep (err %d), continuing PM test", ret);
+	}
+
+	LOG_INF("POWER STATE SEQUENCE:");
+#if defined(CONFIG_POWEROFF)
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	LOG_INF("  3. Power off (sys_poweroff)");
+#elif defined(CONFIG_RTSS_HE)
+	/* HE core: sequence depends on boot location */
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	if (!is_mram_boot) {
+		/* TCM boot: S2RAM works (TCM retention) */
+		LOG_INF("  3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)");
+		LOG_INF("  4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)");
+		LOG_INF("  5. (SOFT_OFF skipped - TCM boot, using retention)");
+	} else {
+		/* MRAM boot: Enable Only SOFT_OFF */
+		LOG_INF("  3. (S2RAM skipped - MRAM boot)");
+		LOG_INF("  4. PM_STATE_SOFT_OFF");
+	}
+#else
+	/* HP core: no retention, only SOFT_OFF supported */
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	LOG_INF("  3. PM_STATE_SOFT_OFF");
+#endif
+
+	/* Lock SUSPEND_IDLE to force PM policy to select RUNTIME_IDLE only */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("Enter RUNTIME_IDLE sleep for (%d microseconds)", RUNTIME_IDLE_SLEEP_USEC);
+	ret = app_enter_normal_sleep(RUNTIME_IDLE_SLEEP_USEC);
+	__ASSERT(ret == 0, "Could not enter RUNTIME_IDLE sleep (err %d)", ret);
+
+	LOG_INF("Exited from RUNTIME_IDLE sleep");
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+	LOG_INF("--- BMI323 poll after RUNTIME_IDLE ---");
+	ret = bmi323_poll(dev);
+	if (ret) {
+		LOG_ERR("BMI323 poll failed after RUNTIME_IDLE (err %d)", ret);
+	}
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	LOG_INF("Enter PM_STATE_SUSPEND_TO_IDLE for (%d microseconds)",
+		SUSPEND_IDLE_SLEEP_USEC);
+	k_sleep(K_USEC(SUSPEND_IDLE_SLEEP_USEC));
+	LOG_INF("Exited from PM_STATE_SUSPEND_TO_IDLE");
+
+	LOG_INF("--- BMI323 poll after SUSPEND_TO_IDLE ---");
+	ret = bmi323_poll(dev);
+	if (ret) {
+		LOG_ERR("BMI323 poll failed after SUSPEND_TO_IDLE (err %d)", ret);
+	}
+#else
+	/* Lock SUSPEND_TO_IDLE when LPM timer support is not configured */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("PM_STATE_SUSPEND_TO_IDLE (skipped - LPM timer not enabled)");
+#endif
+
+#if defined(CONFIG_POWEROFF)
+	/* Configure wakeup source for permanent power off */
+	struct counter_alarm_cfg alarm_cfg = {0};
+
+	LOG_INF("=== Enter (sys_poweroff) ===");
+	LOG_INF("System will power off and can only wake via external event (RTC/Timer)");
+	k_sleep(K_SECONDS(2));
+
+	/* Set alarm for wakeup from power off */
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, POWEROFF_WAKEUP_USEC);
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set wakeup alarm (err %d)", ret);
+	} else {
+		LOG_INF("Wakeup alarm set for %u seconds", POWEROFF_WAKEUP_USEC / 1000000);
+	}
+
+	/* Configure OFF profile for wakeup capability */
+#if !defined(CONFIG_ALIF_SE_DTS_OFF_PROFILE)
+	app_set_off_params(PM_STATE_SOFT_OFF, 0);
+#endif
+
+	LOG_INF("Calling sys_poweroff() - system will power off permanently");
+	sys_poweroff();
+
+	/* Should never reach here */
+	LOG_ERR("Failed to execute sys_poweroff()");
+
+	return -1;
+#else
+	/* Unlock deeper power states to allow S2RAM and/or SOFT_OFF */
+	app_pm_lock_deeper_states(false);
+
+#if defined(CONFIG_RTSS_HE)
+	/* HE core: S2RAM only if booting from TCM */
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("Enter PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) for (%d microseconds)",
+			S2RAM_STANDBY_SLEEP_USEC);
+		ret = bmi323_prepare_deep_sleep(dev);
+		__ASSERT(ret == 0, "BMI323 prepare for S2RAM failed (err %d)", ret);
+		ret = app_enter_deep_sleep(S2RAM_STANDBY_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		LOG_INF("=== Resumed from PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) ===");
+
+		ret = bmi323_restore_after_deep_sleep(dev);
+		if (ret) {
+			LOG_ERR("BMI323 restore after S2RAM STANDBY failed: %d", ret);
+		}
+
+		/* Verify main thread is running properly */
+		for (int i = 0; i < 3; i++) {
+			LOG_INF("Main thread running - iteration %d - tick: %llu",
+				i, k_uptime_ticks());
+			k_sleep(K_SECONDS(2));
+		}
+
+		LOG_INF("--- BMI323 poll after S2RAM (STANDBY) ---");
+		ret = bmi323_poll(dev);
+		if (ret) {
+			LOG_ERR("BMI323 poll failed after S2RAM STANDBY (err %d)", ret);
+		}
+
+		LOG_INF("Enter PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) for (%d microseconds)",
+			S2RAM_STOP_SLEEP_USEC);
+		ret = bmi323_prepare_deep_sleep(dev);
+		__ASSERT(ret == 0, "BMI323 prepare for S2RAM failed (err %d)", ret);
+		ret = app_enter_deep_sleep(S2RAM_STOP_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		LOG_INF("=== Resumed from PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) ===");
+
+		ret = bmi323_restore_after_deep_sleep(dev);
+		if (ret) {
+			LOG_ERR("BMI323 restore after S2RAM STOP failed: %d", ret);
+		}
+
+		/* Verify main thread is running properly */
+		for (int i = 0; i < 3; i++) {
+			LOG_INF("Main thread running - iteration %d - tick: %llu",
+				i, k_uptime_ticks());
+			k_sleep(K_SECONDS(2));
+		}
+
+		LOG_INF("--- BMI323 poll after S2RAM (STOP) ---");
+		ret = bmi323_poll(dev);
+		if (ret) {
+			LOG_ERR("BMI323 poll failed after S2RAM STOP (err %d)", ret);
+		}
+	} else {
+		LOG_INF("Skipping PM_STATE_SUSPEND_TO_RAM (MRAM boot)");
+	}
+#endif /* CONFIG_RTSS_HE */
+
+	/* PM_STATE_SOFT_OFF (deepest sleep with wake capability) */
+#if defined(CONFIG_RTSS_HP)
+	/* HP core: always SOFT_OFF */
+	LOG_INF("Enter PM_STATE_SOFT_OFF for (%d microseconds)", SOFT_OFF_SLEEP_USEC);
+	LOG_INF("Note: SOFT_OFF has no retention - system will reset on wakeup");
+
+	ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+	__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+	/* Should never reach here - SOFT_OFF causes full reset on wakeup */
+	LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+	__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+
+#elif defined(CONFIG_RTSS_HE)
+	/* HE core: only SOFT_OFF when booting from MRAM */
+	if (SOFT_OFF_SUPPORTED) {
+		LOG_INF("Enter PM_STATE_SOFT_OFF for (%d microseconds)", SOFT_OFF_SLEEP_USEC);
+		LOG_INF("Note: SOFT_OFF has no retention - system will reset on wakeup");
+		ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+		/* Should never reach here - SOFT_OFF causes full reset on wakeup */
+		LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+		__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+	} else {
+		LOG_INF("Skipping PM_STATE_SOFT_OFF (TCM boot, using retention instead)");
+	}
+#endif
+
+	LOG_INF("=== BMI323 PM TEST COMPLETED ===");
+
+	app_pm_lock_deeper_states(true);
+
+	while (true) {
+		k_sleep(K_SECONDS(1));
+	}
+#endif
+
+	return 0;
+}

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 7d93eb0f78df992035eaa1ac2d077a86fbee9d34
+      revision: 010e9c74bf952dec0c833586eadc599f1d1baf9c
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Walk Alif PM states (RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM or SOFT_OFF) and poll the on-board BMI323 over I3C after each wake.

RTC/EWIC is the wake source; the sensor INT pin is not LPGPIO.

Suspend the sensor from the application thread before S2RAM so idle does not issue I3C transfers. After STANDBY/STOP, resume at the existing DTS dynamic address.

This PR points to alifsemi/zephyr_alif#592