### PR TITLE
manifest: Update zephyr version to ISP Build assert fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 2134310f0be8bacd09c776513e66b6012b4a86b2
+      revision: 0f64950f75c1fd378cf4f84f38d91ba57c767b58
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Update zephyr version to ISP build assert fix due to missing binning property.

This PR depends on: alifsemi/zephyr_alif/pull/647