### PR TITLE
i3c: Enable I3C Bus Recovery GPIO

### DIFF
--- a/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
+++ b/boards/alif/alif_b1_eb/balletto-eb-pinctrl.dtsi
@@ -800,3 +800,8 @@
 		};
 	};
 };
+
+&i3c0 {
+	scl-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+};

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_b1_e1c_dk.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_b1_e1c_dk.overlay
@@ -33,3 +33,8 @@
 	pinctrl-names   = "default";
 	status		= "okay";
 };
+
+/* I3C bus recovery (scl-gpios / sda-gpios on gpio0) */
+&gpio0 {
+	status = "okay";
+};

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e3_e4_e7_e8_dk.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e3_e4_e7_e8_dk.overlay
@@ -34,3 +34,7 @@
 	status		= "okay";
 };
 
+/* I3C bus recovery (scl-gpios / sda-gpios on gpio7) */
+&gpio7 {
+	status = "okay";
+};

--- a/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e8_ak.overlay
+++ b/samples/sensor/bmi323_pm/snippets/alif-dk-ak/alif_e8_ak.overlay
@@ -33,3 +33,8 @@
 	pinctrl-names	= "default";
 	status		= "okay";
 };
+
+/* I3C bus recovery (scl-gpios / sda-gpios on gpio7 */
+&gpio7 {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 010e9c74bf952dec0c833586eadc599f1d1baf9c
+      revision: 45e4a533b5a31caf0c4368b1c68662214f993720
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
This PR contains the following:
- Adding I3C's Recovery GPIO instance in b1 engineering board.
- Enabling I3C's bus recovery gpio instance.

This PR points to https://github.com/alifsemi/zephyr_alif/pull/650

