### PR TITLE
manifest: update zephyr version to fetch XiP DDR changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr_alif
-      revision: b728a3274037e790562fcd564f717edba7facd65
+      revision: pull/656/head
       import:
         # In addition to the zephyr repository itself,
         # Alif SDK fetches the needed projects


### PR DESCRIPTION
update zephyr version to fetch MX66 XiP DDR instruction changes.

Zephyr changes : [Mx66 XiP Support](https://github.com/alifsemi/zephyr_alif/pull/656)