### PR TITLE
tests: drivers: display: add MIPI-DSI coverage for display_test suite

### DIFF
--- a/tests/drivers/display/README.rst
+++ b/tests/drivers/display/README.rst
@@ -7,9 +7,10 @@ Overview
 ********
 
 ZTest suite for the Alif CDC200 display driver
-(``alif,cdc200``).
+(``tes,cdc-2.1``).
 
 Two test suites are provided:
+
 - **display_api**: Tests all display driver API functions (standard and CDC200-specific)
 - **display_functional**: Tests helper functions and functional behavior
 
@@ -18,13 +19,14 @@ covers basic capabilities reporting, framebuffer access, display writes,
 blanking control, orientation changes, and buffer management.
 
 Test Coverage
-************
+*************
 
 API Tests (display_api suite)
-******************************
+*****************************
 
 Standard Display API
 ====================
+
 #. Display blanking on/off control.
 #. Display read operations.
 #. Display pixel format setting.
@@ -32,11 +34,13 @@ Standard Display API
 #. Display contrast setting.
 #. Capabilities reporting (resolution, pixel formats, orientation).
 #. Display orientation changes (validates all 4 orientations).
-#. Basic display write operations.
+#. CDC200 layer write (``cdc200_display_write``) API success.
+#. Standard ``display_write()`` API success (MIPI DSI builds).
 #. Multiple rectangle write operations.
 
 CDC200-Specific API
 ===================
+
 #. Display enable/disable control.
 #. CDC200-specific capabilities (panel resolution, layer configuration).
 #. Framebuffer access for both layers.
@@ -45,26 +49,61 @@ CDC200-Specific API
 #. Default framebuffer restoration.
 
 Functional Tests (display_functional suite)
-********************************************
+*******************************************
+
 #. Framebuffer solid color sweep (red, blue, green, white, black).
 #. Framebuffer fill performance benchmark (word-based vs per-pixel memcpy).
 #. Framebuffer readback verification (write pattern, read back, verify match).
-#. Region clipping (negative coordinates, out-of-bounds, partial out-of-bounds).
-#. Display power cycle (disable/enable, test operations while disabled, verify recovery).
+#. Region clipping (out-of-bounds, partial out-of-bounds, valid write).
+#. Display power cycle (disable/enable, operations while disabled, recovery).
+#. Invalid layer index handling.
+#. Undersized buffer / NULL parameter checks (skipped until driver is fixed).
+#. Read cache coherency probe.
 
 Requirements
 ************
 
-* Alif Ensemble E8 Development/Application Kit (or any board exposing
-  the display node with compatible ``alif,cdc200``).
+* A board with a CDC200 node (``tes,cdc-2.1``). Panel interfaces:
+
+  - **Parallel RGB**: all targets (E7, E8, E1C, B1)
+  - **2-lane MIPI-DSI**: alif_e8_dk / alif_e7_dk
+  - **1-lane MIPI-DSI**: alif_e1c_dk / alif_b1_dk
 * Zephyr RTOS with display subsystem enabled.
 
 Building and Running
 ********************
 
+Parallel RGB (default, all targets):
+
 .. code-block:: console
 
    west build -b <board> <test_app_path>
+
+2-lane MIPI-DSI (ILI9806E / MW405 on E7/E8 DK):
+
+.. code-block:: console
+
+   west build -b <board> <test_app_path> -- \
+     -DDTC_OVERLAY_FILE="boards/serial_display_2lane.overlay" \
+     -DEXTRA_CONF_FILE="boards/serial_display.conf"
+
+1-lane MIPI-DSI (ILI9488 on E1C/B1 DK):
+
+.. code-block:: console
+
+   west build -b <board> <test_app_path> -- \
+     -DDTC_OVERLAY_FILE="boards/serial_display_1lane.overlay" \
+     -DEXTRA_CONF_FILE="boards/serial_display.conf"
+
+Twister scenarios in ``testcase.yaml``:
+
+* ``drivers.display.cdc200`` — parallel RGB (all targets)
+* ``drivers.display.cdc200.mipi_2lane`` — 2-lane MIPI-DSI (E7/E8)
+* ``drivers.display.cdc200.mipi_1lane`` — 1-lane MIPI-DSI (E1C/B1)
+
+Timeout is 180 s to cover the visual ``k_msleep()`` delays. Optional
+``boards/overlay_bg*.overlay`` files are background-color experiments;
+they disable the layers and are not part of the default suite.
 
 Expected output
 ***************
@@ -78,6 +117,7 @@ Expected output
    PASS - display_api::test_display_get_capabilities
    PASS - display_api::test_display_orientation
    PASS - display_api::test_display_write
+   PASS - display_api::test_generic_display_write
    PASS - display_api::test_display_write_multiple_rects
    PASS - display_api::test_display_read
    PASS - display_api::test_display_set_pixel_format
@@ -91,12 +131,20 @@ Expected output
    PASS - display_functional::test_display_fb_solid_sweep
    PASS - display_functional::test_display_power_cycle
    PASS - display_functional::test_display_region_clipping
+   PASS - display_functional::test_display_invalid_layer
+   SKIP - display_functional::test_display_undersized_buffer
+   SKIP - display_functional::test_display_null_params
+   PASS - display_functional::test_display_read_cache_coherency
+
+``test_generic_display_write`` is skipped when ``CONFIG_MIPI_DSI`` is not
+enabled. ``test_display_undersized_buffer`` and ``test_display_null_params``
+are skipped until the driver adds the corresponding validation.
 
 Test Details
 ************
 
 API Tests
-========
+=========
 
 test_display_blanking
   Validates display blanking on/off control for power management.
@@ -122,12 +170,19 @@ test_display_orientation
   hardware does not support orientation changes.
 
 test_display_write
-  Performs a basic display write operation to test the rendering
-  pipeline.
+  Calls ``cdc200_display_write()`` for one full-width row and asserts
+  that the call succeeds. This is an API success check, not a visual
+  full-screen fill. Colors are packed for the active pixel format.
+
+test_generic_display_write
+  Calls the standard Zephyr ``display_write()`` API for one full-width
+  row and asserts success. Runs when MIPI DSI is enabled; skipped
+  otherwise.
 
 test_display_write_multiple_rects
   Tests writing multiple colored rectangles to different positions on
-  the display to verify coordinate handling.
+  the display to verify coordinate handling. Rectangle colors are packed
+  for the active pixel format (ARGB8888 / RGB888 / RGB565).
 
 test_display_cdc200_enable
   Tests display enable/disable functionality through the CDC200-specific
@@ -151,7 +206,7 @@ test_restore_fb
   Tests restoring default framebuffers for all layers.
 
 Functional Tests
-=================
+================
 
 test_display_fb_fill_benchmark
   Benchmarks framebuffer fill performance by comparing word-based fill
@@ -170,8 +225,10 @@ test_display_fb_readback_verify
 
 test_display_fb_solid_sweep
   Tests framebuffer solid color sweep (red, blue, green, white, black)
-  with 3-second delays for visual observation. The write method can be
-  selected via the DISPLAY_FB_WRITE_METHOD macro:
+  with 3-second delays for visual observation. Colors are packed for the
+  active pixel format. The write method can be selected via the
+  DISPLAY_FB_WRITE_METHOD macro:
+
   - DISPLAY_FB_WRITE_DIRECT (default): Uses cdc200_get_framebuffer()
     and word-based fill for direct memory access
   - DISPLAY_FB_WRITE_API: Uses cdc200_display_write() API with 10-row
@@ -183,15 +240,33 @@ test_display_power_cycle
   attempting write and read operations while disabled (to verify robustness),
   re-enabling the display, waiting for power up, and verifying functionality by
   clearing the display to white. This test ensures the display driver correctly
-  handles power state transitions, rejects operations gracefully when disabled,
-  and recovers functionality after a power cycle.
+  handles power state transitions and recovers functionality after a power cycle.
 
 test_display_region_clipping
   Tests region clipping behavior by attempting writes with various invalid
   coordinates:
-  - Negative coordinates (-10, -10)
+
+  - Negative coordinates (-10, -10) — skipped (known driver fault, waiting
+    for a fix)
   - Coordinates beyond display resolution
   - Partial out-of-bounds rectangles (rectangle extends beyond edge)
   - Valid write at (100, 100) as control
-  The test validates that the driver either rejects invalid coordinates or
-  clips them appropriately, while valid writes succeed.
+
+  Out-of-bounds cases currently log the driver return value. A valid write
+  must succeed.
+
+test_display_invalid_layer
+  Passes invalid layer indices (2, 5, 255) to CDC200 APIs and expects
+  ``-EINVAL`` from write/read, and no output modification from void APIs.
+
+test_display_undersized_buffer
+  Skipped until the driver validates ``desc->buf_size`` against
+  width * height * pixel size.
+
+test_display_null_params
+  Skipped until the driver rejects NULL ``desc`` / ``buf`` with ``-EINVAL``.
+
+test_display_read_cache_coherency
+  Writes a pattern directly into the framebuffer (no cache flush) and
+  reads it back via ``cdc200_display_read()``. Documents cache behavior
+  on the read path.

--- a/tests/drivers/display/boards/serial_display.conf
+++ b/tests/drivers/display/boards/serial_display.conf
@@ -1,0 +1,1 @@
+CONFIG_MIPI_DSI=y

--- a/tests/drivers/display/boards/serial_display_1lane.overlay
+++ b/tests/drivers/display/boards/serial_display_1lane.overlay
@@ -1,0 +1,74 @@
+#include <dt-bindings/misc/alif_aipm_common.h>
+
+/ {
+	soc {
+		cdc200: cdc200@49031000 {
+			width = <320>;
+			hfront-porch = <46>;
+			hback-porch = <16>;
+			hsync-len = <14>;
+
+			height = <480>;
+			vfront-porch = <2>;
+			vback-porch = <2>;
+			vsync-len = <2>;
+
+			hsync-active = <0>;
+			vsync-active = <0>;
+			de-active = <0>;
+			pixelclk-active = <1>;
+
+			clock-frequency = <11547360>;
+
+			bg-color = <0>;
+			enable-l1 = <1>;
+			pixel-fmt-l1 = "rgb-565";
+			def-back-color-l1 = <0>;
+			win-x0-l1 = <0>;
+			win-y0-l1 = <0>;
+			win-x1-l1 = <320>;
+			win-y1-l1 = <480>;
+			blend-factor1-l1 = <4>;
+			blend-factor2-l1 = <5>;
+			const-alpha-l1 = <0xff>;
+			enable-l2 = <0>;
+			pixel-fmt-l2 = "undefined";
+			win-x0-l2 = <0>;
+			win-y0-l2 = <0>;
+			win-x1-l2 = <0>;
+			win-y1-l2 = <0>;
+			blend-factor1-l2 = <6>;
+			blend-factor2-l2 = <7>;
+			const-alpha-l2 = <0xff>;
+		};
+	};
+};
+
+&mipi_dsi {
+	//dpi-video-pattern-gen = "vertical-color-bar";
+	//dpi-video-pattern-gen = "horizontal-color-bar";
+	//dpi-video-pattern-gen = "vertical-bit-error-rate";
+	status = "okay";
+};
+
+&ili9488 {
+	status = "okay";
+};
+
+ns: &ns {
+	status = "okay";
+};
+
+&gpio8 {
+	status = "okay";
+};
+
+&aipm_run_default {
+	phy-pwr-gating = <(ALIF_PHY_GATE_LDO_MASK |
+			ALIF_PHY_GATE_MIPI_TX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_RX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_PLL_DPHY_MASK)>;
+	ip-clock-gating = <(ALIF_IP_CLK_GATE_CDC200_MASK |
+			ALIF_IP_CLK_GATE_MIPI_DSI_MASK |
+			ALIF_IP_CLK_GATE_GPU_MASK)>;
+};

--- a/tests/drivers/display/boards/serial_display_2lane.overlay
+++ b/tests/drivers/display/boards/serial_display_2lane.overlay
@@ -1,0 +1,59 @@
+#include <dt-bindings/misc/alif_aipm_common.h>
+
+/ {
+	soc {
+		cdc200: cdc200@49031000 {
+			width = <480>;
+			height = <800>;
+			hfront-porch = <5>;
+			hback-porch = <5>;
+			hsync-len = <4>;
+			vfront-porch = <10>;
+			vback-porch = <10>;
+			vsync-len = <2>;
+			clock-frequency = <24364080>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			de-active = <1>;
+			pixelclk-active = <0>;
+			bg-color = <0>;
+			enable-l1 = <1>;
+			pixel-fmt-l1 = "rgb-888";
+			def-back-color-l1 = <0>;
+			win-x0-l1 = <0>;
+			win-y0-l1 = <0>;
+			win-x1-l1 = <480>;
+			win-y1-l1 = <800>;
+			blend-factor1-l1 = <4>;
+			blend-factor2-l1 = <5>;
+			const-alpha-l1 = <0xff>;
+			enable-l2 = <0>;
+			pixel-fmt-l2 = "undefined";
+			win-x0-l2 = <0>;
+			win-y0-l2 = <0>;
+			win-x1-l2 = <0>;
+			win-y1-l2 = <0>;
+			blend-factor1-l2 = <6>;
+			blend-factor2-l2 = <7>;
+			const-alpha-l2 = <0xff>;
+		};
+	};
+};
+
+&mipi_dsi {
+	status = "okay";
+};
+
+&gpio14 {
+	status = "okay";
+};
+
+&aipm_run_default {
+	phy-pwr-gating = <(ALIF_PHY_GATE_LDO_MASK |
+			ALIF_PHY_GATE_MIPI_TX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_RX_DPHY_MASK |
+			ALIF_PHY_GATE_MIPI_PLL_DPHY_MASK)>;
+	ip-clock-gating = <(ALIF_IP_CLK_GATE_CDC200_MASK |
+			ALIF_IP_CLK_GATE_MIPI_DSI_MASK |
+			ALIF_IP_CLK_GATE_GPU_MASK)>;
+};

--- a/tests/drivers/display/src/display_common.c
+++ b/tests/drivers/display/src/display_common.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <zephyr/cache.h>
 #include "display_common.h"
 
 const struct device *display_dev;
@@ -20,9 +21,38 @@ void display_suite_before(void *fixture)
 	zassert_not_null(display_dev, "Display device handle is NULL");
 	zassert_true(device_is_ready(display_dev),
 		     "Display device %s not ready", display_dev->name);
-}
 
-void display_fb_fill_word(uint8_t *fb_addr, size_t fb_size,
+#ifdef CONFIG_MIPI_DSI
+	{
+		const struct device *panel = DEVICE_DT_GET(DT_ALIAS(panel));
+		const struct device *dsi = DEVICE_DT_GET(DT_ALIAS(mipi_dsi));
+		int ret;
+
+		zassert_true(device_is_ready(panel),
+			     "MIPI panel %s not ready "
+			     "(enable reset/backlight GPIOs in the overlay)",
+			     panel->name);
+		zassert_true(device_is_ready(dsi),
+			     "MIPI-DSI host %s not ready", dsi->name);
+
+		/*
+		 * Panel init runs in command mode. Video mode is what
+		 * streams the CDC200 framebuffer over the DSI link.
+		 * Without this the panel stays black.
+		 */
+		ret = dsi_dw_set_mode(dsi, DSI_DW_VIDEO_MODE);
+		zassert_equal(ret, 0,
+			      "dsi_dw_set_mode(VIDEO) failed: %d", ret);
+	}
+#endif
+
+	/*
+	 * CDC200 init only programs registers; scan-out starts here.
+	 * display_blanking_off() on CDC200 is a no-op (-ENOTSUP).
+	 */
+	cdc200_set_enable(display_dev, true);
+}
+void display_fb_fill_word_noflush(uint8_t *fb_addr, size_t fb_size,
 			  int pixel_size, uint32_t color)
 {
 	if (pixel_size == 2) {
@@ -49,7 +79,14 @@ void display_fb_fill_word(uint8_t *fb_addr, size_t fb_size,
 	}
 }
 
-void display_fb_fill_memcpy(uint8_t *fb_addr, size_t fb_size,
+void display_fb_fill_word(uint8_t *fb_addr, size_t fb_size,
+			  int pixel_size, uint32_t color)
+{
+	display_fb_fill_word_noflush(fb_addr, fb_size, pixel_size, color);
+	sys_cache_data_flush_range(fb_addr, fb_size);
+}
+
+void display_fb_fill_memcpy_noflush(uint8_t *fb_addr, size_t fb_size,
 			    int pixel_size, uint32_t color)
 {
 	size_t count = fb_size / pixel_size;
@@ -57,6 +94,13 @@ void display_fb_fill_memcpy(uint8_t *fb_addr, size_t fb_size,
 	for (size_t i = 0; i < count; i++) {
 		memcpy(fb_addr + (i * pixel_size), &color, pixel_size);
 	}
+}
+
+void display_fb_fill_memcpy(uint8_t *fb_addr, size_t fb_size,
+			    int pixel_size, uint32_t color)
+{
+	display_fb_fill_memcpy_noflush(fb_addr, fb_size, pixel_size, color);
+	sys_cache_data_flush_range(fb_addr, fb_size);
 }
 
 void display_clear_to_white(const struct device *dev)
@@ -82,20 +126,10 @@ void display_clear_to_white(const struct device *dev)
 
 	/* Get pixel size */
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
-
-	/* Determine white color based on pixel format */
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = WHITE_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = WHITE_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-	default:
-		color = WHITE_RGB565;
-		break;
-	}
+	zassert_true(pixel_size > 0, "Unsupported pixel format: %d",
+		     caps.layer[0].current_pixel_format);
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_WHITE);
 
 	/* Fill framebuffer with white */
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
@@ -112,6 +146,37 @@ int display_get_pixel_size(enum display_pixel_format fmt)
 		return CDC200_PIXEL_SIZE_RGB565;
 	default:
 		return 0;
+	}
+}
+
+uint32_t display_solid_color(enum display_pixel_format fmt,
+			     enum display_test_color color)
+{
+	static const uint32_t colors_argb8888[DISPLAY_COLOR_COUNT] = {
+		RED_ARGB8888, GREEN_ARGB8888, BLUE_ARGB8888,
+		WHITE_ARGB8888, BLACK_ARGB8888,
+	};
+	static const uint32_t colors_rgb888[DISPLAY_COLOR_COUNT] = {
+		RED_RGB888, GREEN_RGB888, BLUE_RGB888,
+		WHITE_RGB888, BLACK_RGB888,
+	};
+	static const uint32_t colors_rgb565[DISPLAY_COLOR_COUNT] = {
+		RED_RGB565, GREEN_RGB565, BLUE_RGB565,
+		WHITE_RGB565, BLACK_RGB565,
+	};
+
+	if (color >= DISPLAY_COLOR_COUNT) {
+		return 0;
+	}
+
+	switch (fmt) {
+	case PIXEL_FORMAT_ARGB_8888:
+		return colors_argb8888[color];
+	case PIXEL_FORMAT_RGB_888:
+		return colors_rgb888[color];
+	case PIXEL_FORMAT_RGB_565:
+	default:
+		return colors_rgb565[color];
 	}
 }
 
@@ -149,92 +214,12 @@ void display_fill_buffer_solid(uint8_t *buf, size_t buf_size,
 	}
 }
 
-void display_fill_buffer_gradient(uint8_t *buf, size_t buf_size,
-				   enum display_pixel_format fmt,
-				   size_t width, size_t height)
-{
-	int pixel_size = display_get_pixel_size(fmt);
-	size_t pixel_count = buf_size / pixel_size;
-
-	if (pixel_size == 0) {
-		return;
-	}
-
-	for (size_t idx = 0; idx < pixel_count; idx++) {
-		size_t x = idx % width;
-		size_t y = idx / width;
-		uint32_t color;
-
-		/* Create a gradient based on position */
-		uint8_t r = (uint8_t)((x * 255) / width);
-		uint8_t g = (uint8_t)((y * 255) / height);
-		uint8_t b = (uint8_t)(((x + y) * 255) / (width + height));
-
-		switch (fmt) {
-		case PIXEL_FORMAT_ARGB_8888:
-			color = (0xFF << 24) | (r << 16) | (g << 8) | b;
-			*((uint32_t *)(buf + idx * pixel_size)) = color;
-			break;
-		case PIXEL_FORMAT_RGB_888:
-			buf[idx * pixel_size + 0] = r;
-			buf[idx * pixel_size + 1] = g;
-			buf[idx * pixel_size + 2] = b;
-			break;
-		case PIXEL_FORMAT_RGB_565:
-			color = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
-			*(uint16_t *)(buf + idx * pixel_size) = (uint16_t)color;
-			break;
-		default:
-			break;
-		}
-	}
-}
-
-bool display_validate_buffer_color(const uint8_t *buf, size_t buf_size,
-				   enum display_pixel_format fmt,
-				   uint32_t expected_color)
-{
-	int pixel_size = display_get_pixel_size(fmt);
-
-	if (pixel_size == 0) {
-		return false;
-	}
-
-	switch (fmt) {
-	case PIXEL_FORMAT_ARGB_8888:
-		for (size_t idx = 0; idx < buf_size; idx += 4) {
-			if (*((uint32_t *)(buf + idx)) != expected_color) {
-				return false;
-			}
-		}
-		return true;
-	case PIXEL_FORMAT_RGB_888:
-		for (size_t idx = 0; idx < buf_size; idx += 3) {
-			uint32_t actual = ((uint32_t)buf[idx + 2] << 16) |
-					  ((uint32_t)buf[idx + 1] << 8) |
-					  (uint32_t)buf[idx + 0];
-			if (actual != expected_color) {
-				return false;
-			}
-		}
-		return true;
-	case PIXEL_FORMAT_RGB_565:
-		for (size_t idx = 0; idx < buf_size; idx += 2) {
-			uint16_t actual = ((uint16_t)buf[idx + 1] << 8) |
-					  (uint16_t)buf[idx + 0];
-			if (actual != (uint16_t)expected_color) {
-				return false;
-			}
-		}
-		return true;
-	default:
-		return false;
-	}
-}
-
 uint8_t *display_alloc_buffer(size_t size)
 {
-	return k_malloc(size);
+	uint8_t *buf = k_malloc(size);
+
+	zassert_not_null(buf, "Failed to allocate %zu byte buffer", size);
+	return buf;
 }
 
 void display_free_buffer(uint8_t *buf)

--- a/tests/drivers/display/src/display_common.h
+++ b/tests/drivers/display/src/display_common.h
@@ -14,9 +14,19 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/display/cdc200.h>
+#ifdef CONFIG_MIPI_DSI
+#include <zephyr/drivers/mipi_dsi/dsi_dw.h>
+#endif
 #include <zephyr/logging/log.h>
 #include <zephyr/ztest.h>
 #include <stdint.h>
+
+#include <soc_common.h>
+#include <zephyr/cache.h>
+
+#if defined(CONFIG_ENSEMBLE_GEN2)
+#include <zephyr/drivers/gpio.h>
+#endif
 
 #define DISPLAY_DEVICE_NODE	DT_CHOSEN(zephyr_display)
 
@@ -51,6 +61,16 @@
 #define CDC200_PIXEL_SIZE_RGB888	3
 #define CDC200_PIXEL_SIZE_RGB565	2
 
+/* Named colors for display_solid_color() */
+enum display_test_color {
+	DISPLAY_COLOR_RED = 0,
+	DISPLAY_COLOR_GREEN,
+	DISPLAY_COLOR_BLUE,
+	DISPLAY_COLOR_WHITE,
+	DISPLAY_COLOR_BLACK,
+	DISPLAY_COLOR_COUNT,
+};
+
 /* Shared device handle. */
 extern const struct device *display_dev;
 
@@ -60,22 +80,16 @@ void display_suite_before(void *fixture);
 /* Get pixel size in bytes for a given pixel format. */
 int display_get_pixel_size(enum display_pixel_format fmt);
 
+/* Packed solid color for the given pixel format. */
+uint32_t display_solid_color(enum display_pixel_format fmt,
+			     enum display_test_color color);
+
 /* Fill a buffer with a solid color for the given pixel format. */
 void display_fill_buffer_solid(uint8_t *buf, size_t buf_size,
 			       enum display_pixel_format fmt,
 			       uint32_t color);
 
-/* Fill a buffer with a color gradient pattern. */
-void display_fill_buffer_gradient(uint8_t *buf, size_t buf_size,
-				   enum display_pixel_format fmt,
-				   size_t width, size_t height);
-
-/* Validate that a buffer contains the expected color pattern. */
-bool display_validate_buffer_color(const uint8_t *buf, size_t buf_size,
-				   enum display_pixel_format fmt,
-				   uint32_t expected_color);
-
-/* Allocate a display buffer of the given size. */
+/* Allocate a display buffer of the given size. Asserts if allocation fails. */
 uint8_t *display_alloc_buffer(size_t size);
 
 /* Free a display buffer. */
@@ -86,6 +100,15 @@ const char *display_pixel_format_to_string(enum display_pixel_format fmt);
 
 /* Convert errno code to readable string. */
 const char *display_errno_to_string(int err);
+
+
+/* Fast word-based framebuffer fill with no flush. */
+void display_fb_fill_word_noflush(uint8_t *fb_addr, size_t fb_size,
+				  int pixel_size, uint32_t color);
+
+/* Per-pixel memcpy framebuffer fill with no flush. */
+void display_fb_fill_memcpy_noflush(uint8_t *fb_addr, size_t fb_size,
+				    int pixel_size, uint32_t color);
 
 /* Fast word-based framebuffer fill (more efficient than per-pixel memcpy). */
 void display_fb_fill_word(uint8_t *fb_addr, size_t fb_size,

--- a/tests/drivers/display/src/main.c
+++ b/tests/drivers/display/src/main.c
@@ -8,13 +8,14 @@
  */
 
 #include <string.h>
+#include <zephyr/sys/util.h>
 #include "display_common.h"
 
 LOG_MODULE_REGISTER(display_test, LOG_LEVEL_INF);
 
 /*
  * Test suites for the Alif CDC200 display driver
- * (compatible: alif,cdc200).
+ * (compatible: tes,cdc-2.1).
  *
  * Two test suites:
  * - display_api: Tests all display driver API functions
@@ -93,18 +94,8 @@ ZTEST(display_functional, test_display_fb_fill_benchmark)
 	zassert_not_null(fb_desc.fb_addr, "Layer 0 framebuffer address is NULL");
 
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
-
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = BLUE_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = BLUE_RGB888;
-		break;
-	default:
-		color = BLUE_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_BLUE);
 
 	TC_PRINT("\n=== Framebuffer Fill Benchmark ===\n");
 	TC_PRINT("Framebuffer size: %zu bytes\n", fb_desc.fb_size);
@@ -113,14 +104,14 @@ ZTEST(display_functional, test_display_fb_fill_benchmark)
 
 	/* Benchmark word-based fill */
 	start = k_cycle_get_32();
-	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
+	display_fb_fill_word_noflush(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 	end = k_cycle_get_32();
 	cycles_word = end - start;
 	ns_word = k_cyc_to_ns_floor64(cycles_word);
 
 	/* Benchmark per-pixel memcpy fill */
 	start = k_cycle_get_32();
-	display_fb_fill_memcpy(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
+	display_fb_fill_memcpy_noflush(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 	end = k_cycle_get_32();
 	cycles_memcpy = end - start;
 	ns_memcpy = k_cyc_to_ns_floor64(cycles_memcpy);
@@ -189,7 +180,6 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 	 */
 	buf_size = caps.layer[0].x_resolution * 10 * pixel_size; /* 10 rows */
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	TC_PRINT("Layer 0:\n");
 	TC_PRINT("  Resolution: %dx%d\n", caps.layer[0].x_resolution,
@@ -210,20 +200,8 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 
 	/* Fill with RED */
 	TC_PRINT("Filling framebuffer with RED\n");
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = RED_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = RED_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-		color = RED_RGB565;
-		break;
-	default:
-		color = RED_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_RED);
 #if DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_DIRECT
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 #elif DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_API
@@ -238,20 +216,8 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 
 	/* Fill with BLUE */
 	TC_PRINT("Filling framebuffer with BLUE\n");
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = BLUE_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = BLUE_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-		color = BLUE_RGB565;
-		break;
-	default:
-		color = BLUE_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_BLUE);
 #if DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_DIRECT
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 #elif DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_API
@@ -266,20 +232,8 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 
 	/* Fill with GREEN */
 	TC_PRINT("Filling framebuffer with GREEN\n");
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = GREEN_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = GREEN_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-		color = GREEN_RGB565;
-		break;
-	default:
-		color = GREEN_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_GREEN);
 #if DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_DIRECT
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 #elif DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_API
@@ -294,20 +248,8 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 
 	/* Fill with WHITE */
 	TC_PRINT("Filling framebuffer with WHITE\n");
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = WHITE_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = WHITE_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-		color = WHITE_RGB565;
-		break;
-	default:
-		color = WHITE_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_WHITE);
 #if DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_DIRECT
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 #elif DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_API
@@ -322,20 +264,8 @@ ZTEST(display_functional, test_display_fb_solid_sweep)
 
 	/* Fill with BLACK */
 	TC_PRINT("Filling framebuffer with BLACK\n");
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color = BLACK_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color = BLACK_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-		color = BLACK_RGB565;
-		break;
-	default:
-		color = BLACK_RGB565;
-		break;
-	}
+	color = display_solid_color(caps.layer[0].current_pixel_format,
+				    DISPLAY_COLOR_BLACK);
 #if DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_DIRECT
 	display_fb_fill_word(fb_desc.fb_addr, fb_desc.fb_size, pixel_size, color);
 #elif DISPLAY_FB_WRITE_METHOD == DISPLAY_FB_WRITE_API
@@ -406,22 +336,10 @@ ZTEST(display_functional, test_display_fb_readback_verify)
 	buf_desc.width = rect_w;
 	buf_desc.height = rect_h;
 
-	/* Determine colors based on pixel format */
-	switch (caps.layer[0].current_pixel_format) {
-	case PIXEL_FORMAT_ARGB_8888:
-		color1 = RED_ARGB8888;
-		color2 = BLUE_ARGB8888;
-		break;
-	case PIXEL_FORMAT_RGB_888:
-		color1 = RED_RGB888;
-		color2 = BLUE_RGB888;
-		break;
-	case PIXEL_FORMAT_RGB_565:
-	default:
-		color1 = RED_RGB565;
-		color2 = BLUE_RGB565;
-		break;
-	}
+	color1 = display_solid_color(caps.layer[0].current_pixel_format,
+				     DISPLAY_COLOR_RED);
+	color2 = display_solid_color(caps.layer[0].current_pixel_format,
+				     DISPLAY_COLOR_BLUE);
 
 	/* ===== Pattern 1: Checkerboard color pattern ===== */
 	TC_PRINT("\n--- Pattern 1: Checkerboard (color1/color2) ---\n");
@@ -526,7 +444,6 @@ ZTEST(display_functional, test_display_region_clipping)
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
 	buf_size = rect_w * rect_h * pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
@@ -537,7 +454,8 @@ ZTEST(display_functional, test_display_region_clipping)
 	/* Fill buffer with red */
 	display_fill_buffer_solid(buf, buf_size,
 				  caps.layer[0].current_pixel_format,
-				  RED_RGB565);
+				  display_solid_color(caps.layer[0].current_pixel_format,
+						     DISPLAY_COLOR_RED));
 
 	/* Test 1: Negative coordinates (-10, -10) - disabled (known driver fault) */
 	TC_PRINT("\nTest 1: Negative coordinates (-10, -10) - skipped\n");
@@ -609,7 +527,6 @@ ZTEST(display_functional, test_display_power_cycle)
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
 	buf_size = rect_w * rect_h * pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
@@ -620,7 +537,8 @@ ZTEST(display_functional, test_display_power_cycle)
 	/* Fill buffer with red */
 	display_fill_buffer_solid(buf, buf_size,
 				  caps.layer[0].current_pixel_format,
-				  RED_RGB565);
+				  display_solid_color(caps.layer[0].current_pixel_format,
+						     DISPLAY_COLOR_RED));
 
 	/* Clear display to white for visual observation
 	 * TC_PRINT("Clearing display to white for visual observation...\n");
@@ -712,7 +630,6 @@ ZTEST(display_functional, test_display_invalid_layer)
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
 	buf_size = rect_w * rect_h * pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	buf_desc.buf_size = buf_size;
 	buf_desc.pitch = rect_w;
@@ -721,7 +638,8 @@ ZTEST(display_functional, test_display_invalid_layer)
 
 	display_fill_buffer_solid(buf, buf_size,
 				  caps.layer[0].current_pixel_format,
-				  RED_RGB565);
+				  display_solid_color(caps.layer[0].current_pixel_format,
+						     DISPLAY_COLOR_RED));
 
 	for (size_t i = 0; i < ARRAY_SIZE(invalid_indices); i++) {
 		uint8_t idx = invalid_indices[i];
@@ -802,7 +720,6 @@ ZTEST(display_functional, test_display_undersized_buffer)
 	ztest_test_skip();
 
 	buf = display_alloc_buffer(small_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 	memset(buf, 0xAB, small_size);
 
 	/* Buffer descriptor claims large size, but actual buf is tiny */
@@ -864,7 +781,6 @@ ZTEST(display_functional, test_display_null_params)
 	pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
 	buf_size = rect_w * rect_h * pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	buf_desc.buf_size = buf_size;
 	buf_desc.pitch = rect_w;
@@ -1203,10 +1119,11 @@ ZTEST(display_api, test_display_write)
 {
 	struct display_buffer_descriptor buf_desc;
 	struct cdc200_display_caps caps;
+	enum display_pixel_format fmt;
 	uint8_t *buf;
 	size_t buf_size;
+	int pixel_size;
 
-	/* Get capabilities to determine buffer size */
 	cdc200_get_capabilities(display_dev, &caps);
 
 	if (!caps.layer[0].layer_en) {
@@ -1214,33 +1131,72 @@ ZTEST(display_api, test_display_write)
 		ztest_test_skip();
 	}
 
-	/* Allocate a small buffer for testing (one full row) */
-	int pixel_size = display_get_pixel_size(caps.layer[0].current_pixel_format);
+	fmt = caps.layer[0].current_pixel_format;
+	pixel_size = display_get_pixel_size(fmt);
+	zassert_true(pixel_size > 0, "Unsupported pixel format: %d", fmt);
 
-	zassert_true(pixel_size > 0, "Unsupported pixel format: %d",
-			caps.layer[0].current_pixel_format);
 	buf_size = caps.layer[0].x_resolution * (size_t)pixel_size;
 	buf = display_alloc_buffer(buf_size);
 
-	/* Fill buffer with red */
 	TC_PRINT("Using pixel format: %s\n",
-		 display_pixel_format_to_string(caps.layer[0].current_pixel_format));
-	display_fill_buffer_solid(buf, buf_size,
-				  caps.layer[0].current_pixel_format,
-				  RED_ARGB8888);
+		 display_pixel_format_to_string(fmt));
+	display_fill_buffer_solid(buf, buf_size, fmt,
+				  display_solid_color(fmt, DISPLAY_COLOR_RED));
 
-	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
 	buf_desc.pitch = caps.layer[0].x_resolution;
 	buf_desc.width = caps.layer[0].x_resolution;
 	buf_desc.height = 1;
 
-	/* Write to display at position (0, 0) */
 	zassert_equal(cdc200_display_write(display_dev, 0, 0, 0, &buf_desc, buf), 0,
 		      "cdc200_display_write failed");
 
-	/* Delay for visual observation */
-	k_msleep(5000);
+	display_free_buffer(buf);
+}
+
+ZTEST(display_api, test_generic_display_write)
+{
+	struct display_buffer_descriptor buf_desc;
+	struct cdc200_display_caps caps;
+	enum display_pixel_format fmt;
+	uint8_t *buf;
+	size_t buf_size;
+	int pixel_size;
+	int ret;
+
+	if (!IS_ENABLED(CONFIG_MIPI_DSI)) {
+		TC_PRINT("MIPI DSI not enabled, skipping display_write() test\n");
+		ztest_test_skip();
+	}
+
+	cdc200_get_capabilities(display_dev, &caps);
+
+	if (!caps.layer[0].layer_en) {
+		TC_PRINT("Layer 0 not enabled, skipping display_write() test\n");
+		ztest_test_skip();
+	}
+
+	fmt = caps.layer[0].current_pixel_format;
+	pixel_size = display_get_pixel_size(fmt);
+	zassert_true(pixel_size > 0, "Unsupported pixel format: %d", fmt);
+
+	buf_size = caps.layer[0].x_resolution * (size_t)pixel_size;
+	buf = display_alloc_buffer(buf_size);
+
+	TC_PRINT("Using pixel format: %s\n",
+		 display_pixel_format_to_string(fmt));
+	display_fill_buffer_solid(buf, buf_size, fmt,
+				  display_solid_color(fmt, DISPLAY_COLOR_RED));
+
+	buf_desc.buf_size = buf_size;
+	buf_desc.pitch = caps.layer[0].x_resolution;
+	buf_desc.width = caps.layer[0].x_resolution;
+	buf_desc.height = 1;
+
+	ret = display_write(display_dev, 0, 0, &buf_desc, buf);
+	TC_PRINT("display_write() returned: %s (%d)\n",
+		 display_errno_to_string(ret), ret);
+	zassert_equal(ret, 0, "display_write failed: %d", ret);
 
 	display_free_buffer(buf);
 }
@@ -1249,8 +1205,12 @@ ZTEST(display_api, test_display_write_multiple_rects)
 {
 	struct display_buffer_descriptor buf_desc;
 	struct cdc200_display_caps caps;
+	enum display_pixel_format fmt;
 	uint8_t *buf;
 	size_t buf_size;
+	size_t rect_w = 64;
+	size_t rect_h = 64;
+	int pixel_size;
 
 	cdc200_get_capabilities(display_dev, &caps);
 
@@ -1259,25 +1219,22 @@ ZTEST(display_api, test_display_write_multiple_rects)
 		ztest_test_skip();
 	}
 
-	/* Allocate buffer for a small rectangle */
-	size_t rect_w = 64;
-	size_t rect_h = 64;
-
 	if (caps.layer[0].x_resolution < rect_w ||
 		caps.layer[0].y_resolution < rect_h) {
 		TC_PRINT("Display too small for %zux%zu rectangles, skipping test\n",
 			 rect_w, rect_h);
 		ztest_test_skip();
 	}
+
+	fmt = caps.layer[0].current_pixel_format;
 	TC_PRINT("Using pixel format: %s\n",
-		 display_pixel_format_to_string(caps.layer[0].current_pixel_format));
-	int pixel_size = display_get_pixel_size(
-		caps.layer[0].current_pixel_format);
+		 display_pixel_format_to_string(fmt));
+	pixel_size = display_get_pixel_size(fmt);
+	zassert_true(pixel_size > 0, "Unsupported pixel format: %d", fmt);
 
 	buf_size = rect_w * rect_h * pixel_size;
 
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
@@ -1288,18 +1245,16 @@ ZTEST(display_api, test_display_write_multiple_rects)
 	/* Write red rectangle at top-left */
 	TC_PRINT("Writing RED rectangle at top-left (0, 0), size %zux%zu\n",
 			rect_w, rect_h);
-	display_fill_buffer_solid(buf, buf_size,
-				  caps.layer[0].current_pixel_format,
-				  RED_RGB565);
+	display_fill_buffer_solid(buf, buf_size, fmt,
+				  display_solid_color(fmt, DISPLAY_COLOR_RED));
 	zassert_equal(cdc200_display_write(display_dev, 0, 0, 0, &buf_desc, buf), 0,
 		      "cdc200_display_write (red) failed");
 
 	/* Write green rectangle at top-right */
 	TC_PRINT("Writing GREEN rectangle at top-right (%d, 0), size %zux%zu\n",
 		 caps.layer[0].x_resolution - rect_w, rect_w, rect_h);
-	display_fill_buffer_solid(buf, buf_size,
-				  caps.layer[0].current_pixel_format,
-				  GREEN_RGB565);
+	display_fill_buffer_solid(buf, buf_size, fmt,
+				  display_solid_color(fmt, DISPLAY_COLOR_GREEN));
 	zassert_equal(cdc200_display_write(display_dev, 0,
 					   caps.layer[0].x_resolution - rect_w, 0,
 					   &buf_desc, buf), 0,
@@ -1308,10 +1263,9 @@ ZTEST(display_api, test_display_write_multiple_rects)
 	/* Write blue rectangle at bottom-left */
 	TC_PRINT("Writing BLUE rectangle at bottom-left (0, %d), size %zux%zu\n",
 		 caps.layer[0].y_resolution - rect_h, rect_w, rect_h);
-	display_fill_buffer_solid(buf, buf_size,
-				  caps.layer[0].current_pixel_format,
-				  BLUE_RGB565);
-zassert_equal(cdc200_display_write(display_dev, 0, 0,
+	display_fill_buffer_solid(buf, buf_size, fmt,
+				  display_solid_color(fmt, DISPLAY_COLOR_BLUE));
+	zassert_equal(cdc200_display_write(display_dev, 0, 0,
 					   caps.layer[0].y_resolution - rect_h,
 					   &buf_desc, buf), 0,
 		      "cdc200_display_write (blue) failed");
@@ -1346,7 +1300,6 @@ ZTEST(display_api, test_display_read)
 		     caps.layer[0].current_pixel_format);
 	buf_size = caps.layer[0].x_resolution * (size_t)pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
@@ -1410,7 +1363,6 @@ ZTEST(display_api, test_cdc200_display_read)
 		     caps.layer[0].current_pixel_format);
 	buf_size = caps.layer[0].x_resolution * (size_t)pixel_size;
 	buf = display_alloc_buffer(buf_size);
-	zassert_not_null(buf, "Failed to allocate buffer");
 
 	/* Setup buffer descriptor */
 	buf_desc.buf_size = buf_size;
@@ -1479,3 +1431,37 @@ ZTEST(display_api, test_display_set_contrast)
 	}
 	zassert_equal(ret, 0, "display_set_contrast failed: %d", ret);
 }
+
+/**
+ * Set the early init configuration for this application.
+ */
+static int app_board_early_init(void)
+{
+#if (defined(CONFIG_ENSEMBLE_GEN2) && defined(CONFIG_MIPI_DSI))
+	const struct gpio_dt_spec cam_disp_mux_gpio =
+		GPIO_DT_SPEC_GET(DT_NODELABEL(mipi_dsi), cam_disp_mux_gpios);
+	int ret = gpio_pin_configure_dt(&cam_disp_mux_gpio, GPIO_OUTPUT_ACTIVE);
+
+	if (ret != 0) {
+		return ret;
+	}
+#endif
+
+	/* Enable HFOSC (38.4 MHz) and CFG (100 MHz) clock. */
+	sys_set_bits(CGU_CLK_ENA, BIT(21) | BIT(23));
+
+	return 0;
+}
+/*
+ * CRITICAL: Must run at PRE_KERNEL_1 to restore SYSTOP before peripherals initialize.
+ *
+ * Priority 46 ensures this runs:
+ *   - AFTER SE Services (priority 45) - SE must be ready for set_run_cfg()
+ *   - BEFORE Power Domain (priority 47) - Power domain needs SYSTOP enabled
+ *   - BEFORE UART and peripherals (priority 50+) - Peripherals need SYSTOP ON
+ *
+ * On cold boot: SYSTOP is already ON by default, safe to call.
+ * On SOFT_OFF wakeup: SYSTOP is OFF, must restore BEFORE peripherals access registers.
+ */
+SYS_INIT(app_board_early_init, PRE_KERNEL_1, 46);
+

--- a/tests/drivers/display/testcase.yaml
+++ b/tests/drivers/display/testcase.yaml
@@ -4,12 +4,47 @@ common:
     - display
   depends_on: display
   harness: ztest
+  harness_config:
+    fixture: fixture_display
+  timeout: 180
+  filter: dt_compat_enabled("tes,cdc-2.1")
   platform_allow:
     - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
     - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+    - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+    - alif_e7_dk/ae722f80f55d5xx/rtss_he
+    - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+    - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
   integration_platforms:
     - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
 
 tests:
-  drivers.display.cdc200:
-    filter: dt_compat_enabled("alif,cdc200")
+  # Parallel RGB on all CDC200 targets. App boards/<board>.overlay applies
+  # automatically when present (B1 panel timing, E1C console UART).
+  drivers.display.cdc200: {}
+
+  # MW405 / ILI9806E 2-lane MIPI-DSI (E7/E8 DK).
+  drivers.display.cdc200.mipi_2lane:
+    extra_dtc_overlay_files:
+      - boards/serial_display_2lane.overlay
+    extra_conf_files:
+      - boards/serial_display.conf
+    platform_allow:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_he
+      - alif_e7_dk/ae722f80f55d5xx/rtss_hp
+      - alif_e7_dk/ae722f80f55d5xx/rtss_he
+    integration_platforms:
+      - alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+
+  # ILI9488 1-lane MIPI-DSI (E1C / B1 DK).
+  drivers.display.cdc200.mipi_1lane:
+    extra_dtc_overlay_files:
+      - boards/serial_display_1lane.overlay
+    extra_conf_files:
+      - boards/serial_display.conf
+    platform_allow:
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he
+      - alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+    integration_platforms:
+      - alif_e1c_dk/ae1c1f4051920hh/rtss_he


### PR DESCRIPTION
Extend the CDC200 display ztest suite to run on MIPI-DSI panels as well as parallel RGB.
Bring-up enables DSI video mode in the suite hook (panel init is command
mode; video mode is what actually scans out the CDC200 framebuffer).
split twister cases for parallel, 2-lane (E7/E8), and 1-lane (E1C/B1) panels. 
Pack solid colors per pixel format and test display_write() when CONFIG_MIPI_DSI is set.