### PR TITLE
boards: alif: b1_eb: add ADC and LPPDM sleep pinctrl

### DIFF
--- a/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
+++ b/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
@@ -275,6 +275,18 @@
 		};
 	};
 
+	pinctrl_adc0_sleep:pinctrl_adc0_sleep {
+		group0 {
+			pinmux = <PIN_P0_0__GPIO>,
+			<PIN_P0_1__GPIO>,
+			<PIN_P0_2__GPIO>,
+			<PIN_P0_3__GPIO>,
+			<PIN_P0_4__GPIO>,
+			<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_adc1:pinctrl_adc1 {
 		group0 {
 			pinmux = <PIN_P0_6__ANA_S6>,
@@ -283,6 +295,18 @@
 			<PIN_P2_5__ANA_S13>,
 			<PIN_P2_6__ANA_S14>,
 			<PIN_P2_7__ANA_S15>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_adc1_sleep:pinctrl_adc1_sleep {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+			<PIN_P0_7__GPIO>,
+			<PIN_P2_4__GPIO>,
+			<PIN_P2_5__GPIO>,
+			<PIN_P2_6__GPIO>,
+			<PIN_P2_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};
@@ -342,6 +366,20 @@
 				 <PIN_P5_7__LPPDM_D1_C>,
 				 <PIN_P7_5__LPPDM_D2_C>,
 				 <PIN_P7_7__LPPDM_D3_C>;
+			read-enable = <0x1>;
+		};
+	};
+
+	pinctrl_lppdm_sleep: pinctrl_lppdm_sleep {
+		group0 {
+			pinmux = <PIN_P5_4__GPIO>,
+				 <PIN_P5_5__GPIO>,
+				 <PIN_P7_4__GPIO>,
+				 <PIN_P7_6__GPIO>,
+				 <PIN_P5_6__GPIO>,
+				 <PIN_P5_7__GPIO>,
+				 <PIN_P7_5__GPIO>,
+				 <PIN_P7_7__GPIO>;
 			read-enable = <0x1>;
 		};
 	};


### PR DESCRIPTION
Define ADC0, ADC1, and LPPDM sleep pinctrl on the Balletto B1 evaluation board