### PR TITLE
samples: drivers: pm: add I2S DW power management demo

### DIFF
--- a/samples/drivers/pm/i2s_dw/CMakeLists.txt
+++ b/samples/drivers/pm/i2s_dw/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i2s_dw)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/pm/i2s_dw/Kconfig
+++ b/samples/drivers/pm/i2s_dw/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+mainmenu "Alif I2S DW Power Management Demo"
+
+source "Kconfig.zephyr"

--- a/samples/drivers/pm/i2s_dw/README.rst
+++ b/samples/drivers/pm/i2s_dw/README.rst
@@ -1,0 +1,156 @@
+.. _i2s-dw-pm-sample:
+
+I2S DW Power Management Demo
+#############################
+
+Overview
+********
+
+This sample demonstrates Zephyr power management states combined with I2S DW
+echo streaming on Alif RTSS cores. The application cycles through PM states
+and restarts I2S RX/TX echo after each wake, verifying that the I2S peripheral
+resumes correctly.
+
+PM states exercised (determined at runtime by capability predicates):
+
+- **S2RAM path** (HE TCM retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  S2RAM STANDBY → S2RAM STOP → idle loop
+- **SOFT_OFF path** (MRAM boot, no retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  SOFT_OFF (system resets on wakeup)
+
+I2S routing (microphone in, speaker out):
+
+- Ensemble HE (E7/E8): ``i2s4`` (LPI2S RX) + ``i2s3`` (TX)
+- Ensemble HP (E7/E8): ``i2s3`` (RX) + ``i2s1`` (TX)
+- Balletto B1 / Ensemble E1C HE: ``i2s4`` (LPI2S RX) + ``i2s0`` (TX)
+
+.. note::
+
+   Use LPUART port for console logs on E1C and B1 DevKits.
+
+Building and Running
+********************
+
+HE Core — TCM boot S2RAM (E7/E8/E1C/B1)
+=========================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2s_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2s-dw-pm-s2ram-tcm
+   :gen-args: -DCONFIG_FLASH_BASE_ADDRESS=0x0 -DCONFIG_FLASH_LOAD_OFFSET=0x0 -DCONFIG_FLASH_SIZE=256
+
+HE Core — MRAM boot SOFT_OFF (E7/E8/E1C/B1)
+=============================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2s_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2s-dw-pm-mram
+
+HP Core — MRAM boot SOFT_OFF (E7/E8)
+======================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2s_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2s-dw-pm-mram
+
+Sample Output (S2RAM path)
+**************************
+
+The output below is from an E8 DK HE core TCM-boot run (``APP_PM_WAKEUP_DEBUG 0``,
+the default). Setting ``APP_PM_WAKEUP_DEBUG 1`` in ``main.c`` additionally prints
+``PM wakeup: NVIC ISPR[x] = 0x...`` lines on each resume.
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build 2134310f0be8 ***
+   [00:00:00.000,000] <inf> pm_i2s_dw: alif_e8_dk (S2RAM): I2S DW PM demo (RUNTIME_IDLE, SUSPEND_TO_IDLE, )
+   [00:00:00.000,000] <inf> pm_i2s_dw: POWER STATE SEQUENCE:
+   [00:00:00.000,000] <inf> pm_i2s_dw:   1. PM_STATE_RUNTIME_IDLE
+   [00:00:00.000,000] <inf> pm_i2s_dw:   2. PM_STATE_SUSPEND_TO_IDLE
+   [00:00:00.000,000] <inf> pm_i2s_dw:   3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)
+   [00:00:00.000,000] <inf> pm_i2s_dw:   4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)
+   [00:00:00.001,000] <inf> pm_i2s_dw: [I2S Demo] before RUNTIME_IDLE
+   [00:00:01.989,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:01.989,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:01.989,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:02.090,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:02.090,000] <inf> pm_i2s_dw: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+   [00:00:20.091,000] <inf> pm_i2s_dw: Exited from RUNTIME_IDLE sleep
+   [00:00:20.091,000] <inf> pm_i2s_dw: Request SUSPEND_TO_IDLE for 10000 us
+   [00:00:20.093,000] <inf> pm_i2s_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:20.093,000] <inf> pm_i2s_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:20.102,000] <inf> pm_i2s_dw: [I2S Demo] after SUSPEND_TO_IDLE
+   [00:00:22.090,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:22.090,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:22.090,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:22.191,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:22.191,000] <inf> pm_i2s_dw: Request S2RAM STANDBY for 6000000 us
+   [00:00:22.193,000] <inf> pm_i2s_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:22.193,000] <inf> pm_i2s_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:22.253,000] <inf> pm_i2s_dw: PM enter: SUSPEND_TO_RAM (substate 0)
+   [00:00:22.253,000] <inf> pm_i2s_dw: PM wakeup: SUSPEND_TO_RAM (substate 0)
+   [00:00:22.253,000] <inf> pm_i2s_dw: PM exit:  SUSPEND_TO_RAM (substate 0)
+   [00:00:28.211,000] <inf> pm_i2s_dw: [I2S Demo] after S2RAM STANDBY
+   [00:00:30.199,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:30.199,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:30.200,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:30.301,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:30.301,000] <inf> pm_i2s_dw: Request S2RAM STOP for 9000000 us
+   [00:00:30.303,000] <inf> pm_i2s_dw: PM enter: SUSPEND_TO_IDLE (substate 0)
+   [00:00:30.303,000] <inf> pm_i2s_dw: PM exit:  SUSPEND_TO_IDLE (substate 0)
+   [00:00:30.363,000] <inf> pm_i2s_dw: PM enter: SUSPEND_TO_RAM (substate 1)
+   [00:00:30.363,000] <inf> pm_i2s_dw: PM wakeup: SUSPEND_TO_RAM (substate 1)
+   [00:00:30.363,000] <inf> pm_i2s_dw: PM exit:  SUSPEND_TO_RAM (substate 1)
+   [00:00:39.316,000] <inf> pm_i2s_dw: [I2S Demo] after S2RAM STOP
+   [00:00:41.305,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:41.305,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:41.305,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:41.406,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:41.406,000] <inf> pm_i2s_dw: === I2S DW PM SEQUENCE COMPLETED ===
+
+Sample Output (SOFT_OFF path)
+*****************************
+
+The output below is from an E8 DK HE core MRAM-boot run. After SOFT_OFF the
+system resets and restarts from ``main()``.
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build 2134310f0be8 ***
+   [00:00:00.001,000] <inf> pm_i2s_dw: alif_e8_dk (SOFT_OFF): I2S DW PM demo (RUNTIME_IDLE, SUSPEND_TO_IDL)
+   [00:00:00.001,000] <inf> pm_i2s_dw: POWER STATE SEQUENCE:
+   [00:00:00.001,000] <inf> pm_i2s_dw:   1. PM_STATE_RUNTIME_IDLE
+   [00:00:00.001,000] <inf> pm_i2s_dw:   2. PM_STATE_SUSPEND_TO_IDLE
+   [00:00:00.001,000] <inf> pm_i2s_dw:   3. PM_STATE_SOFT_OFF
+   [00:00:00.001,000] <inf> pm_i2s_dw: [I2S Demo] before RUNTIME_IDLE
+   [00:00:01.990,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:01.990,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:01.990,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:02.091,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:02.091,000] <inf> pm_i2s_dw: Enter RUNTIME_IDLE sleep for (18000000 microseconds)
+   [00:00:20.092,000] <inf> pm_i2s_dw: Exited from RUNTIME_IDLE sleep
+   [00:00:20.092,000] <inf> pm_i2s_dw: Request SUSPEND_TO_IDLE for 10000 us
+   [00:00:20.103,000] <inf> pm_i2s_dw: [I2S Demo] after SUSPEND_TO_IDLE
+   [00:00:22.091,000] <inf> pm_i2s_dw: stream loop exited
+   [00:00:22.091,000] <inf> pm_i2s_dw: i2s_stop: RX drop returned 0
+   [00:00:22.091,000] <inf> pm_i2s_dw: i2s_stop: TX drop returned 0
+   [00:00:22.192,000] <inf> pm_i2s_dw: i2s_stop: done
+   [00:00:22.192,000] <inf> pm_i2s_dw: Request SOFT_OFF for 10000000 us (no retention - system resets on w)
+
+   *** Booting Zephyr OS build 2134310f0be8 ***
+
+Notes
+*****
+
+* Disconnect the debugger before testing — it prevents cores from entering OFF states.
+* I2S is stopped before each PM state and restarted after wakeup (44.1 kHz, 16-bit stereo).
+* Deep-sleep durations stay below the 10.7 s PM driver tick ceiling (except RUNTIME_IDLE).

--- a/samples/drivers/pm/i2s_dw/prj.conf
+++ b/samples/drivers/pm/i2s_dw/prj.conf
@@ -1,0 +1,28 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_I2S=y
+CONFIG_I2S_LOG_LEVEL_INF=n
+
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_IDLE_STACK_SIZE=1024
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_COUNTER=y
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_ASSERT=y
+
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=0
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=5
+CONFIG_LOG_BACKEND_UART=y

--- a/samples/drivers/pm/i2s_dw/sample.yaml
+++ b/samples/drivers/pm/i2s_dw/sample.yaml
@@ -1,0 +1,53 @@
+sample:
+  name: Alif I2S DW Power Management Demo
+  description: >
+    Demonstrates Zephyr power management states (PM_STATE_RUNTIME_IDLE,
+    PM_STATE_SUSPEND_TO_IDLE, PM_STATE_SUSPEND_TO_RAM, PM_STATE_SOFT_OFF)
+    for Alif RTSS cores with I2S echo streaming between PM state transitions.
+    PM states exercised are selected via build snippets: i2s-dw-pm-s2ram-tcm
+    (HE TCM retention) and i2s-dw-pm-mram (MRAM boot SOFT_OFF, HE or HP).
+common:
+  tags:
+    - power
+    - pm
+    - i2s
+    - counter
+    - rtc
+    - drivers
+  filter: SOC_FAMILY_ENSEMBLE or SOC_FAMILY_BALLETTO
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "I2S DW PM demo"
+      - "POWER STATE SEQUENCE"
+tests:
+  sample.drivers.i2s.dw.pm.s2ram_tcm:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e8_dk_rtss_he
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+    depends_on:
+      - counter
+      - i2s
+    extra_args:
+      - SNIPPET=i2s-dw-pm-s2ram-tcm
+  sample.drivers.i2s.dw.pm.mram:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+      - alif_e8_dk_rtss_he
+      - alif_e8_dk_rtss_hp
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+    depends_on:
+      - counter
+      - i2s
+    extra_args:
+      - SNIPPET=i2s-dw-pm-mram

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_b1.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_b1.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: I2S0 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+i2s_tx: &i2s0 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e1c.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e1c.overlay
@@ -1,0 +1,40 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: I2S0 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ * Console: lpuart (overrides uart2 set by pm_mram_common.overlay).
+ */
+
+#include "pm_mram_he.overlay"
+
+/ {
+	chosen {
+		zephyr,console    = &lpuart;
+		zephyr,shell-uart = &lpuart;
+	};
+};
+
+&uart2 {
+	status = "disabled";
+};
+
+&lpuart {
+	status = "okay";
+};
+
+i2s_tx: &i2s0 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e7_he.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e7_he.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: I2S3 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+i2s_tx: &i2s3 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e7_hp.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e7_hp.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HP: I2S1 speaker (TX) + I2S3 mic (RX).
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+i2s_tx: &i2s1 {
+	status = "okay";
+};
+
+i2s_rx: &i2s3 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e8_he.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e8_he.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: I2S3 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+i2s_tx: &i2s3 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e8_hp.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/i2s_dw_e8_hp.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HP: I2S1 speaker (TX) + I2S3 mic (RX).
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+i2s_tx: &i2s1 {
+	status = "okay";
+};
+
+i2s_rx: &i2s3 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_common.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_common.overlay
@@ -1,0 +1,46 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <9000000>;
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	status = "okay";
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+};
+
+/ {
+	chosen {
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_he.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_he.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HE core booting from MRAM.
+ * Uses RTC as wakeup source and idle timer.
+ */
+
+#include "pm_mram_common.overlay"
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+	};
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_hp.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/pm_mram_hp.overlay
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HP core booting from MRAM.
+ * Uses LPTIMER0 as wakeup source.
+ */
+
+#include "pm_mram_common.overlay"
+
+&timer0 {
+	status = "okay";
+};
+
+&utimer5 {
+	status = "disabled";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPTIMER0>;
+	ewic-cfg      = <ALIF_EWIC_VBAT_TIMER>;
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/prj.conf
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/prj.conf
@@ -1,0 +1,2 @@
+# PM MRAM boot - SOFT_OFF configuration (HE and HP)
+# MRAM boot uses SOFT_OFF; S2RAM (PM_S2RAM) is not enabled for this path.

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/snippet.yml
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-mram/snippet.yml
@@ -1,0 +1,22 @@
+name: i2s-dw-pm-mram
+append:
+  EXTRA_CONF_FILE: prj.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e7_he.overlay
+  /alif_e7.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e7_hp.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e8_he.overlay
+  /alif_e8.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e8_hp.overlay

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_b1.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_b1.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: I2S0 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+i2s_tx: &i2s0 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e1c.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e1c.overlay
@@ -1,0 +1,40 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: I2S0 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ * Console: lpuart (overrides uart2 set by pm_tcm_common.overlay).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+/ {
+	chosen {
+		zephyr,console    = &lpuart;
+		zephyr,shell-uart = &lpuart;
+	};
+};
+
+&uart2 {
+	status = "disabled";
+};
+
+&lpuart {
+	status = "okay";
+};
+
+i2s_tx: &i2s0 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e7_he.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e7_he.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: I2S3 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+i2s_tx: &i2s3 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e8_he.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/i2s_dw_e8_he.overlay
@@ -1,0 +1,24 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: I2S3 speaker (TX) + I2S4 LPI2S mic (RX).
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+i2s_tx: &i2s3 {
+	status = "okay";
+};
+
+i2s_rx: &i2s4 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_common.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_common.overlay
@@ -1,0 +1,74 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <9000000>;
+	status = "okay";
+};
+
+&standby_s2ram {
+	min-residency-us = <5000000>;
+	status = "okay";
+};
+
+&stop_s2ram {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&suspend_idle {
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	vtor-address = <0x00000000>;
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
@@ -1,0 +1,33 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble E1C and Balletto B1 SoCs.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
@@ -1,0 +1,28 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble and Ensemble Gen2
+ * SoCs - HE core TCM boot S2RAM.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/snippet.yml
+++ b/samples/drivers/pm/i2s_dw/snippets/i2s-dw-pm-s2ram-tcm/snippet.yml
@@ -1,0 +1,16 @@
+name: i2s-dw-pm-s2ram-tcm
+append:
+  EXTRA_CONF_FILE: ../pm_s2ram_common.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e7_he.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2s_dw_e8_he.overlay

--- a/samples/drivers/pm/i2s_dw/snippets/pm_s2ram_common.conf
+++ b/samples/drivers/pm/i2s_dw/snippets/pm_s2ram_common.conf
@@ -1,0 +1,3 @@
+# Common Kconfig for the S2RAM TCM retention snippet
+CONFIG_PM_S2RAM=y
+CONFIG_PM_SAU_SAVE_RESTORE=y

--- a/samples/drivers/pm/i2s_dw/src/main.c
+++ b/samples/drivers/pm/i2s_dw/src/main.c
@@ -1,0 +1,610 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(pm_i2s_dw, LOG_LEVEL_INF);
+
+/* Set to 1 to dump full NVIC ISPR state on wakeup */
+#define APP_PM_WAKEUP_DEBUG 0
+
+#if DT_NODE_EXISTS(DT_NODELABEL(i2s_rxtx))
+#define I2S_RX_NODE  DT_NODELABEL(i2s_rxtx)
+#define I2S_TX_NODE  I2S_RX_NODE
+#else
+#define I2S_RX_NODE  DT_NODELABEL(i2s_rx)
+#define I2S_TX_NODE  DT_NODELABEL(i2s_tx)
+#endif
+
+#define SAMPLE_FREQUENCY    44100
+#define SAMPLE_BIT_WIDTH    16
+#define BYTES_PER_SAMPLE    sizeof(int16_t)
+#define NUMBER_OF_CHANNELS  2
+/* Such block length provides an echo with the delay of 100 ms. */
+#define SAMPLES_PER_BLOCK   ((SAMPLE_FREQUENCY / 10) * NUMBER_OF_CHANNELS)
+#define INITIAL_BLOCKS      4
+#define TIMEOUT             1000
+
+#define BLOCK_SIZE  (BYTES_PER_SAMPLE * SAMPLES_PER_BLOCK)
+#define BLOCK_COUNT (INITIAL_BLOCKS + 6)
+K_MEM_SLAB_DEFINE_STATIC(mem_slab, BLOCK_SIZE, BLOCK_COUNT, 4);
+
+/* I2S streaming duration per phase (number of loop iterations) */
+#define I2S_STREAM_ITERATIONS 20
+
+static int16_t echo_block[SAMPLES_PER_BLOCK];
+static volatile bool echo_enabled = true;
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
+#else
+#error "Wakeup Device not enabled in the dts"
+#endif
+
+/*
+ * Sleep duration constants for each PM state.
+ *
+ * Upper bound: at 400 MHz, ticks to cycles calculation in PM driver
+ * overflows uint32 max for values > 10.7s (2^32 / 400). All deep-sleep
+ * durations and overlay min-residency-us values must stay below this ceiling.
+ */
+/* Sleep duration for PM_STATE_RUNTIME_IDLE */
+#define RUNTIME_IDLE_SLEEP_USEC (18 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_IDLE */
+#define SUSPEND_IDLE_SLEEP_USEC (10 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 0 (STANDBY) */
+#define S2RAM_STANDBY_SLEEP_USEC (6 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SUSPEND_TO_RAM substate 1 (STOP) */
+#define S2RAM_STOP_SLEEP_USEC (9 * 1000 * 1000)
+/* Sleep duration for PM_STATE_SOFT_OFF */
+#define SOFT_OFF_SLEEP_USEC (10 * 1000 * 1000)
+
+/*
+ * MRAM base address - used to determine boot location
+ * TCM boot: VTOR = 0x0
+ * MRAM boot: VTOR >= 0x80000000
+ */
+#define MRAM_BASE_ADDRESS 0x80000000
+
+#define IS_BOOTING_FROM_MRAM() (SCB->VTOR >= MRAM_BASE_ADDRESS)
+
+/*
+ * True when the DTS chosen zephyr,sram points at sram0. The snippet overlay
+ * is responsible for ensuring SRAM0 has retention support on the target board.
+ */
+#if DT_NODE_EXISTS(DT_NODELABEL(sram0))
+#define IS_SRAM0_CONFIGURED_AS_RAM() \
+	DT_SAME_NODE(DT_CHOSEN(zephyr_sram), DT_NODELABEL(sram0))
+#else
+#define IS_SRAM0_CONFIGURED_AS_RAM() 0
+#endif
+
+/*
+ * S2RAM_SUPPORTED — retention-capable sleep is possible when:
+ *   - SRAM0 is the configured data RAM (HE or HP, E8 only), OR
+ *   - HE core booting from TCM (TCM has hardware retention)
+ *
+ * SOFT_OFF_SUPPORTED — mutually exclusive with S2RAM: used when no
+ * retained RAM is available (HP-TCM, HE-MRAM boot without SRAM0).
+ */
+#define S2RAM_SUPPORTED \
+	(IS_SRAM0_CONFIGURED_AS_RAM() || \
+	 (IS_ENABLED(CONFIG_RTSS_HE) && !IS_BOOTING_FROM_MRAM()))
+
+#define SOFT_OFF_SUPPORTED (!S2RAM_SUPPORTED)
+
+/* Validate ordering of deep-sleep durations at compile time */
+BUILD_ASSERT(S2RAM_STOP_SLEEP_USEC > S2RAM_STANDBY_SLEEP_USEC,
+	"STOP sleep duration must be greater than STANDBY sleep duration");
+BUILD_ASSERT(SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC,
+	"SOFT_OFF sleep duration must be greater than STOP sleep duration");
+
+/**
+ * Helper function to lock/unlock deeper power states.
+ * @param lock true → lock all deep states (allow RUNTIME_IDLE only)
+ *             false → unlock the applicable state; keep the other locked
+ */
+static void app_pm_lock_deeper_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+	} else if (S2RAM_SUPPORTED) {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		/* SOFT_OFF stays locked for the entire demo */
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
+		/* S2RAM stays locked for the entire demo */
+	}
+}
+
+/*
+ * Lock every PM sleep state deeper than RUNTIME_IDLE. Intended for use around
+ * I2S streaming and around any sleep call the app makes where an accidental
+ * upgrade to a deeper state must be prevented.
+ */
+static void app_pm_lock_sleep_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+#if !defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+static volatile uint32_t alarm_cb_status;
+static void alarm_callback_fn(const struct device *wakeup_dev,
+				uint8_t chan_id, uint32_t ticks,
+				void *user_data)
+{
+	LOG_DBG("%s: Alarm triggered", wakeup_dev->name);
+	alarm_cb_status = 1;
+}
+#endif
+
+static int app_enter_normal_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Could not set the alarm");
+		return ret;
+	}
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+
+	k_sleep(K_USEC(sleep_usec));
+
+	if (!alarm_cb_status) {
+		return -1;
+	}
+	alarm_cb_status = 0;
+
+#endif
+	return 0;
+}
+
+static int app_enter_deep_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	/*
+	 * Set a delay more than the min-residency-us configured so that
+	 * the sub-system will go to OFF state.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+	/*
+	 * Set the alarm and delay so that idle thread can run
+	 */
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set the alarm (err %d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+	/*
+	 * Wait for the alarm to trigger. The idle thread will
+	 * take care of entering the deep sleep state via PM framework.
+	 */
+	k_sleep(K_USEC(sleep_usec));
+#endif
+
+	return 0;
+}
+
+static void process_block_data(void *mem_block, uint32_t number_of_samples)
+{
+	static bool clear_echo_block;
+	uint32_t samples = number_of_samples;
+
+	if (samples > SAMPLES_PER_BLOCK) {
+		samples = SAMPLES_PER_BLOCK;
+	}
+
+	if (echo_enabled) {
+		for (uint32_t i = 0; i < samples; ++i) {
+			int16_t *sample = &((int16_t *)mem_block)[i];
+			*sample += echo_block[i];
+			echo_block[i] = (*sample) / 2;
+		}
+
+		clear_echo_block = true;
+	} else if (clear_echo_block) {
+		clear_echo_block = false;
+		memset(echo_block, 0, sizeof(echo_block));
+	}
+}
+
+static bool i2s_configure_streams(const struct device *i2s_dev_rx,
+				  const struct device *i2s_dev_tx,
+				  const struct i2s_config *config)
+{
+	int ret;
+
+	if (i2s_dev_rx == i2s_dev_tx) {
+		ret = i2s_configure(i2s_dev_rx, I2S_DIR_BOTH, config);
+		if (ret == 0) {
+			return true;
+		}
+		/* -ENOSYS means that the RX and TX streams need to be
+		 * configured separately.
+		 */
+		if (ret != -ENOSYS) {
+			LOG_ERR("Failed to configure streams: %d", ret);
+			return false;
+		}
+	}
+
+	ret = i2s_configure(i2s_dev_rx, I2S_DIR_RX, config);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure RX stream: %d", ret);
+		return false;
+	}
+
+	ret = i2s_configure(i2s_dev_tx, I2S_DIR_TX, config);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure TX stream: %d", ret);
+		return false;
+	}
+
+	return true;
+}
+
+static bool i2s_prepare_transfer(const struct device *i2s_dev_tx)
+{
+	int ret;
+
+	for (int i = 0; i < INITIAL_BLOCKS; ++i) {
+		void *mem_block;
+
+		ret = k_mem_slab_alloc(&mem_slab, &mem_block, K_NO_WAIT);
+		if (ret < 0) {
+			LOG_ERR("Failed to allocate TX block %d: %d", i, ret);
+			return false;
+		}
+
+		memset(mem_block, 0, BLOCK_SIZE);
+
+		ret = i2s_write(i2s_dev_tx, mem_block, BLOCK_SIZE);
+		if (ret < 0) {
+			LOG_ERR("Failed to write block %d: %d", i, ret);
+			k_mem_slab_free(&mem_slab, mem_block);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool i2s_trigger_command(const struct device *i2s_dev_rx,
+				const struct device *i2s_dev_tx,
+				enum i2s_trigger_cmd cmd)
+{
+	int ret;
+
+	if (i2s_dev_rx == i2s_dev_tx) {
+		ret = i2s_trigger(i2s_dev_rx, I2S_DIR_BOTH, cmd);
+		if (ret == 0) {
+			return true;
+		}
+		/* -ENOSYS means that commands for the RX and TX streams need
+		 * to be triggered separately.
+		 */
+		if (ret != -ENOSYS) {
+			LOG_ERR("Failed to trigger command %d: %d", cmd, ret);
+			return false;
+		}
+	}
+
+	ret = i2s_trigger(i2s_dev_rx, I2S_DIR_RX, cmd);
+	if (ret < 0) {
+		LOG_ERR("Failed to trigger command %d on RX: %d", cmd, ret);
+		return false;
+	}
+
+	ret = i2s_trigger(i2s_dev_tx, I2S_DIR_TX, cmd);
+	if (ret < 0) {
+		LOG_ERR("Failed to trigger command %d on TX: %d", cmd, ret);
+		return false;
+	}
+
+	return true;
+}
+
+static bool i2s_start(const struct device *i2s_dev_rx,
+		      const struct device *i2s_dev_tx)
+{
+	struct i2s_config config = {0};
+
+	config.word_size = SAMPLE_BIT_WIDTH;
+	config.channels = NUMBER_OF_CHANNELS;
+	config.format = I2S_FMT_DATA_FORMAT_I2S;
+	config.options = I2S_OPT_BIT_CLK_MASTER | I2S_OPT_FRAME_CLK_MASTER;
+	config.frame_clk_freq = SAMPLE_FREQUENCY;
+	config.mem_slab = &mem_slab;
+	config.block_size = BLOCK_SIZE;
+	config.timeout = TIMEOUT;
+
+	if (!i2s_configure_streams(i2s_dev_rx, i2s_dev_tx, &config)) {
+		return false;
+	}
+
+	if (!i2s_prepare_transfer(i2s_dev_tx)) {
+		return false;
+	}
+
+	if (!i2s_trigger_command(i2s_dev_rx, i2s_dev_tx, I2S_TRIGGER_START)) {
+		return false;
+	}
+
+	return true;
+}
+
+static void i2s_stream_for(const struct device *i2s_dev_rx,
+			   const struct device *i2s_dev_tx,
+			   int iterations)
+{
+	for (int i = 0; i < iterations; i++) {
+		void *mem_block;
+		uint32_t block_size;
+		int ret;
+
+		ret = i2s_read(i2s_dev_rx, &mem_block, &block_size);
+		if (ret < 0) {
+			LOG_ERR("read failed: %d", ret);
+			break;
+		}
+
+		process_block_data(mem_block, block_size / BYTES_PER_SAMPLE);
+
+		ret = i2s_write(i2s_dev_tx, mem_block, block_size);
+		if (ret < 0) {
+			LOG_ERR("write failed: %d", ret);
+			k_mem_slab_free(&mem_slab, mem_block);
+			break;
+		}
+	}
+	LOG_INF("stream loop exited");
+}
+
+static void i2s_stop(const struct device *i2s_dev_rx,
+		     const struct device *i2s_dev_tx)
+{
+	int ret;
+
+	/* DROP handles any state (RUNNING, ERROR, READY, STOPPING)
+	 * except NOT_READY, so no need for PREPARE first.
+	 */
+	ret = i2s_trigger(i2s_dev_rx, I2S_DIR_RX, I2S_TRIGGER_DROP);
+	LOG_INF("%s: RX drop returned %d", __func__, ret);
+
+	ret = i2s_trigger(i2s_dev_tx, I2S_DIR_TX, I2S_TRIGGER_DROP);
+	LOG_INF("%s: TX drop returned %d", __func__, ret);
+
+	k_sleep(K_MSEC(100));
+	LOG_INF("%s: done", __func__);
+}
+
+/*
+ * Start → stream → stop around one PM phase. Sleep states deeper than
+ * RUNTIME_IDLE are locked while I2S is active so DMA/I2S IRQs outside the
+ * IWIC wakeup range cannot be lost in SUSPEND_TO_IDLE.
+ */
+static void i2s_echo_run(const struct device *i2s_dev_rx,
+			 const struct device *i2s_dev_tx,
+			 const char *phase_label)
+{
+	app_pm_lock_sleep_states(true);
+	LOG_INF("[I2S Demo] %s", phase_label);
+	if (!i2s_start(i2s_dev_rx, i2s_dev_tx)) {
+		LOG_ERR("Failed to start I2S (%s) - skipping", phase_label);
+		app_pm_lock_sleep_states(false);
+		return;
+	}
+	i2s_stream_for(i2s_dev_rx, i2s_dev_tx, I2S_STREAM_ITERATIONS);
+	i2s_stop(i2s_dev_rx, i2s_dev_tx);
+	app_pm_lock_sleep_states(false);
+}
+
+/* PM state name lookup for notifier logging */
+static const char * const pm_state_names[] = {
+	[PM_STATE_ACTIVE]          = "ACTIVE",
+	[PM_STATE_RUNTIME_IDLE]    = "RUNTIME_IDLE",
+	[PM_STATE_SUSPEND_TO_IDLE] = "SUSPEND_TO_IDLE",
+	[PM_STATE_STANDBY]         = "STANDBY",
+	[PM_STATE_SUSPEND_TO_RAM]  = "SUSPEND_TO_RAM",
+	[PM_STATE_SUSPEND_TO_DISK] = "SUSPEND_TO_DISK",
+	[PM_STATE_SOFT_OFF]        = "SOFT_OFF",
+};
+
+#define PM_STATE_STR(s) \
+	((s) < ARRAY_SIZE(pm_state_names) ? pm_state_names[(s)] : "UNKNOWN")
+
+static void pm_notify_entry(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+
+	LOG_INF("PM enter: %s (substate %u)", PM_STATE_STR(state), info->substate_id);
+}
+
+/*
+ * With CONFIG_LOG_MODE_DEFERRED, LOG_INF here only writes to the ring buffer
+ * — no UART access — so this is safe even before devices are resumed.
+ */
+static void pm_notify_pre_resume(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint32_t active_exc = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
+
+	if (active_exc >= 16U) {
+		LOG_INF("PM wakeup: %s (substate %u) IRQ %u",
+			PM_STATE_STR(state), info->substate_id, active_exc - 16U);
+	} else if (active_exc != 0U) {
+		LOG_INF("PM wakeup: %s (substate %u) exception %u",
+			PM_STATE_STR(state), info->substate_id, active_exc);
+	} else {
+		LOG_INF("PM wakeup: %s (substate %u)",
+			PM_STATE_STR(state), info->substate_id);
+	}
+#if APP_PM_WAKEUP_DEBUG
+	for (int i = 0; i < 16; i++) {
+		if (NVIC->ISPR[i]) {
+			LOG_INF("PM wakeup: NVIC ISPR[%d] = 0x%08x", i, NVIC->ISPR[i]);
+		}
+	}
+#endif
+}
+
+static void pm_notify_exit(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+
+	LOG_INF("PM exit:  %s (substate %u)", PM_STATE_STR(state), info->substate_id);
+}
+
+static struct pm_notifier app_pm_notifier = {
+	.state_entry       = pm_notify_entry,
+	.pre_device_resume = pm_notify_pre_resume,
+	.state_exit        = pm_notify_exit,
+};
+
+int main(void)
+{
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	const struct device *const i2s_dev_rx = DEVICE_DT_GET(I2S_RX_NODE);
+	const struct device *const i2s_dev_tx = DEVICE_DT_GET(I2S_TX_NODE);
+	int ret;
+
+	__ASSERT(device_is_ready(cons), "%s: device not ready", cons->name);
+	__ASSERT(device_is_ready(wakeup_dev), "%s: device not ready", wakeup_dev->name);
+	__ASSERT(device_is_ready(i2s_dev_rx), "%s: device not ready", i2s_dev_rx->name);
+	if (i2s_dev_rx != i2s_dev_tx) {
+		__ASSERT(device_is_ready(i2s_dev_tx), "%s: device not ready",
+			 i2s_dev_tx->name);
+	}
+
+	pm_notifier_register(&app_pm_notifier);
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("%s (S2RAM): I2S DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM STANDBY, S2RAM STOP)",
+			CONFIG_BOARD);
+	} else {
+		LOG_INF("%s (SOFT_OFF): I2S DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)",
+			CONFIG_BOARD);
+	}
+
+	ret = counter_start(wakeup_dev);
+	__ASSERT(!ret || ret == -EALREADY, "Failed to start counter (err %d)", ret);
+
+	LOG_INF("POWER STATE SEQUENCE:");
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("  3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)");
+		LOG_INF("  4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)");
+	} else {
+		LOG_INF("  3. PM_STATE_SOFT_OFF");
+	}
+
+	i2s_echo_run(i2s_dev_rx, i2s_dev_tx, "before RUNTIME_IDLE");
+
+	LOG_INF("Enter RUNTIME_IDLE sleep for (%d microseconds)", RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(true);
+	ret = app_enter_normal_sleep(RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(false);
+	__ASSERT(ret == 0, "Could not enter RUNTIME_IDLE sleep (err %d)", ret);
+
+	LOG_INF("Exited from RUNTIME_IDLE sleep");
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	LOG_INF("Request SUSPEND_TO_IDLE for %d us", SUSPEND_IDLE_SLEEP_USEC);
+	app_pm_lock_deeper_states(true);
+	k_sleep(K_USEC(SUSPEND_IDLE_SLEEP_USEC));
+	app_pm_lock_deeper_states(false);
+	i2s_echo_run(i2s_dev_rx, i2s_dev_tx, "after SUSPEND_TO_IDLE");
+#else
+	/* Lock SUSPEND_TO_IDLE when LPM timer support is not configured */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("PM_STATE_SUSPEND_TO_IDLE (skipped - LPM timer not enabled)");
+#endif
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("Request S2RAM STANDBY for %d us", S2RAM_STANDBY_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STANDBY_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		i2s_echo_run(i2s_dev_rx, i2s_dev_tx, "after S2RAM STANDBY");
+
+		LOG_INF("Request S2RAM STOP for %d us", S2RAM_STOP_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STOP_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		i2s_echo_run(i2s_dev_rx, i2s_dev_tx, "after S2RAM STOP");
+	}
+
+	if (SOFT_OFF_SUPPORTED) {
+		LOG_INF("Request SOFT_OFF for %d us (no retention - system resets on wakeup)",
+			SOFT_OFF_SLEEP_USEC);
+		ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+		/* Should never reach here - SOFT_OFF causes full reset on wakeup */
+		LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+		__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+	}
+
+	LOG_INF("=== I2S DW PM SEQUENCE COMPLETED ===");
+
+	app_pm_lock_deeper_states(true);
+	/* Demo complete — prevent SUSPEND_TO_IDLE so the idle spin stays in RUNTIME_IDLE */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+	while (true) {
+		/* spin here */
+		k_sleep(K_SECONDS(1));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Demonstrate I2S DW echo streaming across the full PM state sequence: RUNTIME_IDLE, SUSPEND_TO_IDLE, SUSPEND_TO_RAM (STANDBY and STOP substates), and SOFT_OFF (on targets without retained RAM).

I2S RX/TX echo runs before each deep sleep phase to verify correct device resume. Streaming is guarded with pm_policy_state_lock to prevent SUSPEND_TO_IDLE entry while I2S is active, since I2S IRQs fall outside the IWIC wakeup range.

Snippet overlays cover TCM and MRAM boot configurations across B1, E1C, E7, and E8 variants.