### PR TITLE
s80ks: overlay and manifest

### DIFF
--- a/samples/drivers/spi_psram/README.rst
+++ b/samples/drivers/spi_psram/README.rst
@@ -7,7 +7,8 @@ PS RAM Test
 Overview
 ********
 
-This is the test application to test and verify PSRAM (APS512XXN) over OSPI interface.
+This is the test application to test and verify PSRAM/HyperRAM devices over
+the OSPI interface.
 This test application is only available for E4/E8 SOC boards.
 
 
@@ -15,8 +16,28 @@ Building and Running
 ********************
 
 The application will build only for a target that has a devicetree entry with
-*:dt compatible:`alif,apmemory-aps512xxn`* as a compatible.
-Use respective ovderlay files in boards folder for AP PSRAM HyperRam with build command.
+*:dt compatible:`alif,apmemory-aps512xxn`* or
+*:dt compatible:`alif,infineon-s80ks2564`* as a compatible.
+Use respective overlay files in the boards folder for APS PSRAM or S80KS
+HyperRAM with the build command.
+
+S80KS HyperRAM Test
+===================
+
+The ``alif_hex_s80ks.overlay`` file provides the devicetree configuration for
+testing the Infineon S80KS HyperRAM with this sample.
+
+This overlay was tested on the Alif E8 CSP engineering board. On the Alif E8
+engineering board, the S80KS HyperRAM is connected over OSPI1, but the sample is
+still built using the Alif E8 DevKit board target.
+
+To test the S80KS HyperRAM on the Alif E8 engineering board, rename
+``alif_hex_s80ks.overlay`` to the overlay name expected by the selected DevKit
+build target. For example, for the ``e8_ae822 HE`` build, rename it to
+``alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay``.
+
+Also make sure the MPU entry for the OSPI1 XiP region is configured as
+read/write with SRAM attributes.
 
 Sample Output
 =============

--- a/samples/drivers/spi_psram/boards/alif_hex_s80ks.overlay
+++ b/samples/drivers/spi_psram/boards/alif_hex_s80ks.overlay
@@ -1,0 +1,86 @@
+/* Copyright (C) 2025 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ */
+
+/*
+ * Enable the Infineon S80KS HyperRAM connected to OSPI1 on E8
+ * DK-compatible engineering boards.
+ *
+ * This configuration was tested on the Alif E8 CSP engineering board.
+ *
+ * On the Alif E8 engineering board, the HyperRAM is connected over OSPI1.
+ * To test on this board, use the Alif E8 DevKit build and rename this file to
+ * match the build target. For example, use
+ * alif_e8_dk_ae822fa0e5597xx0_rtss_he.overlay for the "e8_ae822 HE" build.
+ *
+ * Ensure the MPU entry for the XiP region is marked as read/write with SRAM
+ * attributes.
+ */
+
+/ {
+	aliases {
+		spi-psram = &s80ks2564;
+	};
+};
+
+&pinctrl_ospi1 {
+	group0 {
+		pinmux = <PIN_P9_5__OSPI1_D0_C>,
+			 <PIN_P9_6__OSPI1_D1_C>,
+			 <PIN_P9_7__OSPI1_D2_C>,
+			 <PIN_P10_0__OSPI1_D3_C>,
+			 <PIN_P10_1__OSPI1_D4_C>,
+			 <PIN_P10_2__OSPI1_D5_C>,
+			 <PIN_P10_3__OSPI1_D6_C>,
+			 <PIN_P10_4__OSPI1_D7_C>,
+			 <PIN_P17_0__OSPI1_D8_C>,
+			 <PIN_P17_1__OSPI1_D9_C>,
+			 <PIN_P17_2__OSPI1_D10_C>,
+			 <PIN_P17_3__OSPI1_D11_C>,
+			 <PIN_P17_4__OSPI1_D12_C>,
+			 <PIN_P17_5__OSPI1_D13_C>,
+			 <PIN_P17_6__OSPI1_D14_C>,
+			 <PIN_P17_7__OSPI1_D15_C>,
+			 <PIN_P9_0__OSPI1_RXDS1_C>,
+			 <PIN_P10_7__OSPI1_RXDS0_C>;
+		read-enable = <1>;
+		drive-strength = <12>;
+		slew-rate = <1>;
+	};
+	group1 {
+		pinmux = <PIN_P5_5__OSPI1_SCLK_C>,
+			 <PIN_P5_7__OSPI1_SS0_C>,
+			 <PIN_P15_7__LPGPIO>;
+		read-enable = <0>;
+		drive-strength = <12>;
+	};
+
+};
+
+&ospi_flash {
+	status = "disabled";
+};
+
+
+&ospi1 {
+	rx-ds-delay = <11>;
+	xip-wait-cycles = <255>;
+	tx-fifo-threshold = <0>;
+	ddr-drive-edge = <1>;
+	clocks = <&clockctrl ALIF_OSPI1_ACLK_CLK>;
+	xip-base-address = <0xC0000000 0x10000000>;
+	bus-speed = <40000000>;
+	status = "okay";
+
+	s80ks2564: s80ks2564 {
+		compatible = "alif,infineon-s80ks2564";
+		size = <DT_SIZE_M(32)>;
+		latency = <3>;
+		status = "okay";
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 68f90b429778a6948930580f53586bbc5732c37e
+      revision: 118ac41d80ca43f48c60f7fe3f81ba1324be152b
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Added overlay and usage detail.

S80KS driver: [PR-645](https://github.com/alifsemi/zephyr_alif/pull/645)