### PR TITLE
manifest: Update the zephyr revision for DW I2S DMA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 118ac41d80ca43f48c60f7fe3f81ba1324be152b
+      revision: 3b5625f70273dbb684fa28e5ab3f5d7a534db4ee
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update the zephyr revision for Designware I2S DMA support

zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/642/changes