### PR TITLE
manifest: Fixed Broken 15.4 build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: eb4f4ceb4fc8b5da225da85a640d380f68dd9be4
+      revision: b43923555d01135092b85fcf8b75296b941aef16
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Fixed zephyr 15.4 build problem.

Depends on: https://github.com/alifsemi/zephyr_alif/pull/641