### PR TITLE
Ble sample Updates and fixs

### DIFF
--- a/samples/bluetooth/le_periph_cgms/src/cgms_rom_1_2.c
+++ b/samples/bluetooth/le_periph_cgms/src/cgms_rom_1_2.c
@@ -91,6 +91,8 @@ typedef struct {
 
 static app_env_t app_env;
 
+static void set_start_time(void);
+
 static void racp_response_opcode_pack(racp_resp_t *racp_response, uint8_t opcode, uint8_t status)
 {
 	racp_response->op_code = CGMS_RA_OPCODE_RSP_CODE;
@@ -570,6 +572,15 @@ static void on_control_req(uint8_t conidx, uint8_t char_type, uint16_t token, co
 			LOG_INF("Received SOCP Get Communication Interval command");
 			socp_response_opcode_pack(&socp_response, opcode,
 						  app_env.communication_interval);
+		} else if (opcode == CGMS_SPECIFIC_OPCODE_START_SESSION && length == 0) {
+			LOG_INF("Received SOCP Start Session command");
+			set_start_time();
+			socp_response_opcode_pack(&socp_response, opcode,
+						  CGMS_SPECIFIC_RSP_CODE_SUCCESS);
+		} else if (opcode == CGMS_SPECIFIC_OPCODE_STOP_SESSION && length == 0) {
+			LOG_INF("Received SOCP Stop Session command");
+			socp_response_opcode_pack(&socp_response, opcode,
+						  CGMS_SPECIFIC_RSP_CODE_SUCCESS);
 		} else {
 			LOG_INF("Unsupported SOCP opcode %u with length %u", opcode, length);
 			socp_response_opcode_pack(&socp_response, opcode,

--- a/samples/bluetooth/le_periph_cgms/src/main.c
+++ b/samples/bluetooth/le_periph_cgms/src/main.c
@@ -202,7 +202,7 @@ int main(void)
 	}
 
 	/* Share connection info */
-	service_conn(&ctrl);
+	service_conn_cgms(&ctrl);
 
 	/* Adding battery service */
 	config_battery_service();

--- a/samples/bluetooth/le_periph_hr/src/main.c
+++ b/samples/bluetooth/le_periph_hr/src/main.c
@@ -106,6 +106,16 @@ const gapc_le_con_param_nego_with_ce_len_t preferred_connection_param = {
 /* Store advertising activity index for re-starting after disconnection */
 static uint8_t adv_actv_idx;
 
+/* Connection index awaiting a parameter update, and remaining retry attempts */
+static uint8_t conn_param_conidx;
+static uint8_t conn_param_retries;
+
+#define CONN_PARAM_UPDATE_DELAY K_MSEC(500)
+#define CONN_PARAM_UPDATE_MAX_RETRIES 3
+
+static void conn_param_update_work_handler(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(conn_param_update_work, conn_param_update_work_handler);
+
 /* HRPS callbacks */
 
 static void on_hrps_meas_send_complete(uint16_t status)
@@ -255,26 +265,52 @@ void service_process(void)
 static void on_gapc_proc_cmp_cb(uint8_t const conidx, uint32_t const metainfo,
 				uint16_t const status)
 {
+	/* The controller can reject the update with a transaction collision (0xBA)
+	 * when the peer is running its own LLCP procedure at the same time. Retry.
+	 */
+	if (status == LL_ERR_DIFF_TRANSACTION_COLLISION && conn_param_retries) {
+		conn_param_retries--;
+		LOG_WRN("Connection param update collided, retrying (%u left)",
+			conn_param_retries);
+		k_work_reschedule(&conn_param_update_work, CONN_PARAM_UPDATE_DELAY);
+		return;
+	}
+
 	if (status) {
 		LOG_ERR("GAPC LE connection param update failed %u", status);
-		return;
+	} else {
+		LOG_INF("GAPC LE connection param update success");
 	}
 
 	ctrl.connected = true;
 	k_sem_give(&conn_sem);
 
-	LOG_INF("Connection params updated");
 	power_mgr_log_flush();
 }
 
-static void app_connected_handle(uint8_t const con_idx)
+static void conn_param_update_work_handler(struct k_work *work)
 {
-	uint16_t const ret = gapc_le_update_params(con_idx, 0, &preferred_connection_param,
+	uint16_t const ret = gapc_le_update_params(conn_param_conidx, 0,
+						   &preferred_connection_param,
 						   on_gapc_proc_cmp_cb);
 
 	if (ret) {
 		LOG_ERR("GAPC LE connection param update start failed %u", ret);
+		/* Don’t block forever if the update procedure can’t be started. */
+		ctrl.connected = true;
+		k_sem_give(&conn_sem);
 	}
+}
+
+static void app_connected_handle(uint8_t const con_idx)
+{
+	conn_param_conidx = con_idx;
+	conn_param_retries = CONN_PARAM_UPDATE_MAX_RETRIES;
+
+	/* Defer the update so it does not collide with the peer's connection-setup
+	 * procedures (e.g. feature exchange) that run right after connection.
+	 */
+	k_work_reschedule(&conn_param_update_work, CONN_PARAM_UPDATE_DELAY);
 
 	LOG_DBG("Please enable notifications on peer device..");
 	power_mgr_log_flush();


### PR DESCRIPTION
Peripheral HR
Moved connection update params out from connection handler
callback for avoid colliding with the peer's connection-setup
procedures.

The parameter update is now deferred ~500 ms via a K_WORK_DELAYABLE
so it doesn't race the peer's post-connection LLCP procedures.
On a 0xBA collision, on_gapc_proc_cmp_cb reschedules the update
(up to 3 retries) instead of just logging an error and giving up.
This is the standard remedy for a transaction collision — back off
and retry. If it still fails after retries, it will log the final
error as before.

Peripheral CGM
CGM:
The SOCP handler now handles the two commands the peer used:

* CGMS_SPECIFIC_OPCODE_START_SESSION (26 / 0x1A)
* CGMS_SPECIFIC_OPCODE_STOP_SESSION (27 / 0x1B)

Both are no-operand ops answered via a CGMS_SPECIFIC_OPCODE_RSP,
per the CGMS spec.
