### PR TITLE
manifest: update zephyr revision for pwm/qdec sleep pinctrl

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 945743acd3aa139dac8eb1453a1848d8a909278c
+      revision: 68f90b429778a6948930580f53586bbc5732c37e
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
updated zephyr revision to pick up sleep pinctrl on Alif PWM and QDEC snippet overlays so pinctrl-names matches pinctrl-0 and pinctrl-1.