### PR TITLE
samples: drivers: pm: add I2C DW power management demo

### DIFF
--- a/samples/drivers/pm/i2c_dw/CMakeLists.txt
+++ b/samples/drivers/pm/i2c_dw/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i2c_dw_pm)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/pm/i2c_dw/Kconfig
+++ b/samples/drivers/pm/i2c_dw/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+mainmenu "Alif I2C DW Power Management Demo"
+
+source "Kconfig.zephyr"

--- a/samples/drivers/pm/i2c_dw/README.rst
+++ b/samples/drivers/pm/i2c_dw/README.rst
@@ -1,0 +1,80 @@
+.. _i2c-dw-pm-sample:
+
+I2C DW Power Management Demo
+############################
+
+Overview
+********
+
+This sample demonstrates Zephyr power management states combined with I2C DW
+loopback transfers on Alif RTSS cores. **I2C0 is master** and **I2C1 is slave**.
+The application cycles through PM states and performs one write plus one read
+after each wake, verifying that the I2C peripheral resumes correctly.
+
+PM states exercised (determined at runtime by capability predicates):
+
+- **S2RAM path** (TCM or SRAM0 retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  S2RAM STANDBY → S2RAM STOP → idle loop
+- **SOFT_OFF path** (MRAM boot, no retention): RUNTIME_IDLE → SUSPEND_TO_IDLE →
+  SOFT_OFF (system resets on wakeup)
+
+Connect I2C0 SCL/SDA to I2C1 SCL/SDA (and a common GND) for the on-board
+loopback.
+
+.. note::
+
+   B1 and E1C use UART2 for console logs.
+
+Building and Running
+********************
+
+HE Core — TCM boot S2RAM (E7/E8/E1C/B1)
+=======================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2c_dw
+   :board: alif_b1_dk/ab1c1f4m51820ph0/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2c-dw-pm-s2ram-tcm
+   :gen-args: -DCONFIG_FLASH_BASE_ADDRESS=0x0 -DCONFIG_FLASH_LOAD_OFFSET=0x0
+
+HE Core — MRAM boot SOFT_OFF (E7/E8/E1C/B1)
+===========================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2c_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2c-dw-pm-mram
+
+HP Core — MRAM boot SOFT_OFF (E7/E8)
+====================================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2c_dw
+   :board: alif_e7_dk/ae722f80f55d5xx/rtss_hp
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2c-dw-pm-mram
+
+HE Core — SRAM0 S2RAM (E8 only)
+===============================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2c_dw
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_he
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2c-dw-pm-s2ram-sram0
+
+HP Core — SRAM0 S2RAM (E8 only)
+===============================
+
+.. zephyr-app-commands::
+   :zephyr-app: ../alif/samples/drivers/pm/i2c_dw
+   :board: alif_e8_dk/ae822fa0e5597xx0/rtss_hp
+   :goals: build
+   :west-args: -p auto
+   :snippets: i2c-dw-pm-s2ram-sram0

--- a/samples/drivers/pm/i2c_dw/prj.conf
+++ b/samples/drivers/pm/i2c_dw/prj.conf
@@ -1,0 +1,30 @@
+# Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+# Use, distribution and modification of this code is permitted under the
+# terms stated in the Alif Semiconductor Software License Agreement
+#
+# You should have received a copy of the Alif Semiconductor Software
+# License Agreement with this file. If not, please write to:
+# contact@alifsemi.com, or visit: https://alifsemi.com/license
+
+CONFIG_I2C=y
+CONFIG_I2C_TARGET=y
+CONFIG_I2C_TARGET_BUFFER_MODE=y
+CONFIG_I2C_DW_CLOCK_SPEED=100
+
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_IDLE_STACK_SIZE=1024
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_COUNTER=y
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_ASSERT=y
+
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=0
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=5
+CONFIG_LOG_BACKEND_UART=y

--- a/samples/drivers/pm/i2c_dw/sample.yaml
+++ b/samples/drivers/pm/i2c_dw/sample.yaml
@@ -1,0 +1,58 @@
+sample:
+  name: Alif I2C DW Power Management Demo
+  description: >
+    Demonstrates Zephyr power management states combined with I2C DW
+    master/target loopback on Alif RTSS cores. I2C0 is master and I2C1
+    is slave. Each wake runs one write plus one read and compares the
+    echoed data.
+common:
+  tags:
+    - power
+    - pm
+    - i2c
+    - drivers
+  filter: SOC_FAMILY_ENSEMBLE or SOC_FAMILY_BALLETTO
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "I2C DW PM demo"
+      - "POWER STATE SEQUENCE"
+tests:
+  sample.drivers.i2c_dw.pm.s2ram_tcm:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e8_dk_rtss_he
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=i2c-dw-pm-s2ram-tcm
+  sample.drivers.i2c_dw.pm.mram:
+    platform_allow:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+      - alif_e8_dk_rtss_he
+      - alif_e8_dk_rtss_hp
+      - alif_e1c_dk_rtss_he
+      - alif_b1_dk_rtss_he
+    integration_platforms:
+      - alif_e7_dk_rtss_he
+      - alif_e7_dk_rtss_hp
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=i2c-dw-pm-mram
+  sample.drivers.i2c_dw.pm.s2ram_sram0:
+    platform_allow:
+      - alif_e8_dk_rtss_he
+      - alif_e8_dk_rtss_hp
+    integration_platforms:
+      - alif_e8_dk_rtss_he
+    depends_on:
+      - counter
+    extra_args:
+      - SNIPPET=i2c-dw-pm-s2ram-sram0

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_b1.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_b1.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ * Console: uart2 (from pm_mram_common.overlay).
+ */
+
+#include "pm_mram_he.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e1c.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e1c.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ * Console: uart2 (from pm_mram_common.overlay).
+ */
+
+#include "pm_mram_he.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e7_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e7_he.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e7_hp.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e7_hp.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HP: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e8_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e8_he.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HE, RTC wakeup).
+ */
+
+#include "pm_mram_he.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e8_hp.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/i2c_dw_e8_hp.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HP: I2C0 (master) + I2C1 (slave).
+ * PM: MRAM boot SOFT_OFF (HP, LPTIMER0 wakeup).
+ */
+
+#include "pm_mram_hp.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_common.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_common.overlay
@@ -1,0 +1,46 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	status = "okay";
+	memory-blocks = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK)>;
+};
+
+/ {
+	chosen {
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_he.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HE core booting from MRAM.
+ * Uses RTC as wakeup source and idle timer.
+ */
+
+#include "pm_mram_common.overlay"
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+	};
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_hp.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/pm_mram_hp.overlay
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM SOFT_OFF overlay for HP core booting from MRAM.
+ * Uses LPTIMER0 as wakeup source.
+ */
+
+#include "pm_mram_common.overlay"
+
+&timer0 {
+	status = "okay";
+};
+
+&utimer5 {
+	status = "disabled";
+};
+
+&off_profile_soft_off {
+	wakeup-events = <ALIF_WE_LPTIMER0>;
+	ewic-cfg      = <ALIF_EWIC_VBAT_TIMER>;
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/prj.conf
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/prj.conf
@@ -1,0 +1,2 @@
+# PM MRAM boot - SOFT_OFF configuration (HE and HP)
+# MRAM boot uses SOFT_OFF; S2RAM (PM_S2RAM) is not enabled for this path.

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/snippet.yml
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-mram/snippet.yml
@@ -1,0 +1,22 @@
+name: i2c-dw-pm-mram
+append:
+  EXTRA_CONF_FILE: prj.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e7_he.overlay
+  /alif_e7.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e7_hp.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e8_he.overlay
+  /alif_e8.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e8_hp.overlay

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/i2c_dw_e8_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/i2c_dw_e8_he.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: I2C0 (master) + I2C1 (slave).
+ * PM: SRAM0 retention S2RAM (HE, RTC wakeup).
+ */
+
+#include "pm_sram0_he.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/i2c_dw_e8_hp.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/i2c_dw_e8_hp.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HP: I2C0 (master) + I2C1 (slave).
+ * PM: SRAM0 retention S2RAM (HP, RTC wakeup).
+ */
+
+#include "pm_sram0_hp.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_common.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_common.overlay
@@ -1,0 +1,88 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * Common PM S2RAM overlay for SRAM0 retention builds (HE and HP cores).
+ *
+ * Both cores require a first-stage loader (placed at MRAM before the Zephyr
+ * app image) to power up SRAM0 before execution reaches the application.
+ * SRAM0 retention masks (ALIF_SRAM0_*_RET_MASK) are Ensemble Gen2 specific.
+ */
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&standby_s2ram {
+	min-residency-us = <5000000>;
+	status = "okay";
+};
+
+&stop_s2ram {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&suspend_idle {
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <(ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+				ALIF_SRAM0_MASK | ALIF_SRAM1_MASK)>;
+};
+
+&aipm_off {
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	memory-blocks = <(ALIF_SRAM0_MASK | ALIF_SRAM1_MASK |
+			  ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+			  ALIF_SRAM0_1_RET_MASK | ALIF_SRAM0_2_RET_MASK |
+			  ALIF_SRAM0_3_RET_MASK | ALIF_SRAM0_4_RET_MASK |
+			  ALIF_SRAM1_RET_MASK)>;
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	memory-blocks = <(ALIF_SRAM0_MASK | ALIF_SRAM1_MASK |
+			  ALIF_MRAM_MASK | ALIF_SERAM_MASK |
+			  ALIF_SRAM0_1_RET_MASK | ALIF_SRAM0_2_RET_MASK |
+			  ALIF_SRAM0_3_RET_MASK | ALIF_SRAM0_4_RET_MASK |
+			  ALIF_SRAM1_RET_MASK)>;
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg      = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,sram                = &sram0;
+		zephyr,cortex-m-idle-timer = &rtc0;
+		zephyr,console             = &uart2;
+	};
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_he.overlay
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM S2RAM overlay for HE core with SRAM0 as data RAM.
+ * The aipm_off vtor-address points to the first-stage loader at MRAM
+ * 0x80000000 so the SE restores execution there on wakeup.
+ */
+
+#include "pm_sram0_common.overlay"

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_hp.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/pm_sram0_hp.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM S2RAM overlay for HP core with SRAM0 as data RAM.
+ *
+ * The aipm_off vtor-address points to the first-stage loader at MRAM
+ * 0x80100000 so the SE restores execution there on wakeup.
+ *
+ */
+
+#include "pm_sram0_common.overlay"
+
+&timer0 {
+	status = "disabled";
+};
+
+&utimer5 {
+	status = "disabled";
+};
+
+&aipm_off {
+	vtor-address = <0x80100000>;
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/snippet.yml
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-sram0/snippet.yml
@@ -1,0 +1,10 @@
+name: i2c-dw-pm-s2ram-sram0
+append:
+  EXTRA_CONF_FILE: ../pm_s2ram_common.conf
+boards:
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e8_he.overlay
+  /alif_e8.*rtss_hp.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e8_hp.overlay

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_b1.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_b1.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * B1 HE: I2C0 (master) + I2C1 (slave).
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ * Console: uart2 (from pm_tcm_common.overlay).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e1c.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e1c.overlay
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E1C HE: I2C0 (master) + I2C1 (slave).
+ * PM: TCM boot S2RAM (E1C/B1 memory masks).
+ * Console: uart2 (from pm_tcm_common.overlay).
+ */
+
+#include "pm_tcm_e1c_b1.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e7_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e7_he.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E7 HE: I2C0 (master) + I2C1 (slave).
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e8_he.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/i2c_dw_e8_he.overlay
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * E8 HE: I2C0 (master) + I2C1 (slave).
+ * PM: TCM boot S2RAM (Ensemble memory masks).
+ */
+
+#include "pm_tcm_ensemble.overlay"
+
+/ {
+	aliases {
+		master-i2c = &i2c0;
+		slave-i2c = &i2c1;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_common.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_common.overlay
@@ -1,0 +1,74 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+&rtc0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&lpgpio {
+	status = "disabled";
+};
+
+&uart4 {
+	status = "disabled";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&subsys_off {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&standby_s2ram {
+	min-residency-us = <5000000>;
+	status = "okay";
+};
+
+&stop_s2ram {
+	min-residency-us = <8000000>;
+	status = "okay";
+};
+
+&suspend_idle {
+	status = "okay";
+};
+
+&aipm_run_default {
+	aipm-power-domains = <(ALIF_PD_SSE700_AON_MASK | ALIF_PD_SYST_MASK)>;
+	memory-blocks      = <ALIF_MRAM_MASK>;
+};
+
+&aipm_off {
+	vtor-address = <0x00000000>;
+	status = "okay";
+};
+
+&off_profile_standby {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+&off_profile_stop {
+	status = "okay";
+	wakeup-events = <ALIF_WE_LPRTC>;
+	ewic-cfg = <ALIF_EWIC_RTC_A>;
+};
+
+/ {
+	chosen {
+		zephyr,cortex-m-idle-timer = &rtc0;
+		zephyr,console = &uart2;
+	};
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_e1c_b1.overlay
@@ -1,0 +1,33 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble E1C and Balletto B1 SoCs.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM4_3_MASK | ALIF_SRAM4_4_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SRAM5_3_MASK | ALIF_SRAM5_4_MASK |
+			  ALIF_SRAM5_5_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/pm_tcm_ensemble.overlay
@@ -1,0 +1,28 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+/*
+ * PM off-profile overlay for Ensemble and Ensemble Gen2
+ * SoCs - HE core TCM boot S2RAM.
+ */
+
+#include "pm_tcm_common.overlay"
+
+&off_profile_standby {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};
+
+&off_profile_stop {
+	memory-blocks = <(ALIF_SRAM4_1_MASK | ALIF_SRAM4_2_MASK |
+			  ALIF_SRAM5_1_MASK | ALIF_SRAM5_2_MASK |
+			  ALIF_SERAM_MASK | ALIF_MRAM_MASK)>;
+};

--- a/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/snippet.yml
+++ b/samples/drivers/pm/i2c_dw/snippets/i2c-dw-pm-s2ram-tcm/snippet.yml
@@ -1,0 +1,16 @@
+name: i2c-dw-pm-s2ram-tcm
+append:
+  EXTRA_CONF_FILE: ../pm_s2ram_common.conf
+boards:
+  /alif_e1c.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e1c.overlay
+  /alif_b.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_b1.overlay
+  /alif_e7.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e7_he.overlay
+  /alif_e8.*rtss_he.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: i2c_dw_e8_he.overlay

--- a/samples/drivers/pm/i2c_dw/snippets/pm_s2ram_common.conf
+++ b/samples/drivers/pm/i2c_dw/snippets/pm_s2ram_common.conf
@@ -1,0 +1,3 @@
+# Common Kconfig for all S2RAM-capable snippets (TCM and SRAM0 retention paths)
+CONFIG_PM_S2RAM=y
+CONFIG_PM_SAU_SAVE_RESTORE=y

--- a/samples/drivers/pm/i2c_dw/src/main.c
+++ b/samples/drivers/pm/i2c_dw/src/main.c
@@ -1,0 +1,510 @@
+/* Copyright (C) 2026 Alif Semiconductor - All Rights Reserved.
+ * Use, distribution and modification of this code is permitted under the
+ * terms stated in the Alif Semiconductor Software License Agreement
+ *
+ * You should have received a copy of the Alif Semiconductor Software
+ * License Agreement with this file. If not, please write to:
+ * contact@alifsemi.com, or visit: https://alifsemi.com/license
+ *
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(pm_i2c_dw, LOG_LEVEL_INF);
+
+/* Set to 1 to dump full NVIC ISPR state on wakeup */
+#define APP_PM_WAKEUP_DEBUG 0
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(rtc0), snps_dw_apb_rtc, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(rtc0)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(timer0), snps_dw_timers, okay)
+	#define WAKEUP_SOURCE DT_NODELABEL(timer0)
+#else
+#error "Wakeup Device not enabled in the dts"
+#endif
+
+#if !DT_NODE_EXISTS(DT_ALIAS(master_i2c)) || !DT_NODE_EXISTS(DT_ALIAS(slave_i2c))
+#error "aliases master-i2c (I2C0) and slave-i2c (I2C1) must be set in the overlay"
+#endif
+
+#define I2C_MASTER DT_ALIAS(master_i2c)
+#define I2C_SLAVE  DT_ALIAS(slave_i2c)
+
+#define SLV_I2C_ADDR 0x50
+#define I2C_LB_LEN   4
+
+/*
+ * Sleep duration constants for each PM state.
+ *
+ * Upper bound: at 400 MHz, ticks-to-cycles calculation in the PM driver
+ * overflows uint32 max for values > 10.7s (2^32 / 400). Deep-sleep durations
+ * (S2RAM, SOFT_OFF) and overlay min-residency-us values must stay below this
+ * ceiling. RUNTIME_IDLE may exceed it because deeper states are locked out
+ * during that sleep (see app_pm_lock_sleep_states()).
+ */
+#define RUNTIME_IDLE_SLEEP_USEC  (18 * 1000 * 1000)
+#define SUSPEND_IDLE_SLEEP_USEC  (10 * 1000)
+#define S2RAM_STANDBY_SLEEP_USEC (6 * 1000 * 1000)
+#define S2RAM_STOP_SLEEP_USEC    (9 * 1000 * 1000)
+#define SOFT_OFF_SLEEP_USEC      (10 * 1000 * 1000)
+
+#define MRAM_BASE_ADDRESS 0x80000000
+#define IS_BOOTING_FROM_MRAM() (SCB->VTOR >= MRAM_BASE_ADDRESS)
+
+#if DT_NODE_EXISTS(DT_NODELABEL(sram0)) && DT_HAS_CHOSEN(zephyr_sram)
+#define IS_SRAM0_CONFIGURED_AS_RAM() \
+	DT_SAME_NODE(DT_CHOSEN(zephyr_sram), DT_NODELABEL(sram0))
+#else
+#define IS_SRAM0_CONFIGURED_AS_RAM() 0
+#endif
+
+#define S2RAM_SUPPORTED \
+	(IS_SRAM0_CONFIGURED_AS_RAM() || \
+	 (IS_ENABLED(CONFIG_RTSS_HE) && !IS_BOOTING_FROM_MRAM()))
+
+#define SOFT_OFF_SUPPORTED (!S2RAM_SUPPORTED)
+
+BUILD_ASSERT(S2RAM_STOP_SLEEP_USEC > S2RAM_STANDBY_SLEEP_USEC,
+	"STOP sleep duration must be greater than STANDBY sleep duration");
+BUILD_ASSERT(SOFT_OFF_SLEEP_USEC > S2RAM_STOP_SLEEP_USEC,
+	"SOFT_OFF sleep duration must be greater than STOP sleep duration");
+
+/**
+ * Helper function to lock/unlock deeper power states.
+ * @param lock true  → lock both deep states (S2RAM and SOFT_OFF)
+ *             false → unlock both deep states
+ */
+static void app_pm_lock_deeper_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,       PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
+}
+
+/*
+ * Lock every PM sleep state deeper than RUNTIME_IDLE. Used around I2C
+ * loopback and around any sleep the app must keep in RUNTIME_IDLE.
+ */
+static void app_pm_lock_sleep_states(bool lock)
+{
+	if (lock) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_get(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+	} else {
+		pm_policy_state_lock_put(PM_STATE_SOFT_OFF,        PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,  PM_ALL_SUBSTATES);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+#if !defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+static volatile uint32_t alarm_cb_status;
+static void alarm_callback_fn(const struct device *wakeup_dev,
+				uint8_t chan_id, uint32_t ticks,
+				void *user_data)
+{
+	LOG_DBG("%s: Alarm triggered", wakeup_dev->name);
+	alarm_cb_status = 1;
+}
+#endif
+
+static int app_enter_normal_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+
+	alarm_cfg.flags = 0;
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	alarm_cfg.callback = alarm_callback_fn;
+	alarm_cfg.user_data = &alarm_cfg;
+
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Could not set the alarm");
+		return ret;
+	}
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+
+	k_sleep(K_USEC(sleep_usec));
+
+	if (!alarm_cb_status) {
+		return -1;
+	}
+	alarm_cb_status = 0;
+#endif
+	return 0;
+}
+
+static int app_enter_deep_sleep(uint32_t sleep_usec)
+{
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	k_sleep(K_USEC(sleep_usec));
+#else
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	struct counter_alarm_cfg alarm_cfg = {0};
+	int ret;
+
+	alarm_cfg.ticks = counter_us_to_ticks(wakeup_dev, sleep_usec);
+	ret = counter_set_channel_alarm(wakeup_dev, 0, &alarm_cfg);
+	if (ret) {
+		LOG_ERR("Failed to set the alarm (err %d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("Set alarm for %u microseconds", sleep_usec);
+	k_sleep(K_USEC(sleep_usec));
+#endif
+	return 0;
+}
+
+static uint8_t master_tx[I2C_LB_LEN] = { 0xA5, 0xA6, 0xA7, 0xA8 };
+static uint8_t master_rx[I2C_LB_LEN];
+static uint8_t slave_rx[I2C_LB_LEN];
+static uint8_t slave_tx[I2C_LB_LEN];
+static uint32_t slave_rx_len;
+static struct i2c_target_config slave_cfg;
+
+static int i2c_target_write_requested_cb(struct i2c_target_config *config)
+{
+	ARG_UNUSED(config);
+	return 0;
+}
+
+static int i2c_target_read_requested_cb(struct i2c_target_config *config, uint8_t *val)
+{
+	ARG_UNUSED(config);
+	*val = slave_tx[0];
+	return 0;
+}
+
+static int i2c_target_write_received_cb(struct i2c_target_config *config, uint8_t val)
+{
+	ARG_UNUSED(config);
+#ifndef CONFIG_I2C_TARGET_BUFFER_MODE
+	if (slv_rx_idx < I2C_XFER_LEN) {
+		slv_rx_buf[slv_rx_idx++] = val;
+	}
+#endif
+	//LOG_INF("Received a byte in slave : 0x%x", val);
+	return 0;
+}
+
+static int i2c_target_read_processed_cb(struct i2c_target_config *config, uint8_t *val)
+{
+	ARG_UNUSED(config);
+	*val = slave_tx[0];
+	return 0;
+}
+
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+static int i2c_target_buf_read_requested_cb(struct i2c_target_config *config,
+					    uint8_t **val, uint32_t *len)
+{
+	ARG_UNUSED(config);
+
+	*val = slave_tx;
+	*len = I2C_LB_LEN;
+	LOG_INF("Read requested from Master, send 0x%x 0x%x 0x%x 0x%x",
+		slave_tx[0], slave_tx[1], slave_tx[2], slave_tx[3]);
+	return 0;
+}
+
+static void i2c_target_buf_write_received_cb(struct i2c_target_config *config,
+					     uint8_t *data_buf, uint32_t len)
+{
+	uint32_t n = MIN(len, I2C_LB_LEN);
+
+	ARG_UNUSED(config);
+	memcpy(slave_rx, data_buf, n);
+	slave_rx_len = n;
+	LOG_INF("Received %u bytes from master: 0x%x 0x%x 0x%x 0x%x",
+		n,
+		n > 0 ? slave_rx[0] : 0,
+		n > 1 ? slave_rx[1] : 0,
+		n > 2 ? slave_rx[2] : 0,
+		n > 3 ? slave_rx[3] : 0);
+}
+#endif
+
+static const struct i2c_target_callbacks slave_cbs = {
+	.write_requested = i2c_target_write_requested_cb,
+	.read_requested = i2c_target_read_requested_cb,
+	.write_received = i2c_target_write_received_cb,
+	.read_processed = i2c_target_read_processed_cb,
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	.buf_write_received = i2c_target_buf_write_received_cb,
+	.buf_read_requested = i2c_target_buf_read_requested_cb,
+#endif
+};
+
+static int register_slave_i2c(void)
+{
+	const struct device *const slave_dev = DEVICE_DT_GET(I2C_SLAVE);
+	int ret;
+
+	if (!device_is_ready(slave_dev)) {
+		LOG_ERR("I2C slave device is not ready");
+		return -ENODEV;
+	}
+
+	slave_cfg.flags = 0;
+	slave_cfg.address = SLV_I2C_ADDR;
+	slave_cfg.callbacks = &slave_cbs;
+
+	ret = i2c_target_register(slave_dev, &slave_cfg);
+	if (ret) {
+		LOG_ERR("I2C slave register failed: %d", ret);
+	}
+	return ret;
+}
+
+/*
+ * One write + one read on I2C0 (master) / I2C1 (slave). Slave echoes the
+ * written payload so both directions are checked after each PM wake.
+ */
+static int i2c_loopback_run(const char *phase_label)
+{
+	const struct device *const master_dev = DEVICE_DT_GET(I2C_MASTER);
+	struct i2c_msg msgs[2];
+	int ret;
+
+	app_pm_lock_sleep_states(true);
+	ARG_UNUSED(phase_label);
+
+	if (!device_is_ready(master_dev)) {
+		LOG_ERR("I2C master device is not ready");
+		app_pm_lock_sleep_states(false);
+		return -ENODEV;
+	}
+
+	memcpy(slave_tx, master_tx, I2C_LB_LEN);
+	memset(master_rx, 0, sizeof(master_rx));
+	memset(slave_rx, 0, sizeof(slave_rx));
+	slave_rx_len = 0;
+
+	msgs[0].buf = master_tx;
+	msgs[0].len = I2C_LB_LEN;
+	msgs[0].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+	msgs[1].buf = master_rx;
+	msgs[1].len = I2C_LB_LEN;
+	msgs[1].flags = I2C_MSG_READ | I2C_MSG_STOP;
+
+	ret = i2c_transfer(master_dev, &msgs[0], 1, SLV_I2C_ADDR);
+	if (ret) {
+		LOG_ERR("I2C master write failed: %d", ret);
+		app_pm_lock_sleep_states(false);
+		return ret;
+	}
+	LOG_INF("Master wrote:  %x %x %x %x",
+		master_tx[0], master_tx[1], master_tx[2], master_tx[3]);
+
+	ret = i2c_transfer(master_dev, &msgs[1], 1, SLV_I2C_ADDR);
+	if (ret) {
+		LOG_ERR("I2C master read failed: %d", ret);
+		app_pm_lock_sleep_states(false);
+		return ret;
+	}
+	LOG_INF("Master read:   %x %x %x %x",
+		master_rx[0], master_rx[1], master_rx[2], master_rx[3]);
+
+	if (slave_rx_len != I2C_LB_LEN || memcmp(slave_rx, master_tx, I2C_LB_LEN) != 0) {
+		LOG_ERR("I2C master TX & slave RX data mismatch");
+		app_pm_lock_sleep_states(false);
+		return -EIO;
+	}
+
+	if (memcmp(master_rx, slave_tx, I2C_LB_LEN) != 0) {
+		LOG_ERR("I2C master RX & slave TX data mismatch");
+		app_pm_lock_sleep_states(false);
+		return -EIO;
+	}
+
+	LOG_INF("SUCCESS: I2C loopback data is matching");
+	LOG_INF("Master Transfer Successfully Completed");
+
+	app_pm_lock_sleep_states(false);
+	return 0;
+}
+
+static const char * const pm_state_names[] = {
+	[PM_STATE_ACTIVE]          = "ACTIVE",
+	[PM_STATE_RUNTIME_IDLE]    = "RUNTIME_IDLE",
+	[PM_STATE_SUSPEND_TO_IDLE] = "SUSPEND_TO_IDLE",
+	[PM_STATE_STANDBY]         = "STANDBY",
+	[PM_STATE_SUSPEND_TO_RAM]  = "SUSPEND_TO_RAM",
+	[PM_STATE_SUSPEND_TO_DISK] = "SUSPEND_TO_DISK",
+	[PM_STATE_SOFT_OFF]        = "SOFT_OFF",
+};
+
+#define PM_STATE_STR(s) \
+	((s) < ARRAY_SIZE(pm_state_names) ? pm_state_names[(s)] : "UNKNOWN")
+
+static void pm_notify_entry(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+
+	LOG_INF("PM enter: %s (substate %u)", PM_STATE_STR(state), substate_id);
+}
+
+static void pm_notify_pre_resume(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+	uint32_t active_exc = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
+
+	if (active_exc >= 16U) {
+		LOG_INF("PM wakeup: %s (substate %u) IRQ %u",
+			PM_STATE_STR(state), substate_id, active_exc - 16U);
+	} else if (active_exc != 0U) {
+		LOG_INF("PM wakeup: %s (substate %u) exception %u",
+			PM_STATE_STR(state), substate_id, active_exc);
+	} else {
+		LOG_INF("PM wakeup: %s (substate %u)",
+			PM_STATE_STR(state), substate_id);
+	}
+#if APP_PM_WAKEUP_DEBUG
+	for (int i = 0; i < 16; i++) {
+		if (NVIC->ISPR[i]) {
+			LOG_INF("PM wakeup: NVIC ISPR[%d] = 0x%08x", i, NVIC->ISPR[i]);
+		}
+	}
+#endif
+}
+
+static void pm_notify_exit(enum pm_state state)
+{
+	const struct pm_state_info *info = pm_state_next_get(0);
+	uint8_t substate_id = info ? info->substate_id : 0U;
+
+	LOG_INF("PM exit:  %s (substate %u)", PM_STATE_STR(state), substate_id);
+}
+
+static struct pm_notifier app_pm_notifier = {
+	.state_entry       = pm_notify_entry,
+	.pre_device_resume = pm_notify_pre_resume,
+	.state_exit        = pm_notify_exit,
+};
+
+int main(void)
+{
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const wakeup_dev = DEVICE_DT_GET(WAKEUP_SOURCE);
+	int ret;
+
+	__ASSERT(device_is_ready(cons), "%s: device not ready", cons->name);
+	__ASSERT(device_is_ready(wakeup_dev), "%s: device not ready", wakeup_dev->name);
+
+	pm_notifier_register(&app_pm_notifier);
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("%s (S2RAM): I2C DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, S2RAM STANDBY, S2RAM STOP)",
+			CONFIG_BOARD);
+	} else {
+		LOG_INF("%s (SOFT_OFF): I2C DW PM demo "
+			"(RUNTIME_IDLE, SUSPEND_TO_IDLE, SOFT_OFF)",
+			CONFIG_BOARD);
+	}
+
+	ret = counter_start(wakeup_dev);
+	__ASSERT(!ret || ret == -EALREADY, "Failed to start counter (err %d)", ret);
+
+	ret = register_slave_i2c();
+	__ASSERT(ret == 0, "Failed to register I2C slave (err %d)", ret);
+
+	LOG_INF("POWER STATE SEQUENCE:");
+	LOG_INF("  1. PM_STATE_RUNTIME_IDLE");
+	LOG_INF("  2. PM_STATE_SUSPEND_TO_IDLE");
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("  3. PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY)");
+		LOG_INF("  4. PM_STATE_SUSPEND_TO_RAM (substate 1: STOP)");
+	} else {
+		LOG_INF("  3. PM_STATE_SOFT_OFF");
+	}
+
+	ret = i2c_loopback_run("before RUNTIME_IDLE");
+	__ASSERT(ret == 0, "I2C loopback failed (err %d)", ret);
+
+	LOG_INF("Enter RUNTIME_IDLE sleep for (%d microseconds)", RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(true);
+	ret = app_enter_normal_sleep(RUNTIME_IDLE_SLEEP_USEC);
+	app_pm_lock_sleep_states(false);
+	__ASSERT(ret == 0, "Could not enter RUNTIME_IDLE sleep (err %d)", ret);
+
+	LOG_INF("Exited from RUNTIME_IDLE sleep");
+
+#if defined(CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER)
+	LOG_INF("Enter PM_STATE_SUSPEND_TO_IDLE for (%d microseconds)",
+		SUSPEND_IDLE_SLEEP_USEC);
+	app_pm_lock_deeper_states(true);
+	k_sleep(K_USEC(SUSPEND_IDLE_SLEEP_USEC));
+	app_pm_lock_deeper_states(false);
+	LOG_INF("Exited from PM_STATE_SUSPEND_TO_IDLE");
+	ret = i2c_loopback_run("after SUSPEND_TO_IDLE");
+	__ASSERT(ret == 0, "I2C loopback failed (err %d)", ret);
+#else
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	LOG_INF("PM_STATE_SUSPEND_TO_IDLE (skipped - LPM timer not enabled)");
+#endif
+
+	if (S2RAM_SUPPORTED) {
+		LOG_INF("Enter PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) for (%d microseconds)",
+			S2RAM_STANDBY_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STANDBY_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		LOG_INF("=== Resumed from PM_STATE_SUSPEND_TO_RAM (substate 0: STANDBY) ===");
+		ret = i2c_loopback_run("after S2RAM STANDBY");
+		__ASSERT(ret == 0, "I2C loopback failed (err %d)", ret);
+
+		LOG_INF("Enter PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) for (%d microseconds)",
+			S2RAM_STOP_SLEEP_USEC);
+		ret = app_enter_deep_sleep(S2RAM_STOP_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SUSPEND_TO_RAM (err %d)", ret);
+
+		LOG_INF("=== Resumed from PM_STATE_SUSPEND_TO_RAM (substate 1: STOP) ===");
+		ret = i2c_loopback_run("after S2RAM STOP");
+		__ASSERT(ret == 0, "I2C loopback failed (err %d)", ret);
+	}
+
+	if (SOFT_OFF_SUPPORTED) {
+		LOG_INF("Enter PM_STATE_SOFT_OFF for (%d microseconds)", SOFT_OFF_SLEEP_USEC);
+		LOG_INF("Note: SOFT_OFF has no retention - system will reset on wakeup");
+		ret = app_enter_deep_sleep(SOFT_OFF_SLEEP_USEC);
+		__ASSERT(ret == 0, "Could not enter PM_STATE_SOFT_OFF (err %d)", ret);
+
+		LOG_ERR("ERROR: Resumed after PM_STATE_SOFT_OFF - this should not happen!");
+		__ASSERT(false, "PM_STATE_SOFT_OFF should have caused a reset");
+	}
+
+	LOG_INF("=== I2C DW PM SEQUENCE COMPLETED ===");
+
+	app_pm_lock_deeper_states(true);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+	while (true) {
+		k_sleep(K_SECONDS(1));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Demonstrate I2C DW master/target loopback across the full PM state sequence: RUNTIME_IDLE, SUSPEND_TO_IDLE, SUSPEND_TO_RAM (STANDBY and STOP substates), and SOFT_OFF (on targets without retained RAM).

I2C0 is master and I2C1 is slave. One write plus one read runs before each deep sleep phase to verify correct device resume. Transfers are guarded with pm_policy_state_lock so SUSPEND_TO_IDLE cannot start while the bus is active.

Snippet overlays cover TCM, MRAM, and SRAM0 boot configurations across B1, E1C, E7, and E8 variants.