### PR TITLE
boards: alif: alif_b1_eb: define i3c recovery pinctrl

### DIFF
--- a/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
+++ b/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
@@ -245,6 +245,14 @@
 		};
 	};
 
+	pinctrl_i3c0_recovery: pinctrl_i3c0_recovery {
+		group0 {
+			pinmux = <PIN_P0_6__GPIO>,
+				<PIN_P0_5__GPIO>;
+			read-enable = <0x1>;
+		};
+	};
+
 	pinctrl_can0: pinctrl_can0 {
 		group0 {
 			pinmux = <PIN_P8_2__CAN0_RXD_C>,


### PR DESCRIPTION
Define I3C's Bus Recovery Pinctrl instance for balletto's engineering board series.