### PR TITLE
manifest: Take configurable sync_timer into use

### DIFF
--- a/subsys/bluetooth/le_audio/Kconfig
+++ b/subsys/bluetooth/le_audio/Kconfig
@@ -9,6 +9,7 @@
 menuconfig ALIF_BLE_AUDIO
 	bool "Alif BLE audio subsystem"
 	depends on BT_CUSTOM && ALIF_ROM_LC3_CODEC
+	select ALIF_BLE_ENABLE_AUDIO_SYNC_TIMER
 	help
 	  The Alif BLE audio subsystem contains common code to be re-used across LE audio applications.
 

--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: 2fa5235f4bf3c1588b9ef2b9d097bf4361c60b88
+      revision: b728a3274037e790562fcd564f717edba7facd65
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
Enable sync_timer when BLE audio is used.

Zephyr_alif PR: https://github.com/alifsemi/zephyr_alif/pull/652