### PR TITLE
manifest: Update the zephyr revision Wi-Fi Direct support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 3b5625f70273dbb684fa28e5ab3f5d7a534db4ee
+      revision: 7d93eb0f78df992035eaa1ac2d077a86fbee9d34
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects
@@ -80,8 +80,8 @@ manifest:
          - hal
 
     - name: hal_infineon
-      remote: zephyrproject
-      revision: 470f874ce432763a2b82cd322d0ff6efc89240cd
+      remote: alif
+      revision: a326c0de2bdcb206319098a5f039fcd952581d62
       path: modules/hal/infineon
 
     - name: dave2d


### PR DESCRIPTION
Update the zephyr revision and hal_infineon revision for Wi-Fi Direct support on Murata 1YN board.