### PR TITLE
samples: display: add parallel-display and serial-display snippets

### DIFF
--- a/samples/drivers/display/README.rst
+++ b/samples/drivers/display/README.rst
@@ -24,6 +24,7 @@ To build the display application for a parallel display, use:
    :zephyr-app: ../alif/samples/drivers/display/
    :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
    :goals: build
+   :snippets: parallel-display
 
 To build the display application for ILI9806E (2-lane) serial display:
 
@@ -31,7 +32,7 @@ To build the display application for ILI9806E (2-lane) serial display:
    :zephyr-app: ../alif/samples/drivers/display/
    :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
    :goals: build
-   :gen-args: -DDTC_OVERLAY_FILE="boards/serial_display_2lane.overlay" -DOVERLAY_CONFIG="boards/serial_display.conf"
+   :snippets: serial-display-2lane
 
 To build the display application for ILI9488 (1-lane) serial display:
 
@@ -39,7 +40,7 @@ To build the display application for ILI9488 (1-lane) serial display:
    :zephyr-app: ../alif/samples/drivers/display/
    :board: alif_e1c_dk/ae1c1f4051920hh/rtss_he
    :goals: build
-   :gen-args: -DDTC_OVERLAY_FILE="boards/serial_display_1lane.overlay" -DOVERLAY_CONFIG="boards/serial_display.conf"
+   :snippets: serial-display-1lane
 
 Sample Output
 *************

--- a/samples/drivers/display/boards/alif_e1c_dk_ae1c1f4051920hh_rtss_he.conf
+++ b/samples/drivers/display/boards/alif_e1c_dk_ae1c1f4051920hh_rtss_he.conf
@@ -1,9 +1,0 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
-# Use, distribution and modification of this code is permitted under the
-# terms stated in the Alif Semiconductor Software License Agreement
-#
-# You should have received a copy of the Alif Semiconductor Software
-# License Agreement with this file. If not, please write to:
-# contact@alifsemi.com, or visit: https://alifsemi.com/license
-
-CONFIG_FB_USES_DTCM_REGION=y

--- a/samples/drivers/display/snippets/parallel-display/alif_b1_e1c.conf
+++ b/samples/drivers/display/snippets/parallel-display/alif_b1_e1c.conf
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,4 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_HEAP_MEM_POOL_SIZE=81920
+CONFIG_FB_USES_DTCM_REGION=y

--- a/samples/drivers/display/snippets/parallel-display/alif_b1_e1c.overlay
+++ b/samples/drivers/display/snippets/parallel-display/alif_b1_e1c.overlay
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
  * Use, distribution and modification of this code is permitted under the
  * terms stated in the Alif Semiconductor Software License Agreement
  *
@@ -10,19 +10,26 @@
 
 / {
 	chosen {
-		zephyr,console = &lpuart;
-		zephyr,shell-uart = &lpuart;
+		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
+	};
+};
+
+&pinctrl_uart2 {
+	group0 {
+		pinmux = <PIN_P8_4__UART2_RX_C>,
+			 <PIN_P8_5__UART2_TX_C>;
 	};
 };
 
 &uart2 {
-	status = "disabled";
-};
-
-&lpuart {
 	status = "okay";
 };
 
 ns: &ns {
+	status = "okay";
+};
+
+gpio8: &gpio8 {
 	status = "okay";
 };

--- a/samples/drivers/display/snippets/parallel-display/parallel_display.conf
+++ b/samples/drivers/display/snippets/parallel-display/parallel_display.conf
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,4 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_MIPI_DSI=y
+CONFIG_HEAP_MEM_POOL_SIZE=81920

--- a/samples/drivers/display/snippets/parallel-display/snippet.yml
+++ b/samples/drivers/display/snippets/parallel-display/snippet.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,14 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_FB_USES_DTCM_REGION=y
+name: parallel-display
+
+boards:
+  /alif_(e7|e8)_dk/.*/rtss_(hp|he)/:
+    append:
+      EXTRA_CONF_FILE: parallel_display.conf
+
+  /alif_(b1|e1c)_dk/.*/rtss_he/:
+    append:
+      EXTRA_CONF_FILE: alif_b1_e1c.conf
+      EXTRA_DTC_OVERLAY_FILE: alif_b1_e1c.overlay

--- a/samples/drivers/display/snippets/serial-display-1lane/alif_b1_e1c.conf
+++ b/samples/drivers/display/snippets/serial-display-1lane/alif_b1_e1c.conf
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,4 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_HEAP_MEM_POOL_SIZE=81920
+CONFIG_FB_USES_DTCM_REGION=y

--- a/samples/drivers/display/snippets/serial-display-1lane/alif_b1_e1c.overlay
+++ b/samples/drivers/display/snippets/serial-display-1lane/alif_b1_e1c.overlay
@@ -1,4 +1,4 @@
-/* Copyright (C) Alif Semiconductor - All Rights Reserved.
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
  * Use, distribution and modification of this code is permitted under the
  * terms stated in the Alif Semiconductor Software License Agreement
  *

--- a/samples/drivers/display/snippets/serial-display-1lane/serial_display_1lane.conf
+++ b/samples/drivers/display/snippets/serial-display-1lane/serial_display_1lane.conf
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,4 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_HEAP_MEM_POOL_SIZE=81920
+CONFIG_MIPI_DSI=y

--- a/samples/drivers/display/snippets/serial-display-1lane/serial_display_1lane.overlay
+++ b/samples/drivers/display/snippets/serial-display-1lane/serial_display_1lane.overlay
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
  * Use, distribution and modification of this code is permitted under the
  * terms stated in the Alif Semiconductor Software License Agreement
  *
@@ -13,27 +13,31 @@
 / {
 	soc {
 		cdc200: cdc200@49031000 {
-			width = <480>;
-			height = <800>;
-			hfront-porch = <5>;
-			hback-porch = <5>;
-			hsync-len = <4>;
-			vfront-porch = <10>;
-			vback-porch = <10>;
+			width = <320>;
+			hfront-porch = <46>;
+			hback-porch = <16>;
+			hsync-len = <14>;
+
+			height = <480>;
+			vfront-porch = <2>;
+			vback-porch = <2>;
 			vsync-len = <2>;
-			clock-frequency = <24364080>;
+
 			hsync-active = <0>;
 			vsync-active = <0>;
-			de-active = <1>;
-			pixelclk-active = <0>;
+			de-active = <0>;
+			pixelclk-active = <1>;
+
+			clock-frequency = <11547360>;
+
 			bg-color = <0>;
 			enable-l1 = <1>;
-			pixel-fmt-l1 = "rgb-888";
+			pixel-fmt-l1 = "rgb-565";
 			def-back-color-l1 = <0>;
 			win-x0-l1 = <0>;
 			win-y0-l1 = <0>;
-			win-x1-l1 = <480>;
-			win-y1-l1 = <800>;
+			win-x1-l1 = <320>;
+			win-y1-l1 = <480>;
 			blend-factor1-l1 = <4>;
 			blend-factor2-l1 = <5>;
 			const-alpha-l1 = <0xff>;
@@ -51,10 +55,13 @@
 };
 
 &mipi_dsi {
+	//dpi-video-pattern-gen = "vertical-color-bar";
+	//dpi-video-pattern-gen = "horizontal-color-bar";
+	//dpi-video-pattern-gen = "vertical-bit-error-rate";
 	status = "okay";
 };
 
-&gpio14 {
+&ili9488 {
 	status = "okay";
 };
 

--- a/samples/drivers/display/snippets/serial-display-1lane/snippet.yml
+++ b/samples/drivers/display/snippets/serial-display-1lane/snippet.yml
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+name: serial-display-1lane
+
+boards:
+  # Snippet append values are a single file each; a second matching
+  # regex applies the 1-lane pair after the shared Spark pair.
+  /alif_(b1|e1c)_dk/.*/rtss_he/:
+    append:
+      EXTRA_CONF_FILE: alif_b1_e1c.conf
+      EXTRA_DTC_OVERLAY_FILE: alif_b1_e1c.overlay
+  /alif_b1_dk/.*/rtss_he/:
+    append:
+      EXTRA_CONF_FILE: serial_display_1lane.conf
+      EXTRA_DTC_OVERLAY_FILE: serial_display_1lane.overlay
+  /alif_e1c_dk/.*/rtss_he/:
+    append:
+      EXTRA_CONF_FILE: serial_display_1lane.conf
+      EXTRA_DTC_OVERLAY_FILE: serial_display_1lane.overlay

--- a/samples/drivers/display/snippets/serial-display-2lane/serial_display_2lane.conf
+++ b/samples/drivers/display/snippets/serial-display-2lane/serial_display_2lane.conf
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,5 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_FB_USES_DTCM_REGION=y
+CONFIG_MIPI_DSI=y
+CONFIG_HEAP_MEM_POOL_SIZE=81920

--- a/samples/drivers/display/snippets/serial-display-2lane/serial_display_2lane.overlay
+++ b/samples/drivers/display/snippets/serial-display-2lane/serial_display_2lane.overlay
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
  * Use, distribution and modification of this code is permitted under the
  * terms stated in the Alif Semiconductor Software License Agreement
  *
@@ -13,31 +13,27 @@
 / {
 	soc {
 		cdc200: cdc200@49031000 {
-			width = <320>;
-			hfront-porch = <46>;
-			hback-porch = <16>;
-			hsync-len = <14>;
-
-			height = <480>;
-			vfront-porch = <2>;
-			vback-porch = <2>;
+			width = <480>;
+			height = <800>;
+			hfront-porch = <5>;
+			hback-porch = <5>;
+			hsync-len = <4>;
+			vfront-porch = <10>;
+			vback-porch = <10>;
 			vsync-len = <2>;
-
+			clock-frequency = <24364080>;
 			hsync-active = <0>;
 			vsync-active = <0>;
-			de-active = <0>;
-			pixelclk-active = <1>;
-
-			clock-frequency = <11547360>;
-
+			de-active = <1>;
+			pixelclk-active = <0>;
 			bg-color = <0>;
 			enable-l1 = <1>;
-			pixel-fmt-l1 = "rgb-565";
+			pixel-fmt-l1 = "rgb-888";
 			def-back-color-l1 = <0>;
 			win-x0-l1 = <0>;
 			win-y0-l1 = <0>;
-			win-x1-l1 = <320>;
-			win-y1-l1 = <480>;
+			win-x1-l1 = <480>;
+			win-y1-l1 = <800>;
 			blend-factor1-l1 = <4>;
 			blend-factor2-l1 = <5>;
 			const-alpha-l1 = <0xff>;
@@ -55,21 +51,10 @@
 };
 
 &mipi_dsi {
-	//dpi-video-pattern-gen = "vertical-color-bar";
-	//dpi-video-pattern-gen = "horizontal-color-bar";
-	//dpi-video-pattern-gen = "vertical-bit-error-rate";
 	status = "okay";
 };
 
-&ili9488 {
-	status = "okay";
-};
-
-ns: &ns {
-	status = "okay";
-};
-
-&gpio8 {
+&gpio14 {
 	status = "okay";
 };
 

--- a/samples/drivers/display/snippets/serial-display-2lane/snippet.yml
+++ b/samples/drivers/display/snippets/serial-display-2lane/snippet.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Alif Semiconductor - All Rights Reserved.
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
 # Use, distribution and modification of this code is permitted under the
 # terms stated in the Alif Semiconductor Software License Agreement
 #
@@ -6,4 +6,10 @@
 # License Agreement with this file. If not, please write to:
 # contact@alifsemi.com, or visit: https://alifsemi.com/license
 
-CONFIG_HEAP_MEM_POOL_SIZE=81920
+name: serial-display-2lane
+
+boards:
+  /alif_(e7|e8)_(dk|ak)/.*/rtss_(hp|he)/:
+    append:
+      EXTRA_CONF_FILE: serial_display_2lane.conf
+      EXTRA_DTC_OVERLAY_FILE: serial_display_2lane.overlay


### PR DESCRIPTION
Move board-specific heap, DTCM, and MIPI overlays out of boards/ so E7/E8 and B1/E1C are selected with -S instead of per-board confs.